### PR TITLE
ER-499 job to rebuild employer dashboard

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreator.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreator.cs
@@ -1,0 +1,20 @@
+﻿using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
+using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
+{
+    public class DashboardCreator
+    {
+        private readonly IDashboardService _dashboardService;
+
+        public DashboardCreator(IDashboardService dashboardService)
+        {
+            _dashboardService = dashboardService;
+        }
+
+        public Task RunAsync(string employerId)
+        {
+            return _dashboardService.ReBuildDashboard(employerId);
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreator.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreator.cs
@@ -14,7 +14,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
 
         public Task RunAsync(string employerId)
         {
-            return _dashboardService.ReBuildDashboard(employerId);
+            return _dashboardService.ReBuildDashboardAsync(employerId);
         }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
@@ -29,6 +29,10 @@ namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
                 await _job.RunAsync(data.EmployerAccountId);
                 _logger.LogInformation($"Finished {JobName} For Employer Account: {data.EmployerAccountId}");
             }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Unable to deserialise event: {eventBody}", message);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Unable to run {JobName}.");

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Events;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
+{
+    public class DashboardGeneratorJob
+    {
+        private readonly ILogger<DashboardGeneratorJob> _logger;
+        private readonly DashboardCreator _job;
+        private string JobName => GetType().Name;
+
+        public DashboardGeneratorJob(ILogger<DashboardGeneratorJob> logger, DashboardCreator job)
+        {
+            _logger = logger;
+            _job = job;
+        }
+
+        public async Task GenerateEmployerVacancyData([QueueTrigger(QueueNames.DashboardQueueName, Connection = "EventQueueConnectionString")] string message, TextWriter log)
+        {
+            try
+            {
+                var data = JsonConvert.DeserializeObject<DashboardCreateMessage>(message);
+                _logger.LogInformation($"Start {JobName} For Employer Account: {data.EmployerAccountId}");
+                await _job.RunAsync(data.EmployerAccountId);
+                _logger.LogInformation($"Finished {JobName} For Employer Account: {data.EmployerAccountId}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Unable to run {JobName}.");
+            }
+        }
+
+        class DashboardCreateMessage
+        {
+            public string EmployerAccountId { get; set; }
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using Esfa.Recruit.Vacancies.Jobs.ApprenticeshipProgrammes;
+using Esfa.Recruit.Vacancies.Jobs.DashboardGenerator;
 using Esfa.Recruit.Vacancies.Jobs.EditVacancyInfo;
 using Esfa.Recruit.Vacancies.Jobs.VacancyEvents;
 using Esfa.Recruit.Vacancies.Jobs.VacancyReviewEvents;
@@ -138,6 +139,7 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddScoped<ApprenticeshipProgrammesUpdater>();
             services.AddScoped<EditVacancyInfoUpdater>();
             services.AddScoped<LiveVacancyStatusInspector>();
+            services.AddScoped<DashboardCreator>();
 
 
             services.AddSingleton<IApprenticeshipProgrammeApiClient, ApprenticeshipProgrammeApiClient>();
@@ -150,7 +152,7 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddScoped<ApprenticeshipProgrammesJob>();
             services.AddScoped<EditVacancyInfoJob>();
             services.AddScoped<VacancyStatusJob>();
-
+            services.AddScoped<DashboardGeneratorJob>();
 
             return services;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateDashboardOnVacancyChange.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateDashboardOnVacancyChange.cs
@@ -67,7 +67,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                 throw new ArgumentNullException(nameof(notification), "Should not be null");
             
             _logger.LogInformation($"Handling {notification.GetType().Name} for accountId: {{employerAccountId}} and vacancyId: {notification.VacancyId}", notification.EmployerAccountId);
-            return _dashboardService.ReBuildDashboard(notification.EmployerAccountId);
+            return _dashboardService.ReBuildDashboardAsync(notification.EmployerAccountId);
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Events/QueueNames.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Events/QueueNames.cs
@@ -4,5 +4,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Events
     {
         public const string VacancyEventsQueueName = "vacancy-events-queue";
         public const string VacancyReviewEventsQueueName = "vacancy-review-events-queue";
+        public const string DashboardQueueName = "dashboard-queue";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/DashboardService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/DashboardService.cs
@@ -1,0 +1,44 @@
+﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Dashboard;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services
+{
+    internal class DashboardService : IDashboardService
+    {
+        private readonly ILogger<DashboardService> _logger;
+        private readonly IVacancyRepository _repository;
+        private readonly IQueryStoreWriter _queryStoreWriter;
+
+        public DashboardService(IVacancyRepository repository, IQueryStoreWriter queryStoreWriter, ILogger<DashboardService> logger)
+        {
+            _logger = logger;
+            _repository = repository;
+            _queryStoreWriter = queryStoreWriter;
+        }
+
+        public async Task ReBuildDashboard(string employerAccountId)
+        {
+            var vacancySummaries = await _repository.GetVacanciesByEmployerAccountAsync<VacancySummary>(employerAccountId);
+
+            var activeVacancySummaries = vacancySummaries.Where(v => v.IsDeleted == false).ToList();
+
+            foreach (var summary in activeVacancySummaries)
+            {
+                // PendingReview shows as Submitted in Dashboard.
+                if (summary.Status == VacancyStatus.PendingReview)
+                {
+                    summary.Status = VacancyStatus.Submitted;
+                }
+            }
+
+            await _queryStoreWriter.UpdateDashboardAsync(employerAccountId, activeVacancySummaries.OrderBy(v => v.CreatedDate));
+
+            _logger.LogDebug("Update dashboard with {count} summary records for account: {employerAccountId}", activeVacancySummaries.Count, employerAccountId);
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/DashboardService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/DashboardService.cs
@@ -21,7 +21,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services
             _queryStoreWriter = queryStoreWriter;
         }
 
-        public async Task ReBuildDashboard(string employerAccountId)
+        public async Task ReBuildDashboardAsync(string employerAccountId)
         {
             var vacancySummaries = await _repository.GetVacanciesByEmployerAccountAsync<VacancySummary>(employerAccountId);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/IDashboardService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/IDashboardService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services
+{
+    public interface IDashboardService
+    {
+        Task ReBuildDashboard(string employerAccountId);
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/IDashboardService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/IDashboardService.cs
@@ -4,6 +4,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services
 {
     public interface IDashboardService
     {
-        Task ReBuildDashboard(string employerAccountId);
+        Task ReBuildDashboardAsync(string employerAccountId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddTransient<ITimeProvider, CurrentUtcTimeProvider>();
             services.AddTransient<IEmployerAccountService, EmployerAccountService>();
+            services.AddTransient<IDashboardService, DashboardService>();
             services.AddTransient<IGetMinimumWages, StubNationalMinimumWageService>();
             services.AddTransient<IGenerateVacancyNumbers, MongoSequenceStore>();
             services.AddTransient<IApprenticeshipProgrammeProvider, ApprenticeshipProgrammeProvider>();


### PR DESCRIPTION
This is a very basic job. I have used an inner class for the message at the moment as it is not event driven and just to keep it simple. This is a job that will change soon after private beta.

An example message to be published manually onto the queue can be:
```
{
"EmployerAccountId": "MYJR4X"
}
```