### PR TITLE
Fix for screen readers on apprenticeship training search

### DIFF
--- a/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
@@ -62,7 +62,7 @@
                 </div>
 
                 <div esfa-validation-marker-for="SelectedProgrammeId" class="form-group">
-                    <label asp-for="SelectedProgrammeId" class="form-label-bold">Search for apprenticeship training (standard or framework)</label>
+                    <label asp-for="SelectedProgrammeId" class="form-label-bold">Search for apprenticeship training (standard or framework)<span class="visuallyhidden"> Press Enter key to activate list of apprenticeship standards and frameworks</span></label>
 
                     <span esfa-validation-message-for="SelectedProgrammeId" class="error-message"></span>
 

--- a/src/Employer/Employer.Web/wwwroot/css/application.css
+++ b/src/Employer/Employer.Web/wwwroot/css/application.css
@@ -1084,7 +1084,11 @@ input.form-control, textarea.form-control {
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {
     border: solid black 1px;
-    outline: 0
+}
+
+.select2-selection:focus{
+    outline:3px solid #ffbf47;
+    outline-offset: 0;
 }
 
 .select2-container--default.select2-container--disabled .select2-selection--multiple {


### PR DESCRIPTION
Added visuallyhidden copy for screen readers and changed outline colour on focus to match other fields