### PR TITLE
ER-509 - Logging update & retry policy

### DIFF
--- a/src/Employer/Employer.Web/Controllers/ErrorController.cs
+++ b/src/Employer/Employer.Web/Controllers/ErrorController.cs
@@ -63,23 +63,18 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
                 if (exception is InvalidRouteForVacancyException invalidRouteException)
                 {
-                    _logger.LogInformation(exception.Message);
                     return RedirectToRoute(invalidRouteException.RouteNameToRedirectTo, invalidRouteException.RouteValues);
                 }
 
                 if (exception is VacancyNotFoundException)
                 {
-                    _logger.LogError(exception, exception.Message);
                     return PageNotFound();
                 }
 
                 if (exception is AuthorisationException)
                 {
-                    _logger.LogWarning(exception, exception.Message);
                     return AccessDenied();
                 }
-
-                _logger.LogError(exception, "An unexpected exception occurred.");
             }
 
             return View(ViewNames.ErrorView, new ErrorViewModel { StatusCode = (int)HttpStatusCode.InternalServerError, RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });

--- a/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipProgrammesJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipProgrammesJob.cs
@@ -29,6 +29,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.ApprenticeshipProgrammes
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to update standards and frameworks.");
+                throw;
             }
         }
     }

--- a/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdater.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdater.cs
@@ -72,7 +72,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.ApprenticeshipProgrammes
 
             var retryPolicy = GetApiRetryPolicy();
 
-            var standards = await retryPolicy.ExecuteAsync(() => _standardsClient.GetAllAsync(), new Dictionary<string, object>() {{ "apiCall", "Standards" }});
+            var standards = await retryPolicy.ExecuteAsync(context => _standardsClient.GetAllAsync(), new Dictionary<string, object>() {{ "apiCall", "Standards" }});
 
             return standards.FilterAndMapToApprenticeshipProgrammes();
         }
@@ -83,7 +83,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.ApprenticeshipProgrammes
             
             var retryPolicy = GetApiRetryPolicy();
 
-            var frameworks = await retryPolicy.ExecuteAsync(() => _frameworksClient.GetAllAsync(), new Dictionary<string, object>() {{ "apiCall", "Frameworks" }});
+            var frameworks = await retryPolicy.ExecuteAsync(context => _frameworksClient.GetAllAsync(), new Dictionary<string, object>() {{ "apiCall", "Frameworks" }});
             
             return frameworks.FilterAndMapToApprenticeshipProgrammes();
         }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreateMessage.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreateMessage.cs
@@ -1,0 +1,10 @@
+namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
+{
+    public partial class DashboardGeneratorJob
+    {
+        class DashboardCreateMessage
+        {
+            public string EmployerAccountId { get; set; }
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreateMessage.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardCreateMessage.cs
@@ -1,10 +1,7 @@
 namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
 {
-    public partial class DashboardGeneratorJob
+    internal class DashboardCreateMessage
     {
-        class DashboardCreateMessage
-        {
-            public string EmployerAccountId { get; set; }
-        }
+        public string EmployerAccountId { get; set; }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
 {
-    public partial class DashboardGeneratorJob
+    public class DashboardGeneratorJob
     {
         private readonly ILogger<DashboardGeneratorJob> _logger;
         private readonly DashboardCreator _job;

--- a/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DashboardGenerator/DashboardGeneratorJob.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
 {
-    public class DashboardGeneratorJob
+    public partial class DashboardGeneratorJob
     {
         private readonly ILogger<DashboardGeneratorJob> _logger;
         private readonly DashboardCreator _job;
@@ -32,16 +32,13 @@ namespace Esfa.Recruit.Vacancies.Jobs.DashboardGenerator
             catch (JsonException ex)
             {
                 _logger.LogError(ex, "Unable to deserialise event: {eventBody}", message);
+                throw;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Unable to run {JobName}.");
+                throw;
             }
-        }
-
-        class DashboardCreateMessage
-        {
-            public string EmployerAccountId { get; set; }
         }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/EditVacancyInfo/EditVacancyInfoJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/EditVacancyInfo/EditVacancyInfoJob.cs
@@ -36,6 +36,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.EditVacancyInfo
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Unable to run {JobName}. Event: {{eventBody}}", message);
+                throw;
             }
         }
     }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.2" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
-    <PackageReference Include="Polly" Version="5.8.0" />
+    <PackageReference Include="Polly" Version="6.0.1" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.10.138" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.0" />

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
@@ -28,6 +28,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
             }
 
             _logger.LogInformation($"Finished Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
@@ -44,6 +45,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
             }
 
             _logger.LogInformation($"Finished Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
@@ -60,6 +62,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
             }
 
             _logger.LogInformation($"Finished Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
@@ -19,10 +19,8 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
 
         public async Task Handle(VacancyCreatedEvent @event)
         {
-            
             try
             {
-                
                 _logger.LogInformation($"Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
                 await _client.AssignVacancyNumber(@event.VacancyId);
                 
@@ -33,12 +31,10 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
                 throw;
             }
-
         }
 
         public async Task Handle(VacancyDraftUpdatedEvent @event)
         {
-
             try
             {
                 _logger.LogInformation($"Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
@@ -52,12 +48,10 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
                 throw;
             }
-
         }
 
         public async Task Handle(VacancySubmittedEvent @event)
         {
-            
             try
             {
                 _logger.LogInformation($"Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
@@ -71,7 +65,6 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 _logger.LogError(ex, "Unable to process {eventBody}", @event);
                 throw;
             }
-
         }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventHandler.cs
@@ -19,11 +19,14 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
 
         public async Task Handle(VacancyCreatedEvent @event)
         {
-            _logger.LogInformation($"Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
             
             try
             {
+                
+                _logger.LogInformation($"Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
                 await _client.AssignVacancyNumber(@event.VacancyId);
+                
+                _logger.LogInformation($"Finished Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
             }
             catch (Exception ex)
             {
@@ -31,16 +34,18 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 throw;
             }
 
-            _logger.LogInformation($"Finished Processing {nameof(VacancyCreatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
         }
 
         public async Task Handle(VacancyDraftUpdatedEvent @event)
         {
-            _logger.LogInformation($"Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
 
             try
             {
+                _logger.LogInformation($"Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
+               
                 await _client.EnsureVacancyIsGeocodedAsync(@event.VacancyId);
+               
+                _logger.LogInformation($"Finished Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
             }
             catch (Exception ex)
             {
@@ -48,16 +53,18 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 throw;
             }
 
-            _logger.LogInformation($"Finished Processing {nameof(VacancyDraftUpdatedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
         }
 
         public async Task Handle(VacancySubmittedEvent @event)
         {
-            _logger.LogInformation($"Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
             
             try
             {
+                _logger.LogInformation($"Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
+                
                 await _client.CreateVacancyReview(@event.VacancyReference);
+                
+                _logger.LogInformation($"Finished Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
             }
             catch (Exception ex)
             {
@@ -65,7 +72,6 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
                 throw;
             }
 
-            _logger.LogInformation($"Finished Processing {nameof(VacancySubmittedEvent)} for vacancy: {{VacancyId}}", @event.VacancyId);
         }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventsJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyEvents/VacancyEventsJob.cs
@@ -31,6 +31,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyEvents
             catch (JsonException ex)
             {
                 _logger.LogError(ex, "Unable to deserialise event: {eventBody}", message);
+                throw;
             }
         }
 

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Domain.Events;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
@@ -18,22 +19,37 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyReviewEvents
 
         public async Task Handle(VacancyReviewApprovedEvent @event)
         {
-            _logger.LogInformation($"Processing {nameof(VacancyReviewApprovedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
-            
-            await _client.ApproveVacancy(@event.VacancyReference);
+            try
+            {
+                _logger.LogInformation($"Processing {nameof(VacancyReviewApprovedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+                
+                await _client.ApproveVacancy(@event.VacancyReference);
 
-            _logger.LogInformation($"Finished Processing {nameof(VacancyCreatedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+                _logger.LogInformation($"Finished Processing {nameof(VacancyCreatedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
+            }
         }
 
         public async Task Handle(VacancyReviewReferredEvent @event)
         {
-            _logger.LogInformation($"Processing {nameof(VacancyReviewReferredEvent)} for referral: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+            try
+            {
+                _logger.LogInformation($"Processing {nameof(VacancyReviewReferredEvent)} for referral: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
             
-            await _client.ReferVacancy(@event.VacancyReference);
+                await _client.ReferVacancy(@event.VacancyReference);
 
-            _logger.LogInformation($"Finished Processing {nameof(VacancyReviewReferredEvent)} for referral: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+                _logger.LogInformation($"Finished Processing {nameof(VacancyReviewReferredEvent)} for referral: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
+            }
         }
-        
     }
 }
 

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
@@ -30,7 +30,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyReviewEvents
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unable to handle vacancy event");
+                _logger.LogError(ex, "Unable to deserialise event: {eventBody}", message);
                 throw;
             }
         }

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
@@ -31,6 +31,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyReviewEvents
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to handle vacancy event");
+                throw;
             }
         }
 

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyReviewEvents/VacancyReviewEventsJob.cs
@@ -28,7 +28,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyReviewEvents
                 
                 await UnpackAndExecute(eventItem.EventType, eventItem.Data);
             }
-            catch (Exception ex)
+            catch (JsonException ex)
             {
                 _logger.LogError(ex, "Unable to deserialise event: {eventBody}", message);
                 throw;

--- a/src/Jobs/Recruit.Vacancies.Jobs/VacancyStatus/VacancyStatusJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/VacancyStatus/VacancyStatusJob.cs
@@ -34,6 +34,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.VacancyStatus
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unable to check vacancy statuses.");
+                throw;
             }
         }
     }

--- a/src/Jobs/Recruit.Vacancies.Jobs/nlog.config
+++ b/src/Jobs/Recruit.Vacancies.Jobs/nlog.config
@@ -23,7 +23,7 @@
     <!-- write to the void aka just remove -->
     <target xsi:type="Null" name="blackhole" />
 
-    <target xsi:type="Redis" name="redis" connectionStringName="Redis" environmentKeyName="ASPNETCORE_ENVIRONMENT" appName="das-vacancies-webjobs" includeAllProperties="true" layout="${message}" >
+    <target xsi:type="Redis" name="redis" connectionStringName="Redis" environmentKeyName="ASPNETCORE_ENVIRONMENT" appName="das-recruit-webjobs" includeAllProperties="true" layout="${message}" >
       <field name="loggerName" layout="${logger}"/>
     </target>
   </targets>

--- a/src/QA/QA.Web/Controllers/ErrorController.cs
+++ b/src/QA/QA.Web/Controllers/ErrorController.cs
@@ -51,7 +51,6 @@ namespace Esfa.Recruit.Qa.Web.Controllers
                         _logger.LogError(exception, exception.Message);
                         return PageNotFound();
                     default:
-                        _logger.LogError(exception, "An unexpected exception occurred.");
                         break;
                 }
             }

--- a/src/QA/QA.Web/Controllers/ErrorController.cs
+++ b/src/QA/QA.Web/Controllers/ErrorController.cs
@@ -48,7 +48,6 @@ namespace Esfa.Recruit.Qa.Web.Controllers
                         _logger.LogError(exception, "Exception on path: {route}", exceptionFeature.Path);
                         return View(ViewNames.ErrorView, GetViewModel(HttpStatusCode.NotFound));
                     case VacancyNotFoundException _:
-                        _logger.LogError(exception, exception.Message);
                         return PageNotFound();
                     default:
                         break;

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbCollectionBase.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbCollectionBase.cs
@@ -1,20 +1,30 @@
-﻿using System.Security.Authentication;
+﻿using System;
+using System.Security.Authentication;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
+using Polly;
+using Polly.Retry;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
 {
     internal abstract class MongoDbCollectionBase
     {
+        private readonly ILogger _logger;
         private readonly string _dbName;
         private readonly string _collectionName;
         private readonly MongoDbConnectionDetails _config;
-        
-        protected MongoDbCollectionBase(string dbName, string collectionName, IOptions<MongoDbConnectionDetails> config)
+
+        protected RetryPolicy RetryPolicy { get; }
+
+        protected MongoDbCollectionBase(ILogger logger, string dbName, string collectionName, IOptions<MongoDbConnectionDetails> config)
         {
+            _logger = logger;
             _dbName = dbName;
             _collectionName = collectionName;
             _config = config.Value;
+            RetryPolicy = GetRetryPolicy();
         }
 
         protected IMongoCollection<T> GetCollection<T>()
@@ -27,6 +37,34 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
             var collection = database.GetCollection<T>(_collectionName);
 
             return collection;
+        }
+
+        protected Task Retry(Func<Task> func)
+        {
+            var policy = GetRetryPolicy();
+
+            return policy.ExecuteAsync(func);
+        }
+
+        protected Task<T> Retry<T>(Func<Task<T>> func)
+        {
+            var policy = GetRetryPolicy();
+
+            return policy.ExecuteAsync(func);
+        }
+
+        private Polly.Retry.RetryPolicy GetRetryPolicy()
+        {
+            return Policy
+                    .Handle<MongoCommandException>()
+                    .WaitAndRetryAsync(new[]
+                    {
+                        TimeSpan.FromSeconds(1),
+                        TimeSpan.FromSeconds(2),
+                        TimeSpan.FromSeconds(4)
+                    }, (exception, timeSpan, retryCount, context) => {
+                        _logger.LogWarning($"Error executing Mongo Command for {context["methodName"]}. Retrying in {timeSpan.Seconds} secs...attempt: {retryCount}");    
+                    });
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
@@ -34,7 +34,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
 
         public async Task<Vacancy> GetVacancyAsync(long vacancyReference)
         {
-            var vacancy = await RetryPolicy.ExecuteAsync(() => FindVacancy(v => v.VacancyReference, vacancyReference));
+            var vacancy = await FindVacancy(v => v.VacancyReference, vacancyReference);
 
             if (vacancy == null)
                 throw new VacancyNotFoundException(string.Format(ExceptionMessages.VacancyWithReferenceNotFound, vacancyReference));
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
 
         public async Task<Vacancy> GetVacancyAsync(Guid id)
         {
-            var vacancy = await RetryPolicy.ExecuteAsync(() => FindVacancy(v => v.Id, id));
+            var vacancy = await FindVacancy(v => v.Id, id);
 
             if (vacancy == null)
                 throw new VacancyNotFoundException(string.Format(ExceptionMessages.VacancyWithIdNotFound, id));

--- a/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
+++ b/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -19,30 +19,31 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="4.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="RestSharp" Version="106.2.2" />
-    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.2.0.62882" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
-    <PackageReference Include="FluentValidation" Version="7.5.2" />
+    <PackageReference Include="MediatR" Version="4.0.1"/>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="4.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0"/>
+    <PackageReference Include="MongoDB.Driver" Version="2.5.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3"/>
+    <PackageReference Include="RestSharp" Version="106.2.2"/>
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.2.0.62882"/>
+    <PackageReference Include="WindowsAzure.Storage" Version="9.1.0"/>
+    <PackageReference Include="FluentValidation" Version="7.5.2"/>
+    <PackageReference Include="Polly" Version="6.0.1"/>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Application\Validation\Fluent\CustomValidators\VacancyValidators\" />
-    <Folder Include="Application\Services\" />
+    <Folder Include="Application\Validation\Fluent\CustomValidators\VacancyValidators\"/>
+    <Folder Include="Application\Services\"/>
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="Application\QueryStore\**" />
+    <Compile Remove="Application\QueryStore\**"/>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Remove="Application\QueryStore\**" />
+    <EmbeddedResource Remove="Application\QueryStore\**"/>
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Application\QueryStore\**" />
+    <None Remove="Application\QueryStore\**"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Updated logging to resolve issues highlighted in Gorilla testing session.
- Added retry logic to repo/store classes in the event of a MongoCommandException. 

There is a knock-on effect of the retry logic for the jobs, in that if they pick messages off of queues they could retry up to 15 times.

5 (times message retried) **x** 3 (Polly retries) 