### PR TITLE
ER-515 renaming cookies and turning off arr affinity cookie

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -40,7 +40,12 @@ namespace Esfa.Recruit.Employer.Web.Configuration
 
         public static void AddMvcService(this IServiceCollection services, IHostingEnvironment hostingEnvironment, bool isAuthEnabled)
         {
-            services.AddAntiforgery(options => options.Cookie.Name = CookieNames.AntiForgeryCookie);
+            services.AddAntiforgery(options =>
+            {
+                options.Cookie.Name = CookieNames.AntiForgeryCookie;
+                options.FormFieldName = "_csrfToken";
+                options.HeaderName = "X-XSRF-TOKEN";
+            });
             services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = CookieNames.RecruitTempData);
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 

--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -40,6 +40,8 @@ namespace Esfa.Recruit.Employer.Web.Configuration
 
         public static void AddMvcService(this IServiceCollection services, IHostingEnvironment hostingEnvironment, bool isAuthEnabled)
         {
+            services.AddAntiforgery(options => options.Cookie.Name = CookieNames.AntiForgeryCookie);
+            services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = CookieNames.RecruitTempData);
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 
             services.AddMvc(opts =>
@@ -82,6 +84,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             })
             .AddCookie("Cookies", options =>
             {
+                options.Cookie.Name = CookieNames.RecruitData;
                 options.AccessDeniedPath = "/Error/403";
                 options.SlidingExpiration = true;
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(SessionTimeoutMinutes);

--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -21,7 +21,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
     public static class ConfigurationExtensions
     {
         private const string HasEmployerAccountPolicyName = "HasEmployerAccount";
-        public const int SessionTimeoutMinutes = 30;
+        private const int SessionTimeoutMinutes = 30;
 
         public static void AddAuthorizationService(this IServiceCollection services)
         {

--- a/src/Employer/Employer.Web/Configuration/CookieNames.cs
+++ b/src/Employer/Employer.Web/Configuration/CookieNames.cs
@@ -1,7 +1,10 @@
-﻿namespace Esfa.Recruit.Employer.Web.Configuration
+namespace Esfa.Recruit.Employer.Web.Configuration
 {
     public static class CookieNames
     {
         public const string ShowExampleVacancy = "showExampleVacancy";
+        public const string RecruitData = "recruit-data";
+        public const string RecruitTempData = "recruit-temp-data";
+        public const string AntiForgeryCookie = "recruit-x-csrf";
     }
 }

--- a/src/Employer/Employer.Web/Configuration/CookieNames.cs
+++ b/src/Employer/Employer.Web/Configuration/CookieNames.cs
@@ -6,5 +6,6 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         public const string RecruitData = "recruit-data";
         public const string RecruitTempData = "recruit-temp-data";
         public const string AntiForgeryCookie = "recruit-x-csrf";
+        public const string SetupEmployer = "setup-employer-{0}";
     }
 }

--- a/src/Employer/Employer.Web/Middleware/EmployerAccountHandler.cs
+++ b/src/Employer/Employer.Web/Middleware/EmployerAccountHandler.cs
@@ -43,11 +43,11 @@ namespace Esfa.Recruit.Employer.Web.Middleware
 
         private async Task EnsureEmployerIsSetup(HttpContext context, string employerAccountId)
         {
-            var key = $"setup_employer_{employerAccountId}";
+            var key = string.Format(CookieNames.SetupEmployer, employerAccountId);
             if (context.Request.Cookies[key] == null)
             {
                 await _client.SetupEmployerAsync(employerAccountId);
-                context.Response.Cookies.Append(key, String.Empty);
+                context.Response.Cookies.Append(key, string.Empty);
             }
         }
     }

--- a/src/Employer/Esfa.Recruit.Azure.Resources/Esfa.Recruit.Azure.Resources.deployproj
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/Esfa.Recruit.Azure.Resources.deployproj
@@ -31,6 +31,7 @@
       <Visible>False</Visible>
     </None>
     <Content Include="Deploy-AzureResourceGroup.ps1" />
+    <None Include="deployments\app-service-resources.json" />
   </ItemGroup>
   <Target Name="GetReferenceAssemblyPaths" />
 </Project>

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -366,6 +366,8 @@
       "comments": "This will become a Function App when Core is GA",
       "location": "[resourceGroup().location]",
       "properties": {
+        "phpVersion": "Off",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[variables('SharedAppServicePlanId')]",
         "siteConfig": {
           "appSettings": [

--- a/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
@@ -34,15 +34,17 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
-            "properties": {
-                "serverFarmId": "[variables('SharedAppServicePlanId')]",
-                "siteConfig": {
-                    "appSettings": "[parameters('AppSettings')]",
-                    "connectionStrings": "[parameters('ConnectionStrings')]",
-                    "alwaysOn": true
-                },
-                "httpsOnly": true
+          "properties": {
+            "phpVersion": "Off",
+            "clientAffinityEnabled": false,
+            "serverFarmId": "[variables('SharedAppServicePlanId')]",
+            "siteConfig": {
+              "appSettings": "[parameters('AppSettings')]",
+              "connectionStrings": "[parameters('ConnectionStrings')]",
+              "alwaysOn": true
             },
+            "httpsOnly": true
+          },
             "resources": [
                 {
                     "name": "staging",
@@ -64,7 +66,7 @@
             ]
         },
         {
-            "type": "Microsoft.Web/sites/hostnameBindings",
+            "type": "Microsoft.Web/sites/hostNameBindings",
             "condition": "[variables('UseCustomHostname')]",
             "name": "[concat(parameters('AppServiceName'), '/', if(variables('UseCustomHostname'), parameters('CustomHostname'), 'placeholder'))]",
             "apiVersion": "2016-03-01",

--- a/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
@@ -41,7 +41,7 @@
           "appSettings": "[parameters('AppSettings')]",
           "connectionStrings": "[parameters('ConnectionStrings')]",
           "alwaysOn": true,
-          "phpVersion": "Off"
+          "phpVersion": ""
         },
         "httpsOnly": true
       },
@@ -58,7 +58,7 @@
               "appSettings": "[parameters('AppSettings')]",
               "connectionStrings": "[parameters('ConnectionStrings')]",
               "alwaysOn": true,
-              "phpVersion": "Off"
+              "phpVersion": ""
             }
           },
           "dependsOn": [

--- a/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/deployments/app-service-resources.json
@@ -1,84 +1,86 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "AppServiceName": {
-            "type": "string"
-        },
-        "SharedAppServicePlanName": {
-            "type": "string"
-        },
-        "SharedAppServicePlanResourceGroup": {
-            "type": "string"
-        },
-        "AppSettings": {
-            "type": "array"
-        },
-        "ConnectionStrings": {
-            "type": "array"
-        },
-        "CustomHostname": {
-            "type": "string"
-        },
-        "KeyvaultCertificateName": {
-            "type": "string"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "AppServiceName": {
+      "type": "string"
     },
-    "variables": {
-        "UseCustomHostname": "[greater(length(parameters('CustomHostname')), 0)]",
-        "SharedAppServicePlanId": "[resourceId(parameters('SharedAppServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('SharedAppServicePlanName'))]"
+    "SharedAppServicePlanName": {
+      "type": "string"
     },
-    "resources": [
+    "SharedAppServicePlanResourceGroup": {
+      "type": "string"
+    },
+    "AppSettings": {
+      "type": "array"
+    },
+    "ConnectionStrings": {
+      "type": "array"
+    },
+    "CustomHostname": {
+      "type": "string"
+    },
+    "KeyvaultCertificateName": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "UseCustomHostname": "[greater(length(parameters('CustomHostname')), 0)]",
+    "SharedAppServicePlanId": "[resourceId(parameters('SharedAppServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('SharedAppServicePlanName'))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('AppServiceName')]",
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2016-08-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "clientAffinityEnabled": false,
+        "serverFarmId": "[variables('SharedAppServicePlanId')]",
+        "siteConfig": {
+          "appSettings": "[parameters('AppSettings')]",
+          "connectionStrings": "[parameters('ConnectionStrings')]",
+          "alwaysOn": true,
+          "phpVersion": "Off"
+        },
+        "httpsOnly": true
+      },
+      "resources": [
         {
-            "name": "[parameters('AppServiceName')]",
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2016-08-01",
-            "location": "[resourceGroup().location]",
+          "name": "staging",
+          "type": "slots",
+          "apiVersion": "2016-08-01",
+          "location": "[resourceGroup().location]",
           "properties": {
-            "phpVersion": "Off",
+            "scmSiteAlsoStopped": true,
             "clientAffinityEnabled": false,
-            "serverFarmId": "[variables('SharedAppServicePlanId')]",
             "siteConfig": {
               "appSettings": "[parameters('AppSettings')]",
               "connectionStrings": "[parameters('ConnectionStrings')]",
-              "alwaysOn": true
-            },
-            "httpsOnly": true
+              "alwaysOn": true,
+              "phpVersion": "Off"
+            }
           },
-            "resources": [
-                {
-                    "name": "staging",
-                    "type": "slots",
-                    "apiVersion": "2016-08-01",
-                    "location": "[resourceGroup().location]",
-                    "properties": {
-                        "scmSiteAlsoStopped": true,
-                        "siteConfig": {
-                            "appSettings": "[parameters('AppSettings')]",
-                            "connectionStrings": "[parameters('ConnectionStrings')]",
-                            "alwaysOn": true
-                        }
-                    },
-                    "dependsOn": [
-                        "[parameters('AppServiceName')]"
-                    ]
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.Web/sites/hostNameBindings",
-            "condition": "[variables('UseCustomHostname')]",
-            "name": "[concat(parameters('AppServiceName'), '/', if(variables('UseCustomHostname'), parameters('CustomHostname'), 'placeholder'))]",
-            "apiVersion": "2016-03-01",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "sslState": "SniEnabled",
-                "thumbprint": "[reference(resourceId(parameters('SharedAppServicePlanResourceGroup'), 'Microsoft.Web/certificates', parameters('KeyvaultCertificateName')), '2016-03-01').Thumbprint]"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('AppServiceName'))]"
-            ]
+          "dependsOn": [
+            "[parameters('AppServiceName')]"
+          ]
         }
-    ],
-    "outputs": {}
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "condition": "[variables('UseCustomHostname')]",
+      "name": "[concat(parameters('AppServiceName'), '/', if(variables('UseCustomHostname'), parameters('CustomHostname'), 'placeholder'))]",
+      "apiVersion": "2016-03-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "sslState": "SniEnabled",
+        "thumbprint": "[reference(resourceId(parameters('SharedAppServicePlanResourceGroup'), 'Microsoft.Web/certificates', parameters('KeyvaultCertificateName')), '2016-03-01').Thumbprint]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('AppServiceName'))]"
+      ]
+    }
+  ],
+  "outputs": {}
 }

--- a/src/QA/QA.Web/Configuration/CookieNames.cs
+++ b/src/QA/QA.Web/Configuration/CookieNames.cs
@@ -1,0 +1,9 @@
+﻿namespace Esfa.Recruit.Qa.Web.Configuration
+{
+    public static class CookieNames
+    {
+        public const string QaData = "qa-data";
+        public const string QaTempData = "qa-temp-data";
+        public const string AntiForgeryCookie = "qa-x-csrf";
+    }
+}

--- a/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
+++ b/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
@@ -59,7 +59,12 @@ namespace Esfa.Recruit.Qa.Web.Configuration
 
         public static void AddMvcService(this IServiceCollection services)
         {
-            services.AddAntiforgery(options => options.Cookie.Name = CookieNames.AntiForgeryCookie);
+            services.AddAntiforgery(options =>
+            {
+                options.Cookie.Name = CookieNames.AntiForgeryCookie;
+                options.FormFieldName = "_csrfToken";
+                options.HeaderName = "X-XSRF-TOKEN";
+            });
             services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = CookieNames.QaTempData);
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 

--- a/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
+++ b/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 
@@ -19,27 +20,29 @@ namespace Esfa.Recruit.Qa.Web.Configuration
 
         public static void AddAuthenticationService(this IServiceCollection services, AuthenticationConfiguration authConfig)
         {
-            services.AddAuthentication(sharedOptions =>
-                {
-                    sharedOptions.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    sharedOptions.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
-                    sharedOptions.DefaultSignOutScheme = WsFederationDefaults.AuthenticationScheme;
-                })
-                .AddWsFederation(options =>
-                {
-                    options.Wtrealm = authConfig.Wtrealm;
-                    options.MetadataAddress = authConfig.MetaDataAddress;
-                    options.UseTokenLifetime = false;
-                    //options.CallbackPath = "/";
-                    //options.SkipUnrecognizedRequests = true;
-                })
-                .AddCookie(options =>
-                {
-                    options.AccessDeniedPath = RoutePrefixPaths.AccessDeniedPath;
-                    options.SlidingExpiration = true;
-                    options.ExpireTimeSpan = TimeSpan.FromMinutes(SessionTimeoutMinutes);
-                });
+            services
+            .AddAuthentication(sharedOptions =>
+            {
+                sharedOptions.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                sharedOptions.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
+                sharedOptions.DefaultSignOutScheme = WsFederationDefaults.AuthenticationScheme;
+            })
+            .AddWsFederation(options =>
+            {
+                options.Wtrealm = authConfig.Wtrealm;
+                options.MetadataAddress = authConfig.MetaDataAddress;
+                options.UseTokenLifetime = false;
+                //options.CallbackPath = "/";
+                //options.SkipUnrecognizedRequests = true;
+            })
+            .AddCookie(options =>
+            {
+                options.Cookie.Name = CookieNames.QaData;
+                options.AccessDeniedPath = RoutePrefixPaths.AccessDeniedPath;
+                options.SlidingExpiration = true;
+                options.ExpireTimeSpan = TimeSpan.FromMinutes(SessionTimeoutMinutes);
+            });
         }
 
         public static void AddAuthorizationService(this IServiceCollection services, AuthorizationConfiguration authorizationConfig)
@@ -56,6 +59,10 @@ namespace Esfa.Recruit.Qa.Web.Configuration
 
         public static void AddMvcService(this IServiceCollection services)
         {
+            services.AddAntiforgery(options => options.Cookie.Name = CookieNames.AntiForgeryCookie);
+            services.Configure<CookieTempDataProviderOptions>(options => options.Cookie.Name = CookieNames.QaTempData);
+            services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
+
             services.AddMvc(options =>
             {
                 options.SslPort = 5025;


### PR DESCRIPTION
One thing I noticed after while doing this PR and giving cookies unique names between the two sites is I could run the employer app and the qa app in the same browser without conflicts in cookie resolution.

