### PR TITLE
Fix for grabbing App Insights InstrumentationKey from config

### DIFF
--- a/src/jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -56,8 +56,8 @@ namespace Esfa.Recruit.Vacancies.Jobs
 
         private static ILoggerFactory BuildLoggerFactory(ServiceProvider serviceProvider, IConfigurationRoot config)
         {
-            var instrumentationKey = config["AppInsights_InstrumentationKey"];
-            Console.WriteLine($"AppInsights: {config.GetValue<string>("AppInsights_InstrumentationKey")}");
+            var instrumentationKey = config.GetValue<string>("ApplicationInsights:InstrumentationKey");
+            Console.WriteLine($"AppInsights: {instrumentationKey}");
             
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
             loggerFactory.AddNLog(new NLogProviderOptions { CaptureMessageProperties = true, CaptureMessageTemplates = true });


### PR DESCRIPTION
I had an issue running the web role because of a null exception being logged when trying to use App Insights. I found that the key specified needed to be changed. Able to run the TrainingType job successfully now.