### PR TITLE
VacancyClient refactor

### DIFF
--- a/src/Employer/Employer.Web/Controllers/DeleteVacancyController.cs
+++ b/src/Employer/Employer.Web/Controllers/DeleteVacancyController.cs
@@ -3,9 +3,7 @@ using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.RouteModel;
-using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.DeleteVacancy;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
@@ -41,13 +39,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 return RedirectToRoute(RouteNames.Vacancy_Preview_Get);
             }
 
-            var result = await _orchestrator.TryDeleteVacancyAsync(m, User.ToVacancyUser());
-
-            if (!result)
-            {
-                ModelState.AddModelError(string.Empty, ErrorMessages.VacancyAlreadyDeleted);
-                return await GetDeleteVacancyConfirmationView(vrm);
-            }
+            await _orchestrator.DeleteVacancyAsync(m, User.ToVacancyUser());
             
             return RedirectToRoute(RouteNames.Dashboard_Index_Get);
         }

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -36,21 +36,16 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpPost("preview", Name = RouteNames.Preview_Submit_Post)]
         public async Task<IActionResult> Submit(SubmitEditModel m)
         {
-            var response = await _orchestrator.TrySubmitVacancyAsync(m, User.ToVacancyUser());
+            var response = await _orchestrator.SubmitVacancyAsync(m, User.ToVacancyUser());
 
             if (!response.Success)
             {
                 response.AddErrorsToModelState(ModelState);
             }
 
-            if (ModelState.IsValid && response.Data)
+            if (ModelState.IsValid)
             {
                 return RedirectToRoute(RouteNames.Submitted_Index_Get);
-            }
-
-            if (ModelState.IsValid && !response.Data)
-            {
-                ModelState.AddModelError(string.Empty, "Vacancy has already been submitted");
             }
 
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);

--- a/src/Employer/Employer.Web/Orchestrators/DeleteVacancyOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/DeleteVacancyOrchestrator.cs
@@ -34,7 +34,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vm;
         }
 
-        public async Task<bool> TryDeleteVacancyAsync(DeleteEditModel m, VacancyUser user)
+        public async Task DeleteVacancyAsync(DeleteEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
@@ -43,7 +43,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (!vacancy.CanDelete)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForEditing, vacancy.Title));
 
-            return await _client.DeleteVacancyAsync(m.VacancyId, user);
+            await _client.DeleteVacancyAsync(vacancy.Id, user);
         }
     }
 }

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -46,15 +46,15 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vm;
         }
         
-        public async Task<OrchestratorResponse<bool>> TrySubmitVacancyAsync(SubmitEditModel m, VacancyUser user)
+        public async Task<OrchestratorResponse> SubmitVacancyAsync(SubmitEditModel m, VacancyUser user)
         {
             var vacancy = await _client.GetVacancyAsync(m.VacancyId);
 
             Utility.CheckAuthorisedAccess(vacancy, m.EmployerAccountId);
 
-            if (!vacancy.CanEdit)
+            if (!vacancy.CanSubmit)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForEditing, vacancy.Title));
-
+            
             return await ValidateAndExecute(
                 vacancy,
                 v =>

--- a/src/Employer/Employer.Web/ViewModels/ErrorMessages.cs
+++ b/src/Employer/Employer.Web/ViewModels/ErrorMessages.cs
@@ -5,7 +5,5 @@
         public const string VacancyCannotBeViewed = "The vacancy '{0}' can't be viewed.";
         public const string VacancyNotAvailableForEditing = "The vacancy '{0}' has been edited by one of your colleagues. Your changes have not been saved.";
         public const string VacancyNotSubmittedSuccessfully = "The vacancy '{0}' has not been submitted successfully.";
-        public const string VacancyAlreadySubmitted = "Vacancy has already been submitted.";
-        public const string VacancyAlreadyDeleted = "This vacancy does not exist or has already been deleted.";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateVacancyCommandHandler.cs
@@ -5,6 +5,8 @@ using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Services;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
@@ -12,22 +14,41 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     {
         private readonly IVacancyRepository _repository;
         private readonly IMessaging _messaging;
+        private readonly ITimeProvider _timeProvider;
 
-        public CreateVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging)
+        public CreateVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging, ITimeProvider timeProvider)
         {
             _repository = repository;
             _messaging = messaging;
+            _timeProvider = timeProvider;
         }
 
         public async Task Handle(CreateVacancyCommand message, CancellationToken cancellationToken)
         {
-            await _repository.CreateAsync(message.Vacancy);
+            var now = _timeProvider.Now;
+
+            var vacancy = new Vacancy
+            {
+                Id = message.VacancyId,
+                SourceOrigin = message.Origin,
+                SourceType = SourceType.New,
+                Title = message.Title,
+                EmployerAccountId = message.EmployerAccountId,
+                Status = VacancyStatus.Draft,
+                CreatedDate = now,
+                CreatedByUser = message.User,
+                LastUpdatedDate = now,
+                LastUpdatedByUser = message.User,
+                IsDeleted = false
+            };
+
+            await _repository.CreateAsync(vacancy);
 
             await _messaging.PublishEvent(new VacancyCreatedEvent
             {
                 SourceCommandId = message.CommandId.ToString(),
-                EmployerAccountId = message.Vacancy.EmployerAccountId,
-                VacancyId = message.Vacancy.Id
+                EmployerAccountId = vacancy.EmployerAccountId,
+                VacancyId = vacancy.Id
             });
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandler.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Services;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
@@ -12,22 +13,39 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     {
         private readonly IVacancyRepository _repository;
         private readonly IMessaging _messaging;
+        private readonly ITimeProvider _timeProvider;
 
-        public DeleteVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging)
+        public DeleteVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging, ITimeProvider timeProvider)
         {
             _repository = repository;
             _messaging = messaging;
+            _timeProvider = timeProvider;
         }
 
         public async Task Handle(DeleteVacancyCommand message, CancellationToken cancellationToken)
         {
-            await _repository.UpdateAsync(message.Vacancy);
+            var vacancy = await _repository.GetVacancyAsync(message.VacancyId);
+
+            if (vacancy == null || vacancy.CanDelete == false)
+            {
+                return;
+            }
+
+            var now = _timeProvider.Now;
+
+            vacancy.IsDeleted = true;
+            vacancy.DeletedDate = now;
+            vacancy.DeletedByUser = message.User;
+            vacancy.LastUpdatedDate = now;
+            vacancy.LastUpdatedByUser = message.User;
+
+            await _repository.UpdateAsync(vacancy);
 
             await _messaging.PublishEvent(new VacancyDeletedEvent
             {
                 SourceCommandId = message.CommandId.ToString(),
-                EmployerAccountId = message.Vacancy.EmployerAccountId,
-                VacancyId = message.Vacancy.Id
+                EmployerAccountId = vacancy.EmployerAccountId,
+                VacancyId = vacancy.Id
             });
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
@@ -5,6 +5,8 @@ using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Services;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
@@ -12,22 +14,39 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     {
         private readonly IVacancyRepository _repository;
         private readonly IMessaging _messaging;
+        private readonly ITimeProvider _timeProvider;
 
-        public SubmitVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging)
+        public SubmitVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging, ITimeProvider timeProvider)
         {
             _repository = repository;
             _messaging = messaging;
+            _timeProvider = timeProvider;
         }
 
         public async Task Handle(SubmitVacancyCommand message, CancellationToken cancellationToken)
         {
-            await _repository.UpdateAsync(message.Vacancy);
+            var vacancy = await _repository.GetVacancyAsync(message.VacancyId);
+            
+            if (vacancy == null || vacancy.CanSubmit == false)
+            {
+                return;
+            }
+            
+            var now = _timeProvider.Now;
+
+            vacancy.Status = VacancyStatus.Submitted;
+            vacancy.SubmittedDate = now;
+            vacancy.SubmittedByUser = message.User;
+            vacancy.LastUpdatedDate = now;
+            vacancy.LastUpdatedByUser = message.User;
+
+            await _repository.UpdateAsync(vacancy);
 
             await _messaging.PublishEvent(new VacancySubmittedEvent
             {
                 SourceCommandId = message.CommandId.ToString(),
-                EmployerAccountId = message.Vacancy.EmployerAccountId,
-                VacancyId = message.Vacancy.Id
+                EmployerAccountId = vacancy.EmployerAccountId,
+                VacancyId = vacancy.Id
             });
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/UpdateVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/UpdateVacancyCommandHandler.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Services;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
@@ -12,15 +13,20 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     {
         private readonly IVacancyRepository _repository;
         private readonly IMessaging _messaging;
+        private ITimeProvider _timeProvider;
 
-        public UpdateVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging)
+        public UpdateVacancyCommandHandler(IVacancyRepository repository, IMessaging messaging, ITimeProvider timeProvider)
         {
             _repository = repository;
             _messaging = messaging;
+            _timeProvider = timeProvider;
         }
 
         public async Task Handle(UpdateVacancyCommand message, CancellationToken cancellationToken)
         {
+            message.Vacancy.LastUpdatedDate = _timeProvider.Now;
+            message.Vacancy.LastUpdatedByUser = message.User;
+
             await _repository.UpdateAsync(message.Vacancy);
 
             await _messaging.PublishEvent(new VacancyUpdatedEvent

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/CreateVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/CreateVacancyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using MediatR;
 
@@ -6,6 +7,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class CreateVacancyCommand : CommandBase, ICommand, IRequest
     {
-        public Vacancy Vacancy { get; set; }
+        public Guid VacancyId { get; set; }
+        public SourceOrigin Origin { get; set; }
+        public string Title { get;set; }
+        public string EmployerAccountId { get; set; }
+        public VacancyUser User { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/DeleteVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/DeleteVacancyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using MediatR;
 
@@ -6,6 +7,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class DeleteVacancyCommand : CommandBase, ICommand, IRequest
     {
-        public Vacancy Vacancy { get; set; }
+        public Guid VacancyId { get; set; }
+        public VacancyUser User { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using MediatR;
 
@@ -6,6 +7,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class SubmitVacancyCommand : CommandBase, ICommand, IRequest
     {
-        public Vacancy Vacancy { get; set; }
+        public Guid VacancyId { get;set; }
+        public VacancyUser User { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/UpdateVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/UpdateVacancyCommand.cs
@@ -1,5 +1,4 @@
-﻿using Esfa.Recruit.Vacancies.Client.Application.Validation;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using MediatR;
 
@@ -8,7 +7,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
     public class UpdateVacancyCommand : CommandBase, ICommand, IRequest
     {
         public Vacancy Vacancy { get; set; }
-
-        public VacancyRuleSet ValidationRules { get; set; }
+        public VacancyUser User { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -11,12 +11,12 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
     public interface IEmployerVacancyClient
     {
-        Task<Vacancy> GetVacancyAsync(Guid id);
+        Task<Vacancy> GetVacancyAsync(Guid vacancyId);
         Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, string employerAccountId, VacancyUser user);
         Task UpdateVacancyAsync(Vacancy vacancy, VacancyUser user);
-        Task<bool> SubmitVacancyAsync(Guid id, VacancyUser user);
-        Task<bool> ApproveVacancyAsync(Guid id);
-        Task<bool> DeleteVacancyAsync(Guid id, VacancyUser user);
+        Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user);
+        Task<bool> ApproveVacancyAsync(Guid vacancyId);
+        Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<Dashboard> GetDashboardAsync(string employerAccountId);
         Task RecordEmployerAccountSignInAsync(string employerAccountId);
         Task<EditVacancyInfo> GetEditVacancyInfo(string employerAccountId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -15,7 +15,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, string employerAccountId, VacancyUser user);
         Task UpdateVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user);
-        Task<bool> ApproveVacancyAsync(Guid vacancyId);
+        Task ApproveVacancyAsync(Guid vacancyId);
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<Dashboard> GetDashboardAsync(string employerAccountId);
         Task RecordEmployerAccountSignInAsync(string employerAccountId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
@@ -8,7 +8,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
     public interface IJobsVacancyClient
     {
-        Task AssignVacancyNumber(Guid id);
+        Task AssignVacancyNumber(Guid vacancyId);
 
         Task UpdateApprenticeshipProgrammesAsync(IEnumerable<ApprenticeshipProgramme> programmes);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -91,18 +91,15 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _messaging.SendCommandAsync(command);
         }
 
-        public async Task<bool> ApproveVacancyAsync(Guid id)
+        public Task ApproveVacancyAsync(Guid vacancyId)
         {
             var command = new ApproveVacancyCommand()
             {
-                VacancyId = id
+                VacancyId = vacancyId
             };
 
-            await _messaging.SendCommandAsync(command);
-
-            return true;
+            return _messaging.SendCommandAsync(command);
         }
-
 
         public Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user)
         {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -9,7 +9,6 @@ using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
-using Esfa.Recruit.Vacancies.Client.Domain.Services;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Mappings;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Dashboard;
@@ -25,7 +24,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         private readonly IQueryStoreReader _reader;
         private readonly IQueryStoreWriter _writer;
         private readonly IVacancyRepository _repository;
-        private readonly ITimeProvider _timeProvider;
         private readonly IEntityValidator<Vacancy, VacancyRuleSet> _validator;
         private readonly IApprenticeshipProgrammeProvider _apprenticeshipProgrammesProvider;
         private readonly IEmployerAccountService _employerAccountService;
@@ -35,12 +33,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             IQueryStoreReader reader, 
             IQueryStoreWriter writer, 
             IMessaging messaging, 
-            ITimeProvider timeProvider, 
             IEntityValidator<Vacancy, VacancyRuleSet> validator, 
             IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider,
             IEmployerAccountService employerAccountService)
         {
-            _timeProvider = timeProvider;
             _repository = repository;
             _reader = reader;
             _writer = writer;
@@ -52,74 +48,47 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 
         public Task UpdateVacancyAsync(Vacancy vacancy, VacancyUser user)
         {
-            vacancy.LastUpdatedDate = _timeProvider.Now;
-            vacancy.LastUpdatedByUser = user;
-            
             var command = new UpdateVacancyCommand
             {
-                Vacancy = vacancy
+                Vacancy = vacancy,
+                User = user
             };
 
             return _messaging.SendCommandAsync(command);
         }
 
-        public Task<Vacancy> GetVacancyAsync(Guid id)
+        public Task<Vacancy> GetVacancyAsync(Guid vacancyId)
         {
-            return _repository.GetVacancyAsync(id);
+            return _repository.GetVacancyAsync(vacancyId);
         }
 
         public async Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, string employerAccountId, VacancyUser user)
         {
-            var now = _timeProvider.Now;
+            var vacancyId = Guid.NewGuid();
 
             var command = new CreateVacancyCommand
             {
-                Vacancy = new Vacancy
-                {
-                    Id = Guid.NewGuid(),
-                    SourceOrigin = origin,
-                    SourceType = SourceType.New,
-                    Title = title,
-                    EmployerAccountId = employerAccountId,
-                    Status = VacancyStatus.Draft,
-                    CreatedDate = now,
-                    CreatedByUser = user,
-                    LastUpdatedDate = now,
-                    LastUpdatedByUser = user,
-                    IsDeleted = false
-                }
+                VacancyId = vacancyId,
+                User = user,
+                Title = title,
+                EmployerAccountId = employerAccountId,
+                Origin = origin
             };
 
             await _messaging.SendCommandAsync(command);
 
-            return command.Vacancy.Id;
+            return vacancyId;
         }
 
-        public async Task<bool> SubmitVacancyAsync(Guid id, VacancyUser user)
+        public Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user)
         {
-            var vacancy = await GetVacancyAsync(id);
-
-            if(!vacancy.CanSubmit)
-            {
-                return false;
-            }
-
-            var now = _timeProvider.Now;
-
-            vacancy.Status = VacancyStatus.Submitted;
-            vacancy.SubmittedDate = now;
-            vacancy.SubmittedByUser = user;
-            vacancy.LastUpdatedDate = now;
-            vacancy.LastUpdatedByUser = user;
-            
             var command = new SubmitVacancyCommand
             {
-                Vacancy = vacancy
+                VacancyId = vacancyId,
+                User = user
             };
 
-            await _messaging.SendCommandAsync(command);
-            
-            return true;
+            return _messaging.SendCommandAsync(command);
         }
 
         public async Task<bool> ApproveVacancyAsync(Guid id)
@@ -134,31 +103,16 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return true;
         }
 
-        public async Task<bool> DeleteVacancyAsync(Guid id, VacancyUser user)
+
+        public Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user)
         {
-            var vacancy = await GetVacancyAsync(id);
-            
-            if (vacancy == null || vacancy.CanDelete == false)
-            {
-                return false;
-            }
-
-            var now = _timeProvider.Now;
-
-            vacancy.IsDeleted = true;
-            vacancy.DeletedDate = now;
-            vacancy.DeletedByUser = user;
-            vacancy.LastUpdatedDate = now;
-            vacancy.LastUpdatedByUser = user;
-
             var command = new DeleteVacancyCommand
             {
-                Vacancy = vacancy
+                VacancyId = vacancyId,
+                User = user
             };
 
-            await _messaging.SendCommandAsync(command);
-
-            return true;
+            return _messaging.SendCommandAsync(command);
         }
         
         public Task<Dashboard> GetDashboardAsync(string employerAccountId)
@@ -202,11 +156,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         }
 
         // Jobs
-        public Task AssignVacancyNumber(Guid id)
+        public Task AssignVacancyNumber(Guid vacancyId)
         {
             var command = new AssignVacancyNumberCommand
             {
-                VacancyId = id
+                VacancyId = vacancyId
             };
 
             return _messaging.SendCommandAsync(command);            


### PR DESCRIPTION
When it comes to functions that send a command the VacancyClient should only be a skinny wrapper around the command creation.  There was extra logic in VacancyClient that should really be in the handlers.  So I've moved this logic into the relevant handler.

I've also removed some redundant code that will never be executed due to the InvalidStateException checks that we've introduced.
