### PR TITLE
Updated project references to fix security flaw

### DIFF
--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -5,8 +5,7 @@
     <RootNamespace>Esfa.Recruit.Employer.Web</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="1.1.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.0-rc2" />


### PR DESCRIPTION
Updated to double cover us from [Microsoft Security Advisory CVE-2018-0787: ASP.NET Core Elevation Of Privilege Vulnerability](https://github.com/aspnet/Announcements/issues/295)

Article says that "Apps hosted in Azure Web Apps are not susceptible to this vulnerability." but the code fix is simple for us anyway.