### PR TITLE
Update for Storage account connections string used by EditVacancyInfo job and queue event

### DIFF
--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -176,6 +176,11 @@
               "name": "MongoDb",
               "connectionString": "[concat('mongodb://', variables('CosmosDbName'), ':', listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('CosmosDbName')), '2015-11-06').primaryMasterKey,'@', variables('CosmosDbName'), '.documents.azure.com:10255/?ssl=true&replicaSet=globaldb')]",
               "type": "Custom"
+            },
+            {
+              "name": "Storage",
+              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('StorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('StorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]",
+              "type": "Custom"
             }
           ],
           "alwaysOn": true
@@ -204,7 +209,8 @@
             },
             "file": {
               "enabled": true
-            }
+            },
+            ""
           },
           "keySource": "Microsoft.Storage"
         }
@@ -238,6 +244,11 @@
             {
               "name": "MongoDb",
               "connectionString": "[concat('mongodb://', variables('CosmosDbName'), ':', listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('CosmosDbName')), '2015-11-06').primaryMasterKey,'@', variables('CosmosDbName'), '.documents.azure.com:10255/?ssl=true&replicaSet=globaldb')]",
+              "type": "Custom"
+            },
+            {
+              "name": "Storage",
+              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('StorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('StorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]",
               "type": "Custom"
             },
             {

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -209,8 +209,7 @@
             },
             "file": {
               "enabled": true
-            },
-            ""
+            }
           },
           "keySource": "Microsoft.Storage"
         }


### PR DESCRIPTION
I don't think you can specify creation of a storage account queue in ARM templates yet. 😫  @EwanNoble would this be okay.

The consuming code creates a queue if it does not already exist so we shouldn't encounter any issues.