### PR TITLE
Add check for existence of queryViews collection

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyStatus/LiveVacancyStatusInspector.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyStatus/LiveVacancyStatusInspector.cs
@@ -22,7 +22,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyStatus
         internal async Task InspectAsync()
         {
             var vacancies = (await _client.GetLiveVacancies()).ToList();
-            int numberClosed = 0;
+            var numberClosed = 0;
             
             foreach (var vacancy in vacancies.Where(x => x.ClosingDate  <= _timeProvider.Now))
             {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbExtensions.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
+{
+    internal static class MongoDbExtensions
+    {
+        internal static bool Exists<T>(this IMongoCollection<T> collection)
+        {
+            return DetermineIfCollectionExists(collection.Database, collection.CollectionNamespace.CollectionName);
+        }
+
+        private static bool DetermineIfCollectionExists(IMongoDatabase database, string collectionName)
+        {
+            using (IAsyncCursor<BsonDocument> collectionCursor = database.ListCollections(new ListCollectionsOptions { Filter = Builders<BsonDocument>.Filter.Eq("name", collectionName) }))
+            {
+                while (collectionCursor.MoveNext())
+                {
+                    if (collectionCursor.Current.SingleOrDefault() != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
A work around for the queryViews collection to allow us to delete the collection in environments allow the release process to create and not the webjob auto creating it.