### PR TITLE
Including the QA user in the logs

### DIFF
--- a/src/QA/QA.Web/nlog.config
+++ b/src/QA/QA.Web/nlog.config
@@ -9,13 +9,14 @@
   <!-- enable asp.net core layout renderers -->
   <extensions>
     <add assembly="NLog.Web.AspNetCore"/>
-    <add assembly="SFA.DAS.NLog.Targets.Redis"/>    
+    <add assembly="SFA.DAS.NLog.Targets.Redis"/>
   </extensions>
 
   <!-- the targets to write to -->
   <targets>
     <target xsi:type="Redis" name="redis" connectionStringName="Redis" environmentKeyName="ASPNETCORE_ENVIRONMENT" appName="das-qa-recruit-web" includeAllProperties="true" layout="${message}">
       <field name="requestId" layout="${aspnet-traceidentifier}"/>
+      <field name="user" layout="${aspnet-User-Identity}"/>
       <field name="loggerName" layout="${logger}"/>
     </target>
   </targets>


### PR DESCRIPTION
This is something that maybe temporary while we have internal QA users to help monitor which users experience which errors on the QA site. Maybe remove it for public beta.