### PR TITLE
ER-311 Properties to support QA

### DIFF
--- a/src/Employer/Employer.Web/Controllers/DeleteVacancyController.cs
+++ b/src/Employer/Employer.Web/Controllers/DeleteVacancyController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.DeleteVacancy;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
@@ -37,7 +39,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 return RedirectToRoute(RouteNames.Vacancy_Preview_Get);
             }
 
-            var result = await _orchestrator.TryDeleteVacancyAsync(m);
+            var result = await _orchestrator.TryDeleteVacancyAsync(m, User.ToVacancyUser());
 
             if (!result)
             {

--- a/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("employer", Name = RouteNames.Employer_Post)]
         public async Task<IActionResult> Employer(EmployerEditModel m)
         {
-            var response = await _orchestrator.PostEmployerEditModelAsync(m);
+            var response = await _orchestrator.PostEmployerEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part1/ShortDescriptionController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/ShortDescriptionController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.ShortDescription;
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("description", Name = RouteNames.ShortDescription_Post)]
         public async Task<IActionResult> ShortDescription(ShortDescriptionEditModel m)
         {
-            var response = await _orchestrator.PostShortDescriptionEditModelAsync(m);
+            var response = await _orchestrator.PostShortDescriptionEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part1/TitleController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TitleController.cs
@@ -38,8 +38,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost(VacancyTitleRoute, Name = RouteNames.Title_Post)]
         public async Task<IActionResult> Title(TitleEditModel m)
         {
-            var user = User.GetDisplayName();
-            var response = await _orchestrator.PostTitleEditModelAsync(m, user);
+            var response = await _orchestrator.PostTitleEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part1/TrainingController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TrainingController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Training;
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("training", Name = RouteNames.Training_Post)]
         public async Task<IActionResult> Training(TrainingEditModel m)
         {
-            var response = await _orchestrator.PostTrainingEditModelAsync(m);
+            var response = await _orchestrator.PostTrainingEditModelAsync(m, User.ToVacancyUser());
             
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part1/WageController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/WageController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage;
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("wage", Name = RouteNames.Wage_Get)]
         public async Task<IActionResult> Wage(WageEditModel m)
         {
-            var response = await _orchestrator.PostWageEditModelAsync(m);
+            var response = await _orchestrator.PostWageEditModelAsync(m, User.ToVacancyUser());
             
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/AboutEmployerController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/AboutEmployerController.cs
@@ -3,6 +3,7 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("about-employer", Name =  RouteNames.AboutEmployer_Post)]
         public async Task<IActionResult> AboutEmployer(AboutEmployerEditModel m)
         {
-            var response = await _orchestrator.PostAboutEmployerEditModelAsync(m);
+            var response = await _orchestrator.PostAboutEmployerEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/ApplicationProcessController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/ApplicationProcessController.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 
 namespace Esfa.Recruit.Employer.Web.Controllers.Part2
 {
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("application-process", Name = RouteNames.ApplicationProcess_Post)]
         public async Task<IActionResult> ApplicationProcess(ApplicationProcessEditModel m)
         {            
-            var response = await _orchestrator.PostApplicationProcessEditModelAsync(m);
+            var response = await _orchestrator.PostApplicationProcessEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/ConsiderationsController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/ConsiderationsController.cs
@@ -3,6 +3,7 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("considerations", Name =  RouteNames.Considerations_Post)]
         public async Task<IActionResult> Considerations(ConsiderationsEditModel m)
         {
-            var response = await _orchestrator.PostConsiderationsEditModelAsync(m);
+            var response = await _orchestrator.PostConsiderationsEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/QualificationsController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/QualificationsController.cs
@@ -35,7 +35,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("qualifications", Name = RouteNames.Qualifications_Post)]
         public async Task<IActionResult> Qualifications(QualificationsEditModel m)
         {
-            var response = await _orchestrator.PostQualificationsEditModelAsync(m);
+            var response = await _orchestrator.PostQualificationsEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 using Esfa.Recruit.Employer.Web.ViewModels.Part2.Skills;
@@ -32,7 +33,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("skills", Name = RouteNames.Skills_Post)]
         public async Task<IActionResult> Skills(SkillsEditModel m)
         {
-            var response = await _orchestrator.PostSkillsEditModelAsync(m);
+            var response = await _orchestrator.PostSkillsEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/TrainingProviderController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/TrainingProviderController.cs
@@ -3,6 +3,7 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 
@@ -66,7 +67,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
                 return await ProviderNotFound(vm);
             }
 
-            var response = await _orchestrator.PostConfirmEditModelAsync(m);
+            var response = await _orchestrator.PostConfirmEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/Part2/VacancyDescriptionController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/VacancyDescriptionController.cs
@@ -3,6 +3,7 @@ using Esfa.Recruit.Employer.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 
@@ -28,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpPost("vacancy-description", Name =  RouteNames.VacancyDescription_Index_Post)]
         public async Task<IActionResult> VacancyDescription(VacancyDescriptionEditModel m)
         {
-            var response = await _orchestrator.PostVacancyDescriptionEditModelAsync(m);
+            var response = await _orchestrator.PostVacancyDescriptionEditModelAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -35,7 +35,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpPost("preview", Name = RouteNames.Preview_Submit_Post)]
         public async Task<IActionResult> Submit(SubmitEditModel m)
         {
-            var response = await _orchestrator.TrySubmitVacancyAsync(m, User.GetDisplayName(), User.GetEmailAddress());
+            var response = await _orchestrator.TrySubmitVacancyAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {

--- a/src/Employer/Employer.Web/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Esfa.Recruit.Employer.Web.Configuration;
 using System.Security.Claims;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Extensions
 {
@@ -13,6 +14,21 @@ namespace Esfa.Recruit.Employer.Web.Extensions
         public static string GetEmailAddress(this ClaimsPrincipal user)
         {
             return user.FindFirstValue(EmployerRecruitClaims.IdamsUserEmailClaimTypeIdentifier);
+        }
+
+        public static string GetUserId(this ClaimsPrincipal user)
+        {
+            return user.FindFirstValue(EmployerRecruitClaims.IdamsUserIdClaimTypeIdentifier);
+        }
+
+        public static VacancyUser ToVacancyUser(this ClaimsPrincipal user)
+        {
+            return new VacancyUser
+            {
+                UserId = user.GetUserId(),
+                Name = user.GetDisplayName(),
+                Email = user.GetEmailAddress()
+            };
         }
     }
 }

--- a/src/Employer/Employer.Web/Orchestrators/DeleteVacancyOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/DeleteVacancyOrchestrator.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Employer.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators
 {
@@ -31,14 +32,14 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vm;
         }
 
-        public async Task<bool> TryDeleteVacancyAsync(DeleteEditModel m)
+        public async Task<bool> TryDeleteVacancyAsync(DeleteEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
             if (!vacancy.CanDelete)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForEditing, vacancy.Title));
 
-            return await _client.DeleteVacancyAsync(m.VacancyId);
+            return await _client.DeleteVacancyAsync(m.VacancyId, user);
         }
     }
 }

--- a/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -71,7 +71,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostEmployerEditModelAsync(EmployerEditModel m)
+        public async Task<OrchestratorResponse> PostEmployerEditModelAsync(EmployerEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -93,7 +93,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -49,7 +49,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostShortDescriptionEditModelAsync(ShortDescriptionEditModel m)
+        public async Task<OrchestratorResponse> PostShortDescriptionEditModelAsync(ShortDescriptionEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -64,7 +64,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -62,20 +62,16 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vm;
         }
 
-        public async Task<OrchestratorResponse<Guid>> PostTitleEditModelAsync(TitleEditModel vm, string user)
+        public async Task<OrchestratorResponse<Guid>> PostTitleEditModelAsync(TitleEditModel vm, VacancyUser user)
         {
             if (!vm.VacancyId.HasValue) // Create if it's a new vacancy
             {
                 var newVacancy = new Vacancy { Title = vm.Title };
 
-                return await ValidateAndExecute<Guid>(
+                return await ValidateAndExecute(
                     newVacancy, 
                     v => _client.Validate(v, ValidationRules),
-                    async v =>
-                    {
-                        return await _client.CreateVacancyAsync(vm.Title, vm.EmployerAccountId, user);
-                    }
-                );
+                    async v => await _client.CreateVacancyAsync(SourceOrigin.EmployerWeb, vm.Title, vm.EmployerAccountId, user));
             }
 
             var vacancy = await _client.GetVacancyAsync(vm.VacancyId.Value);
@@ -87,12 +83,12 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
             vacancy.Title = vm.Title;
 
-            return await ValidateAndExecute<Guid>(
+            return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValidationRules),
                 async v =>
                 {
-                    await _client.UpdateVacancyAsync(vacancy);
+                    await _client.UpdateVacancyAsync(vacancy, user);
                     return v.Id;
                 }
             );

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -79,7 +79,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostTrainingEditModelAsync(TrainingEditModel m)
+        public async Task<OrchestratorResponse> PostTrainingEditModelAsync(TrainingEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -95,7 +95,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValdationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -59,7 +59,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostWageEditModelAsync(WageEditModel m)
+        public async Task<OrchestratorResponse> PostWageEditModelAsync(WageEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -82,7 +82,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostAboutEmployerEditModelAsync(AboutEmployerEditModel m)
+        public async Task<OrchestratorResponse> PostAboutEmployerEditModelAsync(AboutEmployerEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -59,7 +59,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return await ValidateAndExecute(
                 vacancy,
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
@@ -52,7 +52,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostApplicationProcessEditModelAsync(ApplicationProcessEditModel m)
+        public async Task<OrchestratorResponse> PostApplicationProcessEditModelAsync(ApplicationProcessEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -68,7 +68,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return await ValidateAndExecute(
                 vacancy,
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostConsiderationsEditModelAsync(ConsiderationsEditModel m)
+        public async Task<OrchestratorResponse> PostConsiderationsEditModelAsync(ConsiderationsEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -56,7 +56,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return await ValidateAndExecute(
                 vacancy,
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
@@ -60,7 +60,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostQualificationsEditModelAsync(QualificationsEditModel m)
+        public async Task<OrchestratorResponse> PostQualificationsEditModelAsync(QualificationsEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -90,7 +90,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                     SyncErrorsAndModel(result.Errors, m);
                     return result;
                 },
-                v => validateOnly ? Task.CompletedTask : _client.UpdateVacancyAsync(v));
+                v => validateOnly ? Task.CompletedTask : _client.UpdateVacancyAsync(v, user));
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, QualificationsEditModel> DefineMappings()

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -64,7 +64,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             vm.CustomSkills = GetCustomSkills(skills).ToList();
         }
 
-        public async Task<OrchestratorResponse> PostSkillsEditModelAsync(SkillsEditModel m)
+        public async Task<OrchestratorResponse> PostSkillsEditModelAsync(SkillsEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -93,7 +93,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                     SyncErrorsAndModel(result.Errors, m);
                     return result;
                 },
-                v => validateOnly ? Task.CompletedTask : _client.UpdateVacancyAsync(v));
+                v => validateOnly ? Task.CompletedTask : _client.UpdateVacancyAsync(v, user));
         }
         
         protected override EntityToViewModelPropertyMappings<Vacancy, SkillsEditModel> DefineMappings()

--- a/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
@@ -68,7 +68,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             };
         }
 
-        public Task<OrchestratorResponse> PostConfirmEditModelAsync(ConfirmTrainingProviderEditModel m)
+        public Task<OrchestratorResponse> PostConfirmEditModelAsync(ConfirmTrainingProviderEditModel m, VacancyUser user)
         {
             var vacancyTask = _client.GetVacancyAsync(m.VacancyId);
             var providerTask = _providerService.GetProviderAsync(long.Parse(m.Ukprn));
@@ -83,7 +83,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return ValidateAndExecute(
                 vacancy,
                 v => _client.Validate(v, ValidationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
@@ -48,7 +48,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostVacancyDescriptionEditModelAsync(VacancyDescriptionEditModel m)
+        public async Task<OrchestratorResponse> PostVacancyDescriptionEditModelAsync(VacancyDescriptionEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -62,7 +62,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return await ValidateAndExecute(
                 vacancy,
                 v => _client.Validate(v, ValdationRules),
-                v => _client.UpdateVacancyAsync(vacancy)
+                v => _client.UpdateVacancyAsync(vacancy, user)
             );
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -45,7 +45,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vm;
         }
         
-        public async Task<OrchestratorResponse<bool>> TrySubmitVacancyAsync(SubmitEditModel m, string user, string userEmail)
+        public async Task<OrchestratorResponse<bool>> TrySubmitVacancyAsync(SubmitEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -60,7 +60,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                     SyncErrorsAndModel(result.Errors);
                     return result;
                 },
-                v => _client.SubmitVacancyAsync(v.Id, user, userEmail)
+                v => _client.SubmitVacancyAsync(v.Id, user)
             );
         }
 

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/SourceOrigin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/SourceOrigin.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+{
+    public enum SourceOrigin
+    {
+        Api,
+        EmployerWeb,
+        WebComplaint
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/SourceType.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/SourceType.cs
@@ -1,0 +1,9 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+{
+    public enum SourceType
+    {
+        Clone,
+        Extension,
+        New
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -7,36 +7,42 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
     {
         public Guid Id { get; set; }
         public long? VacancyReference { get; set; }
-        
-        public string Title { get; set; }
-        
-        public string EmployerAccountId { get; internal set; }
-
-        public string ApplicationInstructions { get; set; }
-        public string ApplicationUrl { get; set; }
+        public VacancyStatus Status { get; set; }
         
         public DateTime? CreatedDate { get; set; }
         public string CreatedBy { get; internal set; }
-        public string Description { get; set; }
-        public string EmployerContactName { get; set; }
-        public string EmployerContactEmail { get; set; }
-        public string EmployerContactPhone { get; set; }
-        public string EmployerDescription { get; set; }
-        public string EmployerWebsiteUrl { get; set; }
-        public VacancyStatus Status { get; set; }
 
         public DateTime? SubmittedDate { get; set; }
-
         public string SubmittedBy { get; set; }
         public string SubmittedByEmail { get; set; }
 
         public bool IsDeleted { get; set; }
         public DateTime? DeletedDate { get; set; }
-
-        /// <summary>
-        /// We can only submit draft vacancies that have not been deleted
-        /// </summary>
-        public bool CanSubmit => Status == VacancyStatus.Draft && IsDeleted == false;
+        
+        public string ApplicationInstructions { get; set; }
+        public string ApplicationUrl { get; set; }
+        public DateTime? ClosingDate { get; set; }
+        public string Description { get; set; }
+        public string EmployerAccountId { get; internal set; }
+        public string EmployerContactEmail { get; set; }
+        public string EmployerContactName { get; set; }
+        public string EmployerContactPhone { get; set; }
+        public string EmployerDescription { get; set; }
+        public Address EmployerLocation { get; set; }
+        public string EmployerName { get; set; }
+        public string EmployerWebsiteUrl { get; set; }
+        public int? NumberOfPositions { get; set; }
+        public string OutcomeDescription { get; set; }
+        public string ProgrammeId { get; set; }
+        public List<Qualification> Qualifications { get; set; }
+        public string ShortDescription { get; set; }
+        public List<string> Skills { get; set; }
+        public DateTime? StartDate { get; set; }
+        public string ThingsToConsider { get; set; }
+        public string Title { get; set; }
+        public string TrainingDescription { get; set; }
+        public TrainingProvider TrainingProvider { get; set; }
+        public Wage Wage { get; set; }
 
         /// <summary>
         /// We can only delete draft vacancies that have not been deleted
@@ -47,28 +53,10 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         /// We can only edit draft vacancies that have not been deleted
         /// </summary>
         public bool CanEdit => Status == VacancyStatus.Draft && IsDeleted == false;
-        
-        public string EmployerName { get; set; }
-        public string OutcomeDescription { get; set; }
-        public Address EmployerLocation { get; set; }
 
-        public int? NumberOfPositions { get; set; }
-
-        public string ShortDescription { get; set; }
-        public string ThingsToConsider { get; set; }
-        public DateTime? ClosingDate { get; set; }
-
-        public DateTime? StartDate { get; set; }
-
-        public string ProgrammeId { get; set; }
-
-        public Wage Wage { get; set; }
-
-        public string TrainingDescription { get; set; }
-        
-        public List<string> Skills { get; set; }
-
-        public List<Qualification> Qualifications { get; set; }
-        public TrainingProvider TrainingProvider { get; set; }
+        /// <summary>
+        /// We can only submit draft vacancies that have not been deleted
+        /// </summary>
+        public bool CanSubmit => Status == VacancyStatus.Draft && IsDeleted == false;
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -5,25 +5,31 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
 {
     public class Vacancy
     {
-        public Guid Id { get; set; }
-        public long? VacancyReference { get; set; }
-        public VacancyStatus Status { get; set; }
+        public Guid Id { get; internal set; }
+        public string EmployerAccountId { get; internal set; }
+        public long? VacancyReference { get; internal set; }
+        public VacancyStatus Status { get; internal set; }
+        public SourceOrigin SourceOrigin { get; internal set; }
+        public SourceType SourceType { get; internal set; }
+        public long? SourceVacancyReference { get; internal set; }
+
+        public DateTime? CreatedDate { get; internal set; }
+        public VacancyUser CreatedByUser { get; internal set; }
+
+        public DateTime? SubmittedDate { get; internal set; }
+        public VacancyUser SubmittedByUser { get; internal set; }
         
-        public DateTime? CreatedDate { get; set; }
-        public string CreatedBy { get; internal set; }
-
-        public DateTime? SubmittedDate { get; set; }
-        public string SubmittedBy { get; set; }
-        public string SubmittedByEmail { get; set; }
-
-        public bool IsDeleted { get; set; }
-        public DateTime? DeletedDate { get; set; }
+        public DateTime? LastUpdatedDate { get; internal set; }
+        public VacancyUser LastUpdatedByUser { get; internal set; }
+        
+        public bool IsDeleted { get; internal set; }
+        public DateTime? DeletedDate { get; internal set; }
+        public VacancyUser DeletedByUser { get; internal set; }
         
         public string ApplicationInstructions { get; set; }
         public string ApplicationUrl { get; set; }
         public DateTime? ClosingDate { get; set; }
         public string Description { get; set; }
-        public string EmployerAccountId { get; internal set; }
         public string EmployerContactEmail { get; set; }
         public string EmployerContactName { get; set; }
         public string EmployerContactPhone { get; set; }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyUser.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyUser.cs
@@ -1,0 +1,9 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+{
+    public class VacancyUser
+    {
+        public string UserId { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -12,10 +12,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
     public interface IEmployerVacancyClient
     {
         Task<Vacancy> GetVacancyAsync(Guid id);
-        Task<Guid> CreateVacancyAsync(string title, string employerAccountId, string user);
-        Task UpdateVacancyAsync(Vacancy vacancy);
-        Task<bool> SubmitVacancyAsync(Guid id, string user, string userEmail);
-        Task<bool> DeleteVacancyAsync(Guid id);
+        Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, string employerAccountId, VacancyUser user);
+        Task UpdateVacancyAsync(Vacancy vacancy, VacancyUser user);
+        Task<bool> SubmitVacancyAsync(Guid id, VacancyUser user);
+        Task<bool> DeleteVacancyAsync(Guid id, VacancyUser user);
         Task<Dashboard> GetDashboardAsync(string employerAccountId);
         Task RecordEmployerAccountSignInAsync(string employerAccountId);
         Task<EditVacancyInfo> GetEditVacancyInfo(string employerAccountId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
@@ -10,7 +10,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
             {
                 new CamelCaseElementNameConvention(),
                 new EnumRepresentationConvention(MongoDB.Bson.BsonType.String),
-                new IgnoreExtraElementsConvention(true)
+                new IgnoreExtraElementsConvention(true),
+                new IgnoreIfNullConvention(true)
         };
             ConventionRegistry.Register("recruit conventions", pack, t => true);
         }


### PR DESCRIPTION
- Have shuffled the properties around in the Vacancy entity. Identification and state based properties are now at the top and are `internal set`. The remainder of the fields are alphabetical and `public set`. Helpers are located at the bottom of the class.
- Added MongoDB convention IgnoreIfNullConvention
- We now trap user information when creating, updating, submitting and deleting.