### PR TITLE
Docker compose change and env config

### DIFF
--- a/setup/containers/docker-compose.yml
+++ b/setup/containers/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - cluster.name=muggle-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1

--- a/src/Employer/Employer.Web/Program.cs
+++ b/src/Employer/Employer.Web/Program.cs
@@ -30,14 +30,6 @@ namespace Esfa.Recruit.Employer.Web
                 .UseKestrel(c => c.AddServerHeader = false)
                 .UseStartup<Startup>()
                 .UseUrls("http://localhost:5020")
-                .ConfigureAppConfiguration((hostingContext, config) =>
-                    {
-                        var hostingEnvironment = hostingContext.HostingEnvironment;
-                        if (hostingEnvironment.IsDevelopment())
-                        {
-                            config.AddUserSecrets<Startup>();
-                        }
-                    })
                 .UseNLog()
                 .Build();
     }

--- a/src/QA/QA.Web/Program.cs
+++ b/src/QA/QA.Web/Program.cs
@@ -70,14 +70,6 @@ namespace Esfa.Recruit.Qa.Web
                 })
                 .UseStartup<Startup>()
                 .UseUrls("https://localhost:5025")
-                .ConfigureAppConfiguration((hostingContext, config) =>
-                    {
-                        var hostingEnvironment = hostingContext.HostingEnvironment;
-                        if (hostingEnvironment.IsDevelopment())
-                        {
-                            config.AddUserSecrets<Startup>();
-                        }
-                    })
                 .UseNLog()
                 .Build();
     }


### PR DESCRIPTION
Hi, I don't think the changes in this pull request would adversely affect anyone else running the solutions and using Docker for local dependencies. For me it will make a difference as it will allow me to use the local Redis container dependencies for logging without having to change appSettings.json constantly and having to exclude committing it.

Also the `docker-compose.yaml` change makes it easier for me to run an elastic v5 + container without configuring the virtual page memory on the virtual Docker host frequently. Elastic search requires 4GB.