### PR TITLE
Moving enums from Enums to Entities Namespace

### DIFF
--- a/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
@@ -3,11 +3,10 @@ using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Employer.Web.Controllers
+namespace Esfa.Recruit.Employer.Web.Controllers
 {
     [Route(RoutePrefixPaths.AccountVacancyRoutePath)]
     public class VacancyManageController : Controller

--- a/src/Employer/Employer.Web/Extensions/EnumExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/EnumExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Extensions
 {

--- a/src/Employer/Employer.Web/Extensions/QualificationsExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/QualificationsExtensions.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Esfa.Recruit.Employer.Web.ViewModels.Part2.Qualifications;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 
 namespace Esfa.Recruit.Employer.Web.Extensions
 {

--- a/src/Employer/Employer.Web/Extensions/WageExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/WageExtensions.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using Esfa.Recruit.Vacancies.Client.Application.Services.MinimumWage;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Extensions
 {
-    using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-    using System.Linq;
-
     public static class WageExtensions
     {
         const int WeeksPerYear = 52;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/SearchResultPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/SearchResultPreviewOrchestrator.cs
@@ -4,9 +4,8 @@ using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.SearchResultPreview;
-using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Application.Services.MinimumWage;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using System.Linq;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
 {

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -5,7 +5,6 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -1,8 +1,6 @@
 ﻿using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
-using Esfa.Recruit.Vacancies.Client.Domain;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
@@ -1,7 +1,6 @@
 ﻿using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
@@ -1,7 +1,6 @@
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
@@ -3,7 +3,6 @@ using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
@@ -1,6 +1,4 @@
 ﻿using Esfa.Recruit.Employer.Web.ViewModels;
-using Esfa.Recruit.Vacancies.Client.Domain;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using System;

--- a/src/Employer/Employer.Web/Orchestrators/SubmittedOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/SubmittedOrchestrator.cs
@@ -1,10 +1,10 @@
 ﻿using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Submitted;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators
 {

--- a/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -4,7 +4,6 @@ using Esfa.Recruit.Employer.Web.Mappings;
 using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -1,7 +1,6 @@
 ﻿using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Preview;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using System;

--- a/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageEditModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageEditModel.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.ViewModels.Validations;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 using ErrMsg = Esfa.Recruit.Employer.Web.ViewModels.ValidationMessages.WageValidationMessages;
 

--- a/src/Employer/Employer.Web/ViewModels/Part2/Qualifications/QualificationsEditModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part2/Qualifications/QualificationsEditModel.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Esfa.Recruit.Employer.Web.ViewModels.Validations;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part2.Qualifications

--- a/src/Employer/UnitTests/Core/Entities/VacancyExtensionsTest.cs
+++ b/src/Employer/UnitTests/Core/Entities/VacancyExtensionsTest.cs
@@ -1,5 +1,4 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Employer/UnitTests/Employer.Web/Extensions/WageExtensionsTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Extensions/WageExtensionsTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Vacancies.Client.Application.Services.MinimumWage;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Employer/UnitTests/Employer.Web/ViewModels/Part1/Wage/WageEditModelTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/ViewModels/Part1/Wage/WageEditModelTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipApiCollectionExtensions.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipApiCollectionExtensions.cs
@@ -1,6 +1,6 @@
 using System.Linq;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using SFA.DAS.Apprenticeships.Api.Types;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Projections;
 using Esfa.Recruit.Vacancies.Client.Domain.Services;
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -6,7 +6,6 @@ using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Application.Services.MinimumWage;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators.VacancyValidators;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Projections;
 using Esfa.Recruit.Vacancies.Client.Domain.Services;
 using FluentValidation;

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/DurationUnit.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/DurationUnit.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum DurationUnit
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Programme.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Programme.cs
@@ -1,6 +1,4 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Enums;
-
-namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public class Programme
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ProgrammeLevel.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ProgrammeLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum ProgrammeLevel
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Qualification.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Qualification.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
-
-namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public class Qualification
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/QualificationWeighting.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/QualificationWeighting.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum QualificationWeighting
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TrainingType.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TrainingType.cs
@@ -1,4 +1,4 @@
-namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum TrainingType
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -1,4 +1,3 @@
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using System;
 using System.Collections.Generic;
 

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyStatus.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum VacancyStatus
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Wage.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Wage.cs
@@ -1,6 +1,4 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Enums;
-
-namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public class Wage
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/WageType.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/WageType.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Enums
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public enum WageType
     {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Projections/ApprenticeshipProgramme.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Projections/ApprenticeshipProgramme.cs
@@ -1,5 +1,5 @@
 using System;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Domain.Projections
 {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Projections/VacancySummary.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Projections/VacancySummary.cs
@@ -1,5 +1,5 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Enums;
-using System;
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Domain.Projections
 {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -6,7 +6,6 @@ using Esfa.Recruit.Vacancies.Client.Application.Configuration;
 using Esfa.Recruit.Vacancies.Client.Application.QueryStore;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Domain.Projections;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;

--- a/src/Shared/UnitTests/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
+++ b/src/Shared/UnitTests/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
@@ -1,7 +1,6 @@
 using System;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Moq;
 using Xunit;

--- a/src/Shared/UnitTests/Application/VacancyValidation/SingleField/DurationValidationTests.cs
+++ b/src/Shared/UnitTests/Application/VacancyValidation/SingleField/DurationValidationTests.cs
@@ -1,6 +1,5 @@
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Shared/UnitTests/Application/VacancyValidation/SingleField/QualificationsTests.cs
+++ b/src/Shared/UnitTests/Application/VacancyValidation/SingleField/QualificationsTests.cs
@@ -4,7 +4,6 @@ using System.Text;
 using Esfa.Recruit.Vacancies.Client.Application.Configuration;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Shared/UnitTests/Application/VacancyValidation/SingleField/TrainingValidationTests.cs
+++ b/src/Shared/UnitTests/Application/VacancyValidation/SingleField/TrainingValidationTests.cs
@@ -1,6 +1,5 @@
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 

--- a/src/Shared/UnitTests/Application/VacancyValidation/SingleField/WageValidationTests.cs
+++ b/src/Shared/UnitTests/Application/VacancyValidation/SingleField/WageValidationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Enums;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
- Moved Enums from `Esfa.Recruit.Vacancies.Client.Domain.Enums` to  `Esfa.Recruit.Vacancies.Client.Domain.Entities`
- Some namespace clean up