### PR TITLE
Add collections to cosmos config file

### DIFF
--- a/src/CosmosDb/Configuration.json
+++ b/src/CosmosDb/Configuration.json
@@ -1,17 +1,19 @@
 {
     "Databases": [
         {
-            "DatabaseName": "testDb",
+            "DatabaseName": "recruit",
             "Collections": [
                 {
-                    "CollectionName": "testCollection",
+                    "CollectionName": "vacancies",
                     "OfferThroughput": 400,
                     "PartitionKey": "part1",
-                    "StoredProcedures": [
-                        {
-                            "StoredProcedureName": "createMyDocument"
-                        }
-                    ]
+                    "StoredProcedures": []
+                },
+                {
+                    "CollectionName": "queryViews",
+                    "OfferThroughput": 400,
+                    "PartitionKey": "part1",
+                    "StoredProcedures": []
                 }
             ]
         }


### PR DESCRIPTION
Although the database and collections are automatically created if they don't exist we need to be able to pre create them in the release to set things like the thoughput amount (RUs) and partition key.

Therefore we need to add any new collections into the config file.