### PR TITLE
External links

### DIFF
--- a/src/Employer.Web/Configuration/ExternalLinksConfiguration.cs
+++ b/src/Employer.Web/Configuration/ExternalLinksConfiguration.cs
@@ -3,16 +3,6 @@ namespace Esfa.Recruit.Employer.Web.Configuration
     public sealed class ExternalLinksConfiguration
     {
         public string ManageApprenticeshipSiteUrl { get; set; }
-        public string ManageApprenticeshipSiteHelpUrl { get; set; }
-        public string ManageApprenticeshipSiteAccountsUrl { get; set; }
-        public string ManageApprenticeshipSiteChangePasswordUrl { get; set; }
-        public string ManageApprenticeshipSiteChangeEmailAddressUrl { get; set; }
-        public string ManageApprenticeshipSiteSignInUrl { get; set; }
-        public string ManageApprenticeshipSiteAccountsFinanceLink { get; set; }
-        public string ManageApprenticeshipSiteAccountsApprenticesLink { get; set; }
-        public string ManageApprenticeshipSiteAccountsTeamsLink { get; set; }
-        public string ManageApprenticeshipSiteAccountsTeamsViewLink { get; set; }
-        public string ManageApprenticeshipSiteAccountsAgreementsLink { get; set; }
-        public string ManageApprenticeshipSiteAccountsSchemesLink { get; set; }
+        public string EmployerIdamsSiteUrl { get; set; }
     }
 }

--- a/src/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer.Web/Configuration/IoC.cs
@@ -17,6 +17,8 @@ namespace Esfa.Recruit.Employer.Web.Configuration
 
             //Configuration
             services.Configure<ExternalLinksConfiguration>(configuration.GetSection("ExternalLinks"));
+            services.Configure<ManageApprenticeshipsRoutes>(configuration.GetSection("ManageApprenticeshipsRoutes"));
+            services.AddSingleton<ManageApprenticeshipsLinkHelper>();
             services.Configure<AuthenticationConfiguration>(configuration.GetSection("Authentication"));
             services.Configure<AccountApiConfiguration>(configuration.GetSection("AccountApiConfiguration"));
             

--- a/src/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
+++ b/src/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Options;
+
+namespace Esfa.Recruit.Employer.Web.Configuration
+{
+    public class ManageApprenticeshipsLinkHelper
+    {
+        private readonly ExternalLinksConfiguration _externalLinks;
+        private readonly ManageApprenticeshipsRoutes _maRoutes;
+
+        public ManageApprenticeshipsLinkHelper(IOptions<ExternalLinksConfiguration> externalLinks, IOptions<ManageApprenticeshipsRoutes> maRoutes)
+        {
+            _externalLinks = externalLinks.Value;
+            _maRoutes = maRoutes.Value;
+        }
+
+        public string MaRoot => _externalLinks.ManageApprenticeshipSiteUrl;
+        public string Help => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteHelpRoute}";
+        public string Accounts => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsRoute}";
+        public string ChangePassword => $"{_externalLinks.EmployerIdamsSiteUrl}{_maRoutes.ManageApprenticeshipSiteChangePasswordRoute}";
+        public string ChangeEmail => $"{_externalLinks.EmployerIdamsSiteUrl}{_maRoutes.ManageApprenticeshipSiteChangeEmailAddressRoute}";
+        public string Finance => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsFinanceRoute}";
+        public string Apprentices => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsApprenticesRoute}";
+        public string Teams => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsTeamsViewRoute}";
+        public string Agreements => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsAgreementsRoute}";
+        public string Schemes => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsSchemesRoute}";
+    }
+}

--- a/src/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
+++ b/src/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
@@ -16,8 +16,10 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         public string MaRoot => _externalLinks.ManageApprenticeshipSiteUrl;
         public string Help => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteHelpRoute}";
         public string Accounts => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsRoute}";
+        public string RenameAccount => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteRenameAccountRoute}";
         public string ChangePassword => $"{_externalLinks.EmployerIdamsSiteUrl}{_maRoutes.ManageApprenticeshipSiteChangePasswordRoute}";
         public string ChangeEmail => $"{_externalLinks.EmployerIdamsSiteUrl}{_maRoutes.ManageApprenticeshipSiteChangeEmailAddressRoute}";
+        public string Notifications => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteNotificationsRoute}";
         public string Finance => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsFinanceRoute}";
         public string Apprentices => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsApprenticesRoute}";
         public string Teams => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsTeamsViewRoute}";

--- a/src/Employer.Web/Configuration/ManageApprenticeshipsRoutes.cs
+++ b/src/Employer.Web/Configuration/ManageApprenticeshipsRoutes.cs
@@ -4,6 +4,8 @@ namespace Esfa.Recruit.Employer.Web.Configuration
     {
         public string ManageApprenticeshipSiteHelpRoute { get; set; }
         public string ManageApprenticeshipSiteAccountsRoute { get; set; }
+        public string ManageApprenticeshipSiteRenameAccountRoute { get; set; }
+        public string ManageApprenticeshipSiteNotificationsRoute { get; set; }
         public string ManageApprenticeshipSiteChangePasswordRoute { get; set; }
         public string ManageApprenticeshipSiteChangeEmailAddressRoute { get; set; }
         public string ManageApprenticeshipSiteAccountsFinanceRoute { get; set; }

--- a/src/Employer.Web/Configuration/ManageApprenticeshipsRoutes.cs
+++ b/src/Employer.Web/Configuration/ManageApprenticeshipsRoutes.cs
@@ -1,0 +1,15 @@
+namespace Esfa.Recruit.Employer.Web.Configuration
+{
+    public sealed class ManageApprenticeshipsRoutes
+    {
+        public string ManageApprenticeshipSiteHelpRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsRoute { get; set; }
+        public string ManageApprenticeshipSiteChangePasswordRoute { get; set; }
+        public string ManageApprenticeshipSiteChangeEmailAddressRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsFinanceRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsApprenticesRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsTeamsViewRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsAgreementsRoute { get; set; }
+        public string ManageApprenticeshipSiteAccountsSchemesRoute { get; set; }
+    }
+}

--- a/src/Employer.Web/Configuration/RouteNames.cs
+++ b/src/Employer.Web/Configuration/RouteNames.cs
@@ -15,6 +15,7 @@
         public const string Dashboard_ChangePassword = "Dashboard_ChangePassword";
         public const string Dashboard_ChangeEmail = "Dashboard_ChangeEmail";
 
+        public const string Dashboard_AccountsRename = "Dashboard_AccountsRename";
         public const string Dashboard_AccountsHome = "Dashboard_AccountsHome";
         public const string Dashboard_AccountsFinance = "Dashboard_AccountsFinance";
         public const string Dashboard_AccountsApprentices = "Dashboard_AccountsApprentices";

--- a/src/Employer.Web/Controllers/ExternalLinksController.cs
+++ b/src/Employer.Web/Controllers/ExternalLinksController.cs
@@ -13,20 +13,20 @@ namespace Employer.Web.Controllers
     {
         ILogger<ExternalLinksController> _logger;
         private readonly AuthenticationConfiguration _authConfig;
-        private readonly ExternalLinksConfiguration _extLinksConfig;
+        private readonly ManageApprenticeshipsLinkHelper _linkHelper;
 
-        public ExternalLinksController(ILogger<ExternalLinksController> logger, IOptions<AuthenticationConfiguration> authConfig, IOptions<ExternalLinksConfiguration> extLinksConfig)
+        public ExternalLinksController(ILogger<ExternalLinksController> logger, IOptions<AuthenticationConfiguration> authConfig, ManageApprenticeshipsLinkHelper linkHelper)
         {
             _logger = logger;
             _authConfig = authConfig.Value;
-            _extLinksConfig = extLinksConfig.Value;
+            _linkHelper = linkHelper;
         }
 
         [HttpGet("change-password", Name = RouteNames.Dashboard_ChangePassword)]
         public IActionResult ChangePassword(string returnUrl)
         {
             var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");            
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteChangePasswordUrl, _authConfig.ClientId, encodedReturnUrl);
+            var url = string.Format(_linkHelper.ChangePassword, _authConfig.ClientId, encodedReturnUrl);
             return Redirect(url);
         }
 
@@ -34,42 +34,42 @@ namespace Employer.Web.Controllers
         public IActionResult ChangeEmailAddress(string returnUrl)
         {
             var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteChangeEmailAddressUrl, _authConfig.ClientId, encodedReturnUrl);
+            var url = string.Format(_linkHelper.ChangeEmail, _authConfig.ClientId, encodedReturnUrl);
             return Redirect(url);
         }
 
         [HttpGet("finance", Name = RouteNames.Dashboard_AccountsFinance)]
         public IActionResult AccountsFinance(string employerAccountId)
         {
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteAccountsFinanceLink, employerAccountId);
+            var url = string.Format(_linkHelper.Finance, employerAccountId);
             return Redirect(url);
         }
 
         [HttpGet("apprentices", Name = RouteNames.Dashboard_AccountsApprentices)]
         public IActionResult AccountsApprentices(string employerAccountId)
         {
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteAccountsFinanceLink, employerAccountId);
+            var url = string.Format(_linkHelper.Apprentices, employerAccountId);
             return Redirect(url);
         }
 
         [HttpGet("teams", Name = RouteNames.Dashboard_AccountsTeams)]
         public IActionResult AccountsTeams(string employerAccountId)
         {
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteAccountsTeamsViewLink, employerAccountId);
+            var url = string.Format(_linkHelper.Teams, employerAccountId);
             return Redirect(url);
         }
 
         [HttpGet("agreements", Name = RouteNames.Dashboard_AccountsAgreements)]
         public IActionResult AccountsAgreements(string employerAccountId)
         {
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteAccountsAgreementsLink, employerAccountId);
+            var url = string.Format(_linkHelper.Agreements, employerAccountId);
             return Redirect(url);
         }
 
         [HttpGet("schemes", Name = RouteNames.Dashboard_AccountsSchemes)]
         public IActionResult AccountsSchemes(string employerAccountId)
         {
-            var url = string.Format(_extLinksConfig.ManageApprenticeshipSiteAccountsSchemesLink, employerAccountId);
+            var url = string.Format(_linkHelper.Schemes, employerAccountId);
             return Redirect(url);
         }
     }

--- a/src/Employer.Web/Controllers/ExternalLinksController.cs
+++ b/src/Employer.Web/Controllers/ExternalLinksController.cs
@@ -22,7 +22,7 @@ namespace Employer.Web.Controllers
             _linkHelper = linkHelper;
         }
 
-        [HttpGet("change-password", Name = RouteNames.Dashboard_ChangePassword)]
+        [HttpGet("rename-account", Name = RouteNames.Dashboard_AccountsRename)]
         public IActionResult ChangePassword(string returnUrl)
         {
             var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");            
@@ -35,6 +35,13 @@ namespace Employer.Web.Controllers
         {
             var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");
             var url = string.Format(_linkHelper.ChangeEmail, _authConfig.ClientId, encodedReturnUrl);
+            return Redirect(url);
+        }
+
+        [HttpGet("change-password", Name = RouteNames.Dashboard_ChangePassword)]
+        public IActionResult RenameAccount(string employerAccountId)
+        {
+            var url = string.Format(_linkHelper.RenameAccount, employerAccountId);
             return Redirect(url);
         }
 

--- a/src/Employer.Web/Controllers/ExternalLinksController.cs
+++ b/src/Employer.Web/Controllers/ExternalLinksController.cs
@@ -22,14 +22,6 @@ namespace Employer.Web.Controllers
             _linkHelper = linkHelper;
         }
 
-        [HttpGet("rename-account", Name = RouteNames.Dashboard_AccountsRename)]
-        public IActionResult ChangePassword(string returnUrl)
-        {
-            var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");            
-            var url = string.Format(_linkHelper.ChangePassword, _authConfig.ClientId, encodedReturnUrl);
-            return Redirect(url);
-        }
-
         [HttpGet("change-email", Name = RouteNames.Dashboard_ChangeEmail)]
         public IActionResult ChangeEmailAddress(string returnUrl)
         {
@@ -39,9 +31,18 @@ namespace Employer.Web.Controllers
         }
 
         [HttpGet("change-password", Name = RouteNames.Dashboard_ChangePassword)]
-        public IActionResult RenameAccount(string employerAccountId)
+        public IActionResult ChangePassword(string returnUrl)
         {
-            var url = string.Format(_linkHelper.RenameAccount, employerAccountId);
+            var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");            
+            var url = string.Format(_linkHelper.ChangePassword, _authConfig.ClientId, encodedReturnUrl);
+            return Redirect(url);
+        }
+
+        [HttpGet("rename-account", Name = RouteNames.Dashboard_AccountsRename)]
+        public IActionResult RenameAccount(string returnUrl)
+        {
+            var encodedReturnUrl = WebUtility.UrlEncode($"{Request.GetRequestUrlRoot()}{returnUrl}");            
+            var url = string.Format(_linkHelper.RenameAccount, _authConfig.ClientId);
             return Redirect(url);
         }
 

--- a/src/Employer.Web/Startup.ConfigureServices.cs
+++ b/src/Employer.Web/Startup.ConfigureServices.cs
@@ -30,9 +30,6 @@ namespace Esfa.Recruit.Employer.Web
         {
             services.AddIoC(_configuration);
 
-            //A service provider for resolving services configured in IoC
-            var sp = services.BuildServiceProvider();
-
             // Routing has to come before adding Mvc
             services.AddRouting(opt =>
             {
@@ -46,6 +43,9 @@ namespace Esfa.Recruit.Employer.Web
 
             if (_isAuthEnabled)
             {
+                //A service provider for resolving services configured in IoC
+                var sp = services.BuildServiceProvider();
+
                 services.AddAuthenticationService(_authConfig, sp.GetService<IEmployerAccountService>());
                 services.AddAuthorizationService();
             }

--- a/src/Employer.Web/Views/Shared/_Layout.cshtml
+++ b/src/Employer.Web/Views/Shared/_Layout.cshtml
@@ -88,9 +88,10 @@
                                 <a href="/" role="menuitem" class="menu-main">Settings</a>
                                 <ul role="menu" id="settings-menu" class="js-hidden">
                                     <li><a href="@ExternalLinks.Accounts" role="menuitem" class="sub-menu-item">Your accounts</a></li>
+                                    <li><a asp-route="@RouteNames.Dashboard_AccountsRename" asp-route-returnUrl="@Context.Request.Path" class="sub-menu-item">Rename account</a></li>
                                     <li><a asp-route="@RouteNames.Dashboard_ChangePassword" asp-route-returnUrl="@Context.Request.Path" class="sub-menu-item">Change your password</a></li>
                                     <li><a asp-route="@RouteNames.Dashboard_ChangeEmail" asp-route-returnUrl="@Context.Request.Path" class="sub-menu-item">Change your email address</a></li>
-                                    @*<li><a href="@Url.ExternalUrlAction("settings", "notifications",true)" class="sub-menu-item">Notification settings</a></li>*@
+                                    <li><a href="@ExternalLinks.Notifications" class="sub-menu-item">Notifications settings</a></li>
                                 </ul>
                             </li>
                             <li><a asp-route="Home_Logout_Get" role="menuitem" class="menu-main">Sign out</a></li>

--- a/src/Employer.Web/Views/Shared/_Layout.cshtml
+++ b/src/Employer.Web/Views/Shared/_Layout.cshtml
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.Extensions.Options;
 @using Esfa.Recruit.Employer.Web.Configuration;
-@inject IOptions<ExternalLinksConfiguration> ExternalLinks
+@inject ManageApprenticeshipsLinkHelper ExternalLinks
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]-->
 <!--[if gt IE 8]><!-->
@@ -81,13 +81,13 @@
                 <p class="floating-head-text">Your employer account</p>
                 <nav id="user-nav">
                     <ul role="menubar">
-                        <li><a href="@ExternalLinks.Value.ManageApprenticeshipSiteHelpUrl" class="menu-main">Help</a></li>
+                        <li><a href="@ExternalLinks.Help" class="menu-main">Help</a></li>
                         @if (Context.User.Identity.IsAuthenticated)
                         {
                             <li class="has-sub-menu">
                                 <a href="/" role="menuitem" class="menu-main">Settings</a>
                                 <ul role="menu" id="settings-menu" class="js-hidden">
-                                    <li><a href="@ExternalLinks.Value.ManageApprenticeshipSiteAccountsUrl" role="menuitem" class="sub-menu-item">Your accounts</a></li>
+                                    <li><a href="@ExternalLinks.Accounts" role="menuitem" class="sub-menu-item">Your accounts</a></li>
                                     <li><a asp-route="@RouteNames.Dashboard_ChangePassword" asp-route-returnUrl="@Context.Request.Path" class="sub-menu-item">Change your password</a></li>
                                     <li><a asp-route="@RouteNames.Dashboard_ChangeEmail" asp-route-returnUrl="@Context.Request.Path" class="sub-menu-item">Change your email address</a></li>
                                     @*<li><a href="@Url.ExternalUrlAction("settings", "notifications",true)" class="sub-menu-item">Notification settings</a></li>*@
@@ -97,7 +97,7 @@
                         }
                         else
                         {
-                            <li><a href="@ExternalLinks.Value.ManageApprenticeshipSiteSignInUrl" role="menuitem">Sign in / Register</a></li>
+                            <li><a href="@ExternalLinks.MaRoot" role="menuitem">Sign in / Register</a></li>
                         }
                     </ul>
                 </nav>

--- a/src/Employer.Web/appsettings.Development.json
+++ b/src/Employer.Web/appsettings.Development.json
@@ -13,15 +13,15 @@
     "EmployerIdamsSiteUrl": "https://test-login.apprenticeships.sfa.bis.gov.uk"
   },
   "ManageApprenticeshipsRoutes": {
-    "ManageApprenticeshipSiteHelpUrl": "/service/help",
-    "ManageApprenticeshipSiteChangePasswordUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteChangeEmailAddressUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteAccountsFinanceLink": "/accounts/{0}/finance",
-    "ManageApprenticeshipSiteAccountsApprenticesLink": "/accounts/{0}/apprentices",
-    "ManageApprenticeshipSiteAccountsTeamsLink": "/accounts/{0}/teams",
-    "ManageApprenticeshipSiteAccountsTeamsViewLink": "/accounts/{0}/teams/view",
-    "ManageApprenticeshipSiteAccountsAgreementsLink": "/accounts/{0}/agreements",
-    "ManageApprenticeshipSiteAccountsSchemesLink": "/accounts/{0}/schemes"
+    "ManageApprenticeshipSiteHelpRoute": "/service/help",
+    "ManageApprenticeshipSiteAccountsRoute": "/service/accounts",
+    "ManageApprenticeshipSiteChangePasswordRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteChangeEmailAddressRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteAccountsFinanceRoute": "/accounts/{0}/finance",
+    "ManageApprenticeshipSiteAccountsApprenticesRoute": "/accounts/{0}/apprentices",
+    "ManageApprenticeshipSiteAccountsTeamsViewRoute": "/accounts/{0}/teams/view",
+    "ManageApprenticeshipSiteAccountsAgreementsRoute": "/accounts/{0}/agreements",
+    "ManageApprenticeshipSiteAccountsSchemesRoute": "/accounts/{0}/schemes"
   },
   "ConnectionStrings": {
     "Redis": "localhost:6379",

--- a/src/Employer.Web/appsettings.Development.json
+++ b/src/Employer.Web/appsettings.Development.json
@@ -15,6 +15,8 @@
   "ManageApprenticeshipsRoutes": {
     "ManageApprenticeshipSiteHelpRoute": "/service/help",
     "ManageApprenticeshipSiteAccountsRoute": "/service/accounts",
+    "ManageApprenticeshipSiteRenameAccountRoute": "/accounts/{0}/rename",
+    "ManageApprenticeshipSiteNotificationsRoute": "/settings/notifications",
     "ManageApprenticeshipSiteChangePasswordRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteChangeEmailAddressRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteAccountsFinanceRoute": "/accounts/{0}/finance",

--- a/src/Employer.Web/appsettings.Development.json
+++ b/src/Employer.Web/appsettings.Development.json
@@ -10,15 +10,18 @@
   },
   "ExternalLinks": {
     "ManageApprenticeshipSiteUrl": "https://dev-eas.apprenticeships.sfa.bis.gov.uk",
-    "ManageApprenticeshipSiteHelpUrl": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/service/help",
-    "ManageApprenticeshipSiteChangePasswordUrl": "https://test-login.apprenticeships.sfa.bis.gov.uk/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteChangeEmailAddressUrl": "https://test-login.apprenticeships.sfa.bis.gov.uk/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteAccountsFinanceLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/finance",
-    "ManageApprenticeshipSiteAccountsApprenticesLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/apprentices",
-    "ManageApprenticeshipSiteAccountsTeamsLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/teams",
-    "ManageApprenticeshipSiteAccountsTeamsViewLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/teams/view",
-    "ManageApprenticeshipSiteAccountsAgreementsLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/agreements",
-    "ManageApprenticeshipSiteAccountsSchemesLink": "https://dev-eas.apprenticeships.sfa.bis.gov.uk/accounts/{0}/schemes"
+    "EmployerIdamsSiteUrl": "https://test-login.apprenticeships.sfa.bis.gov.uk"
+  },
+  "ManageApprenticeshipsRoutes": {
+    "ManageApprenticeshipSiteHelpUrl": "/service/help",
+    "ManageApprenticeshipSiteChangePasswordUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteChangeEmailAddressUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteAccountsFinanceLink": "/accounts/{0}/finance",
+    "ManageApprenticeshipSiteAccountsApprenticesLink": "/accounts/{0}/apprentices",
+    "ManageApprenticeshipSiteAccountsTeamsLink": "/accounts/{0}/teams",
+    "ManageApprenticeshipSiteAccountsTeamsViewLink": "/accounts/{0}/teams/view",
+    "ManageApprenticeshipSiteAccountsAgreementsLink": "/accounts/{0}/agreements",
+    "ManageApprenticeshipSiteAccountsSchemesLink": "/accounts/{0}/schemes"
   },
   "ConnectionStrings": {
     "Redis": "localhost:6379",

--- a/src/Employer.Web/appsettings.json
+++ b/src/Employer.Web/appsettings.json
@@ -23,6 +23,8 @@
   "ManageApprenticeshipsRoutes": {
     "ManageApprenticeshipSiteHelpRoute": "/service/help",
     "ManageApprenticeshipSiteAccountsRoute": "/service/accounts",
+    "ManageApprenticeshipSiteRenameAccountRoute": "/accounts/{0}/rename",
+    "ManageApprenticeshipSiteNotificationsRoute": "/settings/notifications",
     "ManageApprenticeshipSiteChangePasswordRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteChangeEmailAddressRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteAccountsFinanceRoute": "/accounts/{0}/finance",

--- a/src/Employer.Web/appsettings.json
+++ b/src/Employer.Web/appsettings.json
@@ -18,15 +18,18 @@
   },
   "ExternalLinks": {
     "ManageApprenticeshipSiteUrl": "https://manage-apprenticeships.service.gov.uk/",
-    "ManageApprenticeshipSiteHelpUrl": "https://manage-apprenticeships.service.gov.uk/service/help",
-    "ManageApprenticeshipSiteChangePasswordUrl": "https://beta-login.apprenticeships.sfa.bis.gov.uk/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteChangeEmailAddressUrl": "https://beta-login.apprenticeships.sfa.bis.gov.uk/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteAccountsFinanceLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/finance",
-    "ManageApprenticeshipSiteAccountsApprenticesLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/apprentices",
-    "ManageApprenticeshipSiteAccountsTeamsLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/teams",
-    "ManageApprenticeshipSiteAccountsTeamsViewLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/teams/view",
-    "ManageApprenticeshipSiteAccountsAgreementsLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/agreements",
-    "ManageApprenticeshipSiteAccountsSchemesLink": "https://manage-apprenticeships.service.gov.uk/accounts/{0}/schemes"
+    "EmployerIdamsSiteUrl": "https://beta-login.apprenticeships.sfa.bis.gov.uk"
+  },
+  "ManageApprenticeshipsRoutes": {
+    "ManageApprenticeshipSiteHelpUrl": "/service/help",
+    "ManageApprenticeshipSiteChangePasswordUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteChangeEmailAddressUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteAccountsFinanceLink": "/accounts/{0}/finance",
+    "ManageApprenticeshipSiteAccountsApprenticesLink": "/accounts/{0}/apprentices",
+    "ManageApprenticeshipSiteAccountsTeamsLink": "/accounts/{0}/teams",
+    "ManageApprenticeshipSiteAccountsTeamsViewLink": "/accounts/{0}/teams/view",
+    "ManageApprenticeshipSiteAccountsAgreementsLink": "/accounts/{0}/agreements",
+    "ManageApprenticeshipSiteAccountsSchemesLink": "/accounts/{0}/schemes"
   },
   "AccountApiConfiguration": {
     "ApiBaseUrl": "",

--- a/src/Employer.Web/appsettings.json
+++ b/src/Employer.Web/appsettings.json
@@ -21,15 +21,15 @@
     "EmployerIdamsSiteUrl": "https://beta-login.apprenticeships.sfa.bis.gov.uk"
   },
   "ManageApprenticeshipsRoutes": {
-    "ManageApprenticeshipSiteHelpUrl": "/service/help",
-    "ManageApprenticeshipSiteChangePasswordUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteChangeEmailAddressUrl": "/account/changepassword?clientId={0}&returnUrl={1}",
-    "ManageApprenticeshipSiteAccountsFinanceLink": "/accounts/{0}/finance",
-    "ManageApprenticeshipSiteAccountsApprenticesLink": "/accounts/{0}/apprentices",
-    "ManageApprenticeshipSiteAccountsTeamsLink": "/accounts/{0}/teams",
-    "ManageApprenticeshipSiteAccountsTeamsViewLink": "/accounts/{0}/teams/view",
-    "ManageApprenticeshipSiteAccountsAgreementsLink": "/accounts/{0}/agreements",
-    "ManageApprenticeshipSiteAccountsSchemesLink": "/accounts/{0}/schemes"
+    "ManageApprenticeshipSiteHelpRoute": "/service/help",
+    "ManageApprenticeshipSiteAccountsRoute": "/service/accounts",
+    "ManageApprenticeshipSiteChangePasswordRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteChangeEmailAddressRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
+    "ManageApprenticeshipSiteAccountsFinanceRoute": "/accounts/{0}/finance",
+    "ManageApprenticeshipSiteAccountsApprenticesRoute": "/accounts/{0}/apprentices",
+    "ManageApprenticeshipSiteAccountsTeamsViewRoute": "/accounts/{0}/teams/view",
+    "ManageApprenticeshipSiteAccountsAgreementsRoute": "/accounts/{0}/agreements",
+    "ManageApprenticeshipSiteAccountsSchemesRoute": "/accounts/{0}/schemes"
   },
   "AccountApiConfiguration": {
     "ApiBaseUrl": "",

--- a/src/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -43,6 +43,13 @@
         "Tenant": ""
       }
     },
+    "ExternalLinks": {
+      "type": "object",
+      "defaultValue": {
+        "ManageApprenticeshipSiteUrl": "",
+        "EmployerIdamsSiteUrl": ""
+      }
+    },
     "LoggingRedisConnectionString": {
       "type": "securestring",
       "defaultValue": ""
@@ -139,6 +146,14 @@
             {
               "name": "ApplicationInsights:InstrumentationKey",
               "value": "[reference(concat('microsoft.insights/components/', variables('AppInsightsName'))).InstrumentationKey]"
+            },
+            {
+              "name": "ExternalLinks:ManageApprenticeshipSiteUrl",
+              "value": "[parameters('ExternalLinks').ManageApprenticeshipSiteUrl]"
+            },
+            {
+              "name": "ExternalLinks:ManageApprenticeshipSiteUrl",
+              "value": "[parameters('ExternalLinks').EmployerIdamsSiteUrl]"
             },
             {
               "name": "Environment",

--- a/src/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
+++ b/src/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
@@ -28,6 +28,12 @@
         "Tenant": ""
       }
     },
+    "ExternalLinks": {
+      "value": {
+        "ManageApprenticeshipSiteUrl": "",
+        "EmployerIdamsSiteUrl": ""
+      }
+    },
     "LoggingRedisConnectionString": {
       "value": ""
     }


### PR DESCRIPTION
Pulled out the routes for employer links into separate config.

@EwanNoble I've added 2 new config values that will need adding to the release definition:


**ExternalLinks:ManageApprenticeshipSiteUrl** - This is the base url for the MA site for each environment. e.g. https://test-eas.apprenticeships.sfa.bis.gov.uk

**ExternalLinks:EmployerIdamsSiteUrl** - This is the base url for Idams for each environment. e.g. https://test-login.apprenticeships.sfa.bis.gov.uk
