### PR TITLE
ER-586 - Part one navigation

### DIFF
--- a/src/Data/CosmosDb/030-ER-586_insert_Vacancy_HasCompletedPart1.js
+++ b/src/Data/CosmosDb/030-ER-586_insert_Vacancy_HasCompletedPart1.js
@@ -1,0 +1,72 @@
+// https://stackoverflow.com/a/44564089/5596802
+function toGUID(hex) {
+    var a = hex.substr(6, 2) + hex.substr(4, 2) + hex.substr(2, 2) + hex.substr(0, 2);
+    var b = hex.substr(10, 2) + hex.substr(8, 2);
+    var c = hex.substr(14, 2) + hex.substr(12, 2);
+    var d = hex.substr(16, 16);
+    hex = a + b + c + d;
+    var uuid = hex.substr(0, 8) + "-" + hex.substr(8, 4) + "-" + hex.substr(12, 4) + "-" + hex.substr(16, 4) + "-" + hex.substr(20, 12);
+    return uuid;
+}
+
+print("Start adding/updating Vacancies with HasCompletedPart1 true");
+
+var query = {
+        "hasCompletedPart1": { $exists: false },
+        "title": { $exists: true },
+        "employerLocation": { $exists: true },
+        "programmeId": { $exists: true },
+        "wage": { $exists: true }
+    },
+    batchUpdateLimit = 500,
+    passThrough = 1;
+
+var maxLoops = Math.ceil(db.vacancies.find().count(query) / batchUpdateLimit);
+
+if (maxLoops === 0) {
+    maxLoops = 1;
+}
+
+do {
+    var matchedDocs = db.vacancies.aggregate([
+        {
+            $match: query
+        },
+        {
+            $sort: { "dateCreated": 1 }
+        },
+        {
+            $limit: batchUpdateLimit
+        }
+    ]);
+
+    print("Found " + matchedDocs._batch.length + " document(s) to operate on in passThrough " + passThrough + " of " + maxLoops + ".");
+
+    while (matchedDocs.hasNext()) {
+        var doc = matchedDocs.next();
+
+        var writeResult = db.vacancies.update({
+            "_id": doc._id,
+            "hasCompletedPart1": { $exists: false },
+            "title": { $exists: true },
+            "employerLocation": { $exists: true },
+            "programmeId": { $exists: true },
+            "wage": { $exists: true }
+        }, {
+            $set: { "hasCompletedPart1": true }
+        }, {
+            upsert: false
+        });
+
+        if (writeResult.hasWriteConcernError()) {
+            printjson(writeResult.writeConcernError);
+            quit(14);
+        }
+
+        print("Updated document '" + toGUID(doc._id.hex()) + "' with hasCompletedPart1: true.");
+    }
+
+    passThrough++;
+} while (passThrough <= maxLoops && db.vacancies.find().count(query) > 0);
+
+print("Finished adding/updating Vacancies with default hasCompletedPart1.");

--- a/src/Data/CosmosDb/documentMigration.js
+++ b/src/Data/CosmosDb/documentMigration.js
@@ -8,3 +8,4 @@ if (db !== "recruit") {
 
 load("010-queryViews_LiveVacancy_Insert_DefaultField_ApplicationMethod.js");
 load("020-vacancies_Insert_DefaultField_ApplicationMethod.js");
+load("030-ER-586_insert_Vacancy_HasCompletedPart1.js");

--- a/src/Data/Data.sln
+++ b/src/Data/Data.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CosmosDb\.eslintrc.json = CosmosDb\.eslintrc.json
 		CosmosDb\010-queryViews_LiveVacancy_Insert_DefaultField_ApplicationMethod.js = CosmosDb\010-queryViews_LiveVacancy_Insert_DefaultField_ApplicationMethod.js
 		CosmosDb\020-vacancies_Insert_DefaultField_ApplicationMethod.js = CosmosDb\020-vacancies_Insert_DefaultField_ApplicationMethod.js
+		CosmosDb\030-ER-586_insert_Vacancy_HasCompletedPart1.js = CosmosDb\030-ER-586_insert_Vacancy_HasCompletedPart1.js
 		CosmosDb\Configuration.json = CosmosDb\Configuration.json
 		CosmosDb\documentMigration.js = CosmosDb\documentMigration.js
 		CosmosDb\Invoke-CosmosDbScript.ps1 = CosmosDb\Invoke-CosmosDbScript.ps1

--- a/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
@@ -69,6 +69,7 @@
         public const string VacancyDescription_Index_Post = "VacancyDescription_Index_Post";
 
         public const string SearchResultPreview_Get = "SearchResultPreview_Get";
+        public const string SearchResultPreview_Post = "SearchResultPreview_Post";
 
         public const string Skills_Get = "Skills_Get";
         public const string Skills_Post = "Skills_Post";

--- a/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
@@ -43,7 +43,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return View(vm);
             }
 
-            return RedirectToRoute(RouteNames.Training_Get);
+            return RedirectToRoute(response.Data.RouteName, response.Data.RouteValues, response.Data.Fragment);
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/Part1/SearchResultPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/SearchResultPreviewController.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +22,14 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         {
             var vm = await _orchestrator.GetSearchResultPreviewViewModelAsync(vrm);
             return View(vm);
+        }
+
+        [HttpPost("search-result-preview", Name = RouteNames.SearchResultPreview_Post)]
+        public async Task<IActionResult> PostSearchResultPreview(VacancyRouteModel vrm)
+        {
+            var redirectRouteParameters = await _orchestrator.PostSearchResultPreviewViewModelAsync(vrm, User.ToVacancyUser());
+
+            return RedirectToRoute(redirectRouteParameters.RouteName, redirectRouteParameters.RouteValues, redirectRouteParameters.Fragment);
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/Part1/ShortDescriptionController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/ShortDescriptionController.cs
@@ -43,7 +43,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return View(vm);
             }
 
-            return RedirectToRoute(RouteNames.Employer_Get);
+            return RedirectToRoute(response.Data.RouteName, response.Data.RouteValues, response.Data.Fragment);
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/Part1/TitleController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TitleController.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
+using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Title;
 using Microsoft.AspNetCore.Mvc;
@@ -49,8 +50,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 var vm = await _orchestrator.GetTitleViewModelAsync(m);
                 return View(vm);
             }
-            
-            return RedirectToRoute(RouteNames.ShortDescription_Get, new { vacancyId = response.Data });
+
+            return RedirectToRoute(response.Data.RouteName, response.Data.RouteValues, response.Data.Fragment);
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/Part1/TrainingController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TrainingController.cs
@@ -43,8 +43,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return View(vm);
             }
 
-            return RedirectToRoute(RouteNames.Wage_Get);
+            return RedirectToRoute(response.Data.RouteName, response.Data.RouteValues, response.Data.Fragment);
         }
-        
     }
 }

--- a/src/Employer/Employer.Web/Controllers/Part1/WageController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/WageController.cs
@@ -43,7 +43,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return View(vm);
             }
 
-            return RedirectToRoute(RouteNames.SearchResultPreview_Get);
+            return RedirectToRoute(response.Data.RouteName, response.Data.RouteValues, response.Data.Fragment);
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
@@ -54,11 +54,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
         private IActionResult HandleRedirectOfDraftVacancy(Vacancy vacancy)
         {
-            if (Utility.VacancyHasCompletedPartOne(vacancy))
-            {
-                return RedirectToRoute(RouteNames.Vacancy_Preview_Get);
-            }
-
             var resumeRouteName = Utility.GetValidRoutesForVacancy(vacancy).Last();
 
             return RedirectToRoute(resumeRouteName);

--- a/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -39,7 +39,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             {
                 Organisations = BuildLegalEntityViewModels(employerData, vrm.EmployerAccountId),
                 SelectedOrganisationName = vacancy.EmployerName,
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.EmployerSection)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.EmployerSection),
+                InWizardMode = vacancy.HasCompletedPart1 == false
             };
 
             if (vacancy.EmployerLocation != null)
@@ -90,7 +91,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.EmployerSection);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.EmployerSection, RouteNames.Employer_Post);
                 });
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/SearchResultPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/SearchResultPreviewOrchestrator.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.SearchResultPreview;
 using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Shared.Web.Services;
@@ -53,6 +54,17 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             }
             
             return vm;
+        }
+
+        public async Task<VacancyRouteParameters> PostSearchResultPreviewViewModelAsync(VacancyRouteModel vrm, VacancyUser user)
+        {
+            var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.SearchResultPreview_Post);
+
+            vacancy.HasCompletedPart1 = true;
+
+            await _client.UpdateVacancyAsync(vacancy, user);
+
+            return Utility.GetRedirectRouteParametersForVacancy(vacancy, null, RouteNames.SearchResultPreview_Post);
         }
 
         private async Task<string> GetLevelName(string programmeId)

--- a/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -29,7 +29,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             {
                 VacancyId = vacancy.Id,
                 ShortDescription = vacancy.ShortDescription,
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection),
+                InWizardMode = vacancy.HasCompletedPart1 == false
             };
 
             return vm;
@@ -56,7 +57,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection, RouteNames.ShortDescription_Post);
                 });
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -29,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             {
                 VacancyId = vacancy.Id,
                 ShortDescription = vacancy.ShortDescription,
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescription)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection)
             };
 
             return vm;
@@ -56,7 +56,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescription);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ShortDescriptionSection);
                 });
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -25,7 +25,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
         {
             var vm = new TitleViewModel
             {
-                CancelButtonRouteParameters = new VacancyRouteParameters(RouteNames.Dashboard_Index_Get)
+                CancelButtonRouteParameters = new VacancyRouteParameters(RouteNames.Dashboard_Index_Get),
+                InWizardMode = true
             };
             return vm;
         }
@@ -39,7 +40,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 VacancyId = vacancy.Id,
                 Title = vacancy.Title,
                 NumberOfPositions = vacancy.NumberOfPositions?.ToString(),
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection),
+                InWizardMode = vacancy.HasCompletedPart1 == false
             };
 
             return vm;
@@ -75,7 +77,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 var newVacancy = new Vacancy
                 {
                     Title = m.Title,
-                    NumberOfPositions = numberOfPositions
+                    NumberOfPositions = numberOfPositions,
+                    HasCompletedPart1 = false
                 };
 
                 return await ValidateAndExecute(
@@ -102,7 +105,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection); 
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection, RouteNames.Title_Post); 
                 }
             );
         }

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -1,14 +1,15 @@
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.Title;
-using Esfa.Recruit.Vacancies.Client.Application.Validation;
-using Microsoft.Extensions.Logging;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Employer.Web.ViewModels;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.Title;
+using Esfa.Recruit.Employer.Web.Views;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Microsoft.Extensions.Logging;
 
-namespace Esfa.Recruit.Employer.Web.Orchestrators
+namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
 {
     public class TitleOrchestrator : EntityValidatingOrchestrator<Vacancy, TitleEditModel>
     {
@@ -22,19 +23,23 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
         public TitleViewModel GetTitleViewModel()
         {
-            var vm = new TitleViewModel();
+            var vm = new TitleViewModel
+            {
+                CancelButtonRouteParameters = new VacancyRouteParameters(RouteNames.Dashboard_Index_Get)
+            };
             return vm;
         }
 
         public async Task<TitleViewModel> GetTitleViewModelAsync(VacancyRouteModel vrm)
         {
             var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.Title_Get);
-
+            
             var vm = new TitleViewModel
             {
                 VacancyId = vacancy.Id,
                 Title = vacancy.Title,
                 NumberOfPositions = vacancy.NumberOfPositions?.ToString(),
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection)
             };
 
             return vm;
@@ -61,7 +66,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
         }
 
 
-        public async Task<OrchestratorResponse<Guid>> PostTitleEditModelAsync(TitleEditModel m, VacancyUser user)
+        public async Task<OrchestratorResponse<VacancyRouteParameters>> PostTitleEditModelAsync(TitleEditModel m, VacancyUser user)
         {
             var numberOfPositions = int.TryParse(m.NumberOfPositions, out var n)? n : default(int?);
 
@@ -76,7 +81,13 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                 return await ValidateAndExecute(
                     newVacancy, 
                     v => _client.Validate(v, ValidationRules),
-                    async v => await _client.CreateVacancyAsync(SourceOrigin.EmployerWeb, m.Title, numberOfPositions.Value, m.EmployerAccountId, user));
+                    async v =>
+                    {
+                        var id = await _client.CreateVacancyAsync(SourceOrigin.EmployerWeb, m.Title,
+                            numberOfPositions.Value, m.EmployerAccountId, user);
+
+                        return new VacancyRouteParameters(RouteNames.ShortDescription_Get, id);
+                    });
             }
 
             var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, 
@@ -91,18 +102,19 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return v.Id;
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.TitleSection); 
                 }
             );
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, TitleEditModel> DefineMappings()
         {
-            var mappings = new EntityToViewModelPropertyMappings<Vacancy, TitleEditModel>();
-
-            mappings.Add(e => e.Title, vm => vm.Title);
-            mappings.Add(e => e.NumberOfPositions, vm => vm.NumberOfPositions);
-
+            var mappings = new EntityToViewModelPropertyMappings<Vacancy, TitleEditModel>
+            {
+                {e => e.Title, vm => vm.Title},
+                {e => e.NumberOfPositions, vm => vm.NumberOfPositions}
+            };
+            
             return mappings;
         }
     }

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -38,7 +38,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 SelectedProgrammeId = vacancy.ProgrammeId,
                 Programmes = programmes.ToViewModel(),
                 IsDisabilityConfident = vacancy.DisabilityConfident == DisabilityConfident.Yes,
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection),
+                InWizardMode = vacancy.HasCompletedPart1 == false
             };
 
             if (vacancy.ClosingDate.HasValue)
@@ -92,7 +93,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection, RouteNames.Training_Post);
                 });
         }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -7,6 +7,8 @@ using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Microsoft.Extensions.Logging;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Employer.Web.ViewModels;
+using Esfa.Recruit.Employer.Web.Views;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
 {
@@ -35,7 +37,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 VacancyId = vacancy.Id,
                 SelectedProgrammeId = vacancy.ProgrammeId,
                 Programmes = programmes.ToViewModel(),
-                IsDisabilityConfident = vacancy.DisabilityConfident == DisabilityConfident.Yes
+                IsDisabilityConfident = vacancy.DisabilityConfident == DisabilityConfident.Yes,
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection)
             };
 
             if (vacancy.ClosingDate.HasValue)
@@ -74,7 +77,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return vm;
         }
 
-        public async Task<OrchestratorResponse> PostTrainingEditModelAsync(TrainingEditModel m, VacancyUser user)
+        public async Task<OrchestratorResponse<VacancyRouteParameters>> PostTrainingEditModelAsync(TrainingEditModel m, VacancyUser user)
         {
             var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, m, RouteNames.Training_Post);
             
@@ -86,17 +89,21 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             return await ValidateAndExecute(
                 vacancy, 
                 v => _client.Validate(v, ValdationRules),
-                v => _client.UpdateVacancyAsync(vacancy, user)
-            );
+                async v =>
+                {
+                    await _client.UpdateVacancyAsync(vacancy, user);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection);
+                });
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, TrainingEditModel> DefineMappings()
         {
-            var mappings = new EntityToViewModelPropertyMappings<Vacancy, TrainingEditModel>();
-
-            mappings.Add(e => e.ProgrammeId, vm => vm.SelectedProgrammeId);
-            mappings.Add(e => e.StartDate, vm => vm.StartDate);
-            mappings.Add(e => e.ClosingDate, vm => vm.ClosingDate);
+            var mappings = new EntityToViewModelPropertyMappings<Vacancy, TrainingEditModel>
+            {
+                { e => e.ProgrammeId, vm => vm.SelectedProgrammeId},
+                { e => e.StartDate, vm => vm.StartDate},
+                { e => e.ClosingDate, vm => vm.ClosingDate}
+            };
 
             return mappings;
         }

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -36,7 +36,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 WageType = vacancy.Wage?.WageType ?? WageType.FixedWage,
                 FixedWageYearlyAmount = vacancy.Wage?.FixedWageYearlyAmount?.AsMoney(),
                 WageAdditionalInformation = vacancy.Wage?.WageAdditionalInformation,
-                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection)
+                CancelButtonRouteParameters = Utility.GetCancelButtonRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection),
+                InWizardMode = vacancy.HasCompletedPart1 == false
             };
             
             return vm;
@@ -78,7 +79,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 async v =>
                 {
                     await _client.UpdateVacancyAsync(vacancy, user);
-                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection);
+                    return Utility.GetRedirectRouteParametersForVacancy(vacancy, PreviewAnchors.ApprenticeshipSummarySection, RouteNames.Wage_Post);
                 });
         }
 

--- a/src/Employer/Employer.Web/Utility.cs
+++ b/src/Employer/Employer.Web/Utility.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Exceptions;
+using Esfa.Recruit.Employer.Web.Orchestrators;
+using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
@@ -93,6 +95,22 @@ namespace Esfa.Recruit.Employer.Web
         public static bool VacancyHasCompletedPartOne(Vacancy vacancy)
         {
             return GetValidRoutesForVacancy(vacancy) == null;
+        }
+
+        public static VacancyRouteParameters GetRedirectRouteParametersForVacancy(Vacancy vacancy, string vacancyPreviewFragment)
+        {
+            var routeName = GetValidRoutesForVacancy(vacancy)?.Last() ?? RouteNames.Vacancy_Preview_Get;
+
+            return new VacancyRouteParameters(routeName, vacancy.Id, routeName == RouteNames.Vacancy_Preview_Get ? vacancyPreviewFragment : null);
+        }
+
+        public static VacancyRouteParameters GetCancelButtonRouteParametersForVacancy(Vacancy vacancy, string vacancyPreviewFragment)
+        {
+            var routeName = VacancyHasCompletedPartOne(vacancy)
+                ? RouteNames.Vacancy_Preview_Get
+                : RouteNames.Dashboard_Index_Get;
+
+            return new VacancyRouteParameters(routeName, vacancy.Id, routeName == RouteNames.Vacancy_Preview_Get ? vacancyPreviewFragment : null);
         }
 
         public static async Task<ApplicationReview> GetAuthorisedApplicationReviewAsync(IEmployerVacancyClient client, ApplicationReviewRouteModel rm)

--- a/src/Employer/Employer.Web/Utility.cs
+++ b/src/Employer/Employer.Web/Utility.cs
@@ -12,6 +12,7 @@ using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Esfa.Recruit.Employer.Web
 {
@@ -54,7 +55,7 @@ namespace Esfa.Recruit.Employer.Web
         {
             var validRoutes = GetValidRoutesForVacancy(vacancy);
 
-            if (validRoutes == null || validRoutes.Contains(currentRouteName))
+            if (validRoutes.Contains(currentRouteName) || validRoutes.Last() == RouteNames.Vacancy_Preview_Get)
             {
                 return;
             }
@@ -89,24 +90,55 @@ namespace Esfa.Recruit.Employer.Web
             if (vacancy.Wage?.WageType == null)
                 return validRoutes;
             
-            return null;
+            validRoutes.AddRange(new []{RouteNames.SearchResultPreview_Post, RouteNames.SearchResultPreview_Get});
+            if (vacancy.HasCompletedPart1 == false)
+                return validRoutes;
+
+            validRoutes.Add(RouteNames.Vacancy_Preview_Get);
+            return validRoutes;
         }
 
-        public static bool VacancyHasCompletedPartOne(Vacancy vacancy)
+        public static string GetNextPart1WizardRoute(string currentRouteName)
         {
-            return GetValidRoutesForVacancy(vacancy) == null;
+            switch (currentRouteName)
+            {
+                case RouteNames.Title_Post:
+                    return RouteNames.ShortDescription_Get;
+                case RouteNames.ShortDescription_Post:
+                    return RouteNames.Employer_Get;
+                case RouteNames.Employer_Post:
+                    return RouteNames.Training_Get;
+                case RouteNames.Training_Post:
+                    return RouteNames.Wage_Get;
+                case RouteNames.Wage_Post:
+                    return RouteNames.SearchResultPreview_Get;
+                default:
+                    throw new NotImplementedException($"No next route configured for '{currentRouteName}'");
+            }
         }
 
-        public static VacancyRouteParameters GetRedirectRouteParametersForVacancy(Vacancy vacancy, string vacancyPreviewFragment)
+        public static VacancyRouteParameters GetRedirectRouteParametersForVacancy(Vacancy vacancy, string vacancyPreviewFragment, string currentRouteName)
         {
-            var routeName = GetValidRoutesForVacancy(vacancy)?.Last() ?? RouteNames.Vacancy_Preview_Get;
+            string routeName;
+            if (vacancy.HasCompletedPart1 == false)
+            {
+                //We are in wizard mode (Steps 1-6) so get the next step
+                routeName = GetNextPart1WizardRoute(currentRouteName);
+            }
+            else
+            {
+                //otherwise redirect to the last valid route
+                var validRoutes = GetValidRoutesForVacancy(vacancy);
+                routeName = validRoutes.Last();
+            }
 
-            return new VacancyRouteParameters(routeName, vacancy.Id, routeName == RouteNames.Vacancy_Preview_Get ? vacancyPreviewFragment : null);
+            var fragment = routeName == RouteNames.Vacancy_Preview_Get ? vacancyPreviewFragment : null;
+            return new VacancyRouteParameters(routeName, vacancy.Id, fragment);
         }
 
         public static VacancyRouteParameters GetCancelButtonRouteParametersForVacancy(Vacancy vacancy, string vacancyPreviewFragment)
         {
-            var routeName = VacancyHasCompletedPartOne(vacancy)
+            var routeName = vacancy.HasCompletedPart1
                 ? RouteNames.Vacancy_Preview_Get
                 : RouteNames.Dashboard_Index_Get;
 

--- a/src/Employer/Employer.Web/ViewModels/Part1/Employer/EmployerViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Employer/EmployerViewModel.cs
@@ -1,21 +1,25 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Employer
 {
     public class EmployerViewModel : EmployerEditModel
     {
         public IEnumerable<LocationOrganisationViewModel> Organisations { get; set; }
-
         public bool HasOnlyOneOrganisation => Organisations.Count() == 1;
-        
+
+        public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
+        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
+        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+
         public IList<string> OrderedFieldNames => new List<string>
         {
-            nameof(EmployerEditModel.AddressLine1),
-            nameof(EmployerEditModel.AddressLine2),
-            nameof(EmployerEditModel.AddressLine3),
-            nameof(EmployerEditModel.AddressLine4),
-            nameof(EmployerEditModel.Postcode)
+            nameof(AddressLine1),
+            nameof(AddressLine2),
+            nameof(AddressLine3),
+            nameof(AddressLine4),
+            nameof(Postcode)
         };
     }
 

--- a/src/Employer/Employer.Web/ViewModels/Part1/Employer/EmployerViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Employer/EmployerViewModel.cs
@@ -10,8 +10,8 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Employer
         public bool HasOnlyOneOrganisation => Organisations.Count() == 1;
 
         public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
-        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
-        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+        public bool InWizardMode { get; set; }
+        public string SubmitButtonText => InWizardMode ? "Save and Continue" : "Save and Preview";
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Employer/Employer.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
@@ -6,8 +6,8 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.ShortDescription
     public class ShortDescriptionViewModel : ShortDescriptionEditModel
     {
         public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
-        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
-        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+        public bool InWizardMode { get; set; }
+        public string SubmitButtonText => InWizardMode ? "Save and Continue" : "Save and Preview";
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Employer/Employer.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
@@ -1,9 +1,14 @@
 ﻿using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.ShortDescription
 {
     public class ShortDescriptionViewModel : ShortDescriptionEditModel
     {
+        public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
+        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
+        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+
         public IList<string> OrderedFieldNames => new List<string>
         {
             nameof(ShortDescription)

--- a/src/Employer/Employer.Web/ViewModels/Part1/Title/TitleViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Title/TitleViewModel.cs
@@ -7,9 +7,9 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Title
     public class TitleViewModel : TitleEditModel
     {
         public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
-        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
-        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
-        
+        public bool InWizardMode { get; set; }
+        public string SubmitButtonText => InWizardMode ? "Save and Continue" : "Save and Preview";
+
         public IList<string> OrderedFieldNames => new List<string>
         {
             nameof(NumberOfPositions),

--- a/src/Employer/Employer.Web/ViewModels/Part1/Title/TitleViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Title/TitleViewModel.cs
@@ -1,13 +1,19 @@
 ﻿using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Orchestrators;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Title
 {
     public class TitleViewModel : TitleEditModel
     {
+        public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
+        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
+        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+        
         public IList<string> OrderedFieldNames => new List<string>
         {
-            nameof(TitleEditModel.NumberOfPositions),
-            nameof(TitleEditModel.Title)
+            nameof(NumberOfPositions),
+            nameof(Title)
         };
     }
 }

--- a/src/Employer/Employer.Web/ViewModels/Part1/Training/TrainingViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Training/TrainingViewModel.cs
@@ -9,8 +9,8 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Training
         public IEnumerable<ApprenticeshipProgrammeViewModel> Programmes { get; set; }
 
         public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
-        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
-        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+        public bool InWizardMode { get; set; }
+        public string SubmitButtonText => InWizardMode ? "Save and Continue" : "Save and Preview";
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Employer/Employer.Web/ViewModels/Part1/Training/TrainingViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Training/TrainingViewModel.cs
@@ -1,16 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Training
 {
     public class TrainingViewModel : TrainingEditModel
     {
         public IEnumerable<ApprenticeshipProgrammeViewModel> Programmes { get; set; }
+
+        public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
+        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
+        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+
         public IList<string> OrderedFieldNames => new List<string>
         {
-            nameof(TrainingEditModel.ClosingDate),
-            nameof(TrainingEditModel.StartDate),
-            nameof(TrainingEditModel.SelectedProgrammeId)
+            nameof(ClosingDate),
+            nameof(StartDate),
+            nameof(SelectedProgrammeId)
         };
     }
 

--- a/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
@@ -1,17 +1,22 @@
 ﻿using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage
 {
     public class WageViewModel : WageEditModel
     {
+        public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
+        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
+        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+
         public IList<string> OrderedFieldNames => new List<string>
         {
-            nameof(WageEditModel.Duration),
-            nameof(WageEditModel.WorkingWeekDescription),
-            nameof(WageEditModel.WeeklyHours),
-            nameof(WageEditModel.WageType),
-            nameof(WageEditModel.FixedWageYearlyAmount),
-            nameof(WageEditModel.WageAdditionalInformation)
+            nameof(Duration),
+            nameof(WorkingWeekDescription),
+            nameof(WeeklyHours),
+            nameof(WageType),
+            nameof(FixedWageYearlyAmount),
+            nameof(WageAdditionalInformation)
         };
     }
 }

--- a/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
@@ -6,8 +6,8 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage
     public class WageViewModel : WageEditModel
     {
         public VacancyRouteParameters CancelButtonRouteParameters { get; set; }
-        public bool ShowStep => CancelButtonRouteParameters.RouteName != RouteNames.Vacancy_Preview_Get;
-        public string SubmitButtonText => CancelButtonRouteParameters.RouteName == RouteNames.Vacancy_Preview_Get ? "Save and Preview" : "Save and Continue";
+        public bool InWizardMode { get; set; }
+        public string SubmitButtonText => InWizardMode ? "Save and Continue" : "Save and Preview";
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Employer/Employer.Web/ViewModels/Part2/AboutEmployer/AboutEmployerViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part2/AboutEmployer/AboutEmployerViewModel.cs
@@ -9,7 +9,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels
         public string EmployerDescription { get; internal set; }
         public string EmployerWebsiteUrl { get; internal set; }
 
-        public static string PreviewSectionAnchor => PreviewAnchors.AboutEmployerSection;
+        public static string PreviewSectionAnchor => PreviewAnchors.EmployerSection;
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Employer/Employer.Web/ViewModels/Part2/EmployerContactDetails/EmployerContactDetailsViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part2/EmployerContactDetails/EmployerContactDetailsViewModel.cs
@@ -9,7 +9,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels
         public string EmployerContactName { get; internal set; }
         public string EmployerContactEmail { get; internal set; }
         public string EmployerContactPhone { get; internal set; }
-        public static string PreviewSectionAnchor => PreviewAnchors.AboutEmployerSection;
+        public static string PreviewSectionAnchor => PreviewAnchors.EmployerSection;
         public IList<string> OrderedFieldNames => new List<string>
         {
             nameof(EmployerContactDetailsEditModel.EmployerContactName),

--- a/src/Employer/Employer.Web/ViewModels/VacancyRouteParameters.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyRouteParameters.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Esfa.Recruit.Employer.Web.ViewModels
+{
+    public class VacancyRouteParameters
+    {
+        public VacancyRouteParameters(string routeName, Guid? vacancyId = null, string fragment = null)
+        {
+            RouteName = routeName;
+            Fragment = fragment;
+
+            if (vacancyId.HasValue)
+            {
+                RouteValues = new VacancyRouteParametersRouteValues(vacancyId.Value);
+            }
+        }
+
+        public string RouteName { get; }
+        public VacancyRouteParametersRouteValues RouteValues { get; }
+        public string Fragment { get; }
+    }
+
+    public class VacancyRouteParametersRouteValues
+    {
+        public VacancyRouteParametersRouteValues(Guid vacancyId)
+        {
+            VacancyId = vacancyId;
+        }
+
+        public Guid VacancyId { get; }
+    }
+
+
+}

--- a/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
@@ -9,7 +9,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 3 of 6</h3>
+            <h3 asp-condition="@Model.InWizardMode" class="heading-medium no-top-margin">Step 3 of 6</h3>
             <div asp-condition="@Model.HasOnlyOneOrganisation"><p>@Model.Organisations.First().Name</p></div>
             <form asp-route="@RouteNames.Employer_Post">
                 <div esfa-validation-marker-for="SelectedOrganisationName" class="form-group">

--- a/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
@@ -9,7 +9,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 class="heading-medium no-top-margin">Step 3 of 6</h3>
+            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 3 of 6</h3>
             <div asp-condition="@Model.HasOnlyOneOrganisation"><p>@Model.Organisations.First().Name</p></div>
             <form asp-route="@RouteNames.Employer_Post">
                 <div esfa-validation-marker-for="SelectedOrganisationName" class="form-group">
@@ -62,8 +62,8 @@
                     </div>
                 </div>
 
-                <button type="submit" class="button save-button">Save and continue</button>
-                <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" class="button-link">Cancel</a>
+                <button type="submit" class="button save-button">@Model.SubmitButtonText</button>
+                <a asp-route="@Model.CancelButtonRouteParameters.RouteName" asp-fragment="@Model.CancelButtonRouteParameters.Fragment" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Employer/Employer.Web/Views/Part1/SearchResultPreview/SearchResultPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/SearchResultPreview/SearchResultPreview.cshtml
@@ -54,11 +54,13 @@
             </div> 
         </div>
         <div class="form-group inline">
-                <div class="form-group small-top-margin">
-                    <a asp-route="@RouteNames.Vacancy_Preview_Get" esfa-automation="link-continue" class="button">Add full vacancy details</a>
+            <div class="form-group small-top-margin">
+                <form asp-route="@RouteNames.SearchResultPreview_Post">
+                    <button type="submit" class="button save-button" esfa-automation="link-continue">Add full vacancy details</button>
                     <a asp-route="@RouteNames.Title_Get" esfa-automation="link-change" class="button-link">Make changes</a>
                     <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" esfa-automation="link-dashboard" class="button-link">Return to dashboard</a>
-                </div>
+                </form>
             </div>
+        </div>
     </div>
 </div>

--- a/src/Employer/Employer.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
@@ -12,7 +12,7 @@
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
 
         <div class="todo">
-            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 2 of 6</h3>
+            <h3 asp-condition="@Model.InWizardMode" class="heading-medium no-top-margin">Step 2 of 6</h3>
             <form asp-route="@RouteNames.ShortDescription_Post" novalidate>
                 <div esfa-validation-marker-for="ShortDescription" class="form-group">
                     <label asp-for="ShortDescription" class="form-label-bold">

--- a/src/Employer/Employer.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
@@ -12,7 +12,7 @@
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
 
         <div class="todo">
-            <h3 class="heading-medium no-top-margin">Step 2 of 6</h3>
+            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 2 of 6</h3>
             <form asp-route="@RouteNames.ShortDescription_Post" novalidate>
                 <div esfa-validation-marker-for="ShortDescription" class="form-group">
                     <label asp-for="ShortDescription" class="form-label-bold">
@@ -24,8 +24,8 @@
                     <span class="maxchar-count">350</span>
                     <span class="maxchar-text"> characters remaining</span>
                 </div>
-                <button type="submit" class="button save-button">Save and continue</button>
-                <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" class="button-link">Cancel</a>
+                <button type="submit" class="button save-button">@Model.SubmitButtonText</button>
+                <a asp-route="@Model.CancelButtonRouteParameters.RouteName" asp-fragment="@Model.CancelButtonRouteParameters.Fragment" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Employer/Employer.Web/Views/Part1/Title/Title.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Title/Title.cshtml
@@ -10,7 +10,8 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState })
         <div class="todo">
-            <h3 class="heading-medium no-top-margin">Step 1 of 6</h3>
+            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 1 of 6</h3>
+            
             <form asp-route="@(Model.VacancyId.HasValue ? RouteNames.Title_Post : RouteNames.CreateVacancy_Post)" novalidate>
                 <div esfa-validation-marker-for="Title" class="form-group">
                     <label asp-for="Title" class="form-label-bold">
@@ -28,8 +29,9 @@
                     <span esfa-validation-message-for="NumberOfPositions" class="error-message"></span>
                     <input asp-for="NumberOfPositions" class="form-control form-control-1-8" type="number" min="1" />
                 </div>
-                <button type="submit" class="button save-button">Save and Continue</button>
-                <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" class="button-link">Cancel</a>
+                
+                <button type="submit" class="button save-button">@Model.SubmitButtonText</button>
+                <a asp-route="@Model.CancelButtonRouteParameters.RouteName" asp-fragment="@Model.CancelButtonRouteParameters.Fragment" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Employer/Employer.Web/Views/Part1/Title/Title.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Title/Title.cshtml
@@ -10,7 +10,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState })
         <div class="todo">
-            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 1 of 6</h3>
+            <h3 asp-condition="@Model.InWizardMode" class="heading-medium no-top-margin">Step 1 of 6</h3>
             
             <form asp-route="@(Model.VacancyId.HasValue ? RouteNames.Title_Post : RouteNames.CreateVacancy_Post)" novalidate>
                 <div esfa-validation-marker-for="Title" class="form-group">

--- a/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
@@ -12,7 +12,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 class="heading-medium no-top-margin">Step 4 of 6</h3>
+            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 4 of 6</h3>
             <form asp-route="@RouteNames.Training_Post" novalidate>
 
                 <div esfa-validation-marker-for="ClosingDate" class="form-group">
@@ -85,8 +85,8 @@
                     </fieldset>
                 </div>
 
-                <button type="submit" class="button save-button">Save and continue</button>
-                <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" class="button-link">Cancel</a>
+                <button type="submit" class="button save-button">@Model.SubmitButtonText</button>
+                <a asp-route="@Model.CancelButtonRouteParameters.RouteName" asp-fragment="@Model.CancelButtonRouteParameters.Fragment" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
@@ -12,7 +12,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 4 of 6</h3>
+            <h3 asp-condition="@Model.InWizardMode" class="heading-medium no-top-margin">Step 4 of 6</h3>
             <form asp-route="@RouteNames.Training_Post" novalidate>
 
                 <div esfa-validation-marker-for="ClosingDate" class="form-group">

--- a/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
@@ -10,7 +10,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 5 of 6</h3>
+            <h3 asp-condition="@Model.InWizardMode" class="heading-medium no-top-margin">Step 5 of 6</h3>
             <form asp-route="@RouteNames.Wage_Post" novalidate>
                 <div esfa-validation-marker-for="Duration" class="form-group">
                     <fieldset>

--- a/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
@@ -10,7 +10,7 @@
 
         @Html.Partial("_ValidationSummary", new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames })
         <div class="todo">
-            <h3 class="heading-medium no-top-margin">Step 5 of 6</h3>
+            <h3 asp-condition="@Model.ShowStep" class="heading-medium no-top-margin">Step 5 of 6</h3>
             <form asp-route="@RouteNames.Wage_Post" novalidate>
                 <div esfa-validation-marker-for="Duration" class="form-group">
                     <fieldset>
@@ -84,8 +84,8 @@
                     <span class="maxchar-text"> characters remaining</span>
                 </div>
 
-                <button type="submit" class="button save-button">Save and Continue</button>
-                <a asp-route="@RouteNames.Dashboard_Index_Get" asp-route-statusFilter="@Context.Request.Cookies[CookieNames.VacancyStatusFilter]" class="button-link">Cancel</a>
+                <button type="submit" class="button save-button">@Model.SubmitButtonText</button>
+                <a asp-route="@Model.CancelButtonRouteParameters.RouteName" asp-fragment="@Model.CancelButtonRouteParameters.Fragment" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Employer/Employer.Web/Views/PreviewAnchors.cs
+++ b/src/Employer/Employer.Web/Views/PreviewAnchors.cs
@@ -4,6 +4,7 @@
     {
         //Part 1
         public const string TitleSection = "title";
+        public const string ShortDescription = "shortDescription";
         
         //Part 2
         public const string ApprenticeshipSummarySection = "apprenticeshipSummary";

--- a/src/Employer/Employer.Web/Views/PreviewAnchors.cs
+++ b/src/Employer/Employer.Web/Views/PreviewAnchors.cs
@@ -2,6 +2,10 @@
 {
     public static class PreviewAnchors
     {
+        //Part 1
+        public const string TitleSection = "title";
+        
+        //Part 2
         public const string ApprenticeshipSummarySection = "apprenticeshipSummary";
         public const string RequirementsAndProspectsSection = "reqAndProspects";
         public const string AboutEmployerSection = "aboutEmployer";

--- a/src/Employer/Employer.Web/Views/PreviewAnchors.cs
+++ b/src/Employer/Employer.Web/Views/PreviewAnchors.cs
@@ -2,15 +2,12 @@
 {
     public static class PreviewAnchors
     {
-        //Part 1
-        public const string TitleSection = "title";
-        public const string ShortDescription = "shortDescription";
-        
-        //Part 2
-        public const string ApprenticeshipSummarySection = "apprenticeshipSummary";
-        public const string RequirementsAndProspectsSection = "reqAndProspects";
-        public const string AboutEmployerSection = "aboutEmployer";
         public const string ApplicationProcessSection = "applicationProcess";
+        public const string ApprenticeshipSummarySection = "apprenticeshipSummary";
+        public const string EmployerSection = "employer";
+        public const string RequirementsAndProspectsSection = "reqAndProspects";
+        public const string ShortDescriptionSection = "shortDescription";
+        public const string TitleSection = "title";
         public const string TrainingProviderSection = "trainingProvider";
     }
 }

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -50,7 +50,7 @@
     </div>
 </div>
 
-<div class="grid-row">
+<div class="grid-row" id="@PreviewAnchors.ShortDescription">
     <div class="column-two-thirds">
         <div class="@GetSectionClass(Model.ShortDescriptionSectionState)">
             <h3 class="heading-small no-top-margin">Brief overview of the role</h3>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -40,7 +40,7 @@
     </div>
 </div>
 
-<div class="grid-row">
+<div class="grid-row" id="@PreviewAnchors.TitleSection">
     <div class="column-two-thirds">
         <h2 class="heading-xlarge small-bottom-margin">
             @Model.Title

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -50,7 +50,7 @@
     </div>
 </div>
 
-<div class="grid-row" id="@PreviewAnchors.ShortDescription">
+<div class="grid-row" id="@PreviewAnchors.ShortDescriptionSection">
     <div class="column-two-thirds">
         <div class="@GetSectionClass(Model.ShortDescriptionSectionState)">
             <h3 class="heading-small no-top-margin">Brief overview of the role</h3>
@@ -193,7 +193,7 @@
     </div>
 </div>
 
-<div class="grid-row" id="@PreviewAnchors.AboutEmployerSection">
+<div class="grid-row" id="@PreviewAnchors.EmployerSection">
     <div class="column-full">
         <hr class="no-bottom-margin">
     </div>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -291,7 +291,7 @@
         <div class="@GetSectionClass(Model.TrainingSectionState)">
             <h3 class="heading-small">Apprenticeship @Model.TrainingType</h3>
             <p asp-condition="@Model.HasTrainingTitle">@Model.TrainingTitle</p>
-            @EditLink(RouteNames.Title_Get, Model.TrainingSectionState, "link-standard")
+            @EditLink(RouteNames.Training_Get, Model.TrainingSectionState, "link-standard")
         </div>
     </div>
 </div>

--- a/src/Employer/UnitTests/Employer.Web/HardMocks/VacancyOrchestratorTestData.cs
+++ b/src/Employer/UnitTests/Employer.Web/HardMocks/VacancyOrchestratorTestData.cs
@@ -15,7 +15,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.HardMocks
                 EmployerLocation = new Address { Postcode = "has a value" },
                 ShortDescription = "has a value",
                 ProgrammeId = "has a value",
-                Wage = new Wage { WageType = WageType.FixedWage }
+                Wage = new Wage { WageType = WageType.FixedWage },
+                HasCompletedPart1 = true
             };
         }
 

--- a/src/Employer/UnitTests/Employer.Web/Utility/GetRedirectRouteParametersForVacancyTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Utility/GetRedirectRouteParametersForVacancyTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Utility
+{
+    public class GetRedirectRouteParametersForVacancyTests
+    {
+        [Theory]
+        [InlineData(RouteNames.Title_Post, RouteNames.ShortDescription_Get)]
+        [InlineData(RouteNames.ShortDescription_Post, RouteNames.Employer_Get)]
+        [InlineData(RouteNames.Employer_Post, RouteNames.Training_Get)]
+        [InlineData(RouteNames.Training_Post, RouteNames.Wage_Get)]
+        [InlineData(RouteNames.Wage_Post, RouteNames.SearchResultPreview_Get)]
+        public void GetRedirectRouteParametersForVacancy_ShouldGetNextPageWhenInWizardMode(string currentRouteName, string expectedRedirectRouteName)
+        {
+            //If the vacancy has not completed part 1 then we still need to go through the steps 1-6 (aka wizard mode)
+            var vacancy = new Vacancy
+            {
+                EmployerAccountId = "EMPLOYER ACCOUNT ID",
+                Id = Guid.Parse("84af954e-5baf-4942-897d-d00180a0839e"),
+                Title = "has a value",
+                EmployerLocation = new Address { Postcode = "has a value" },
+                ShortDescription = "has a value",
+                ProgrammeId = "has a value",
+                Wage = new Wage { WageType = WageType.FixedWage },
+                HasCompletedPart1 = false
+            };
+            
+            var redirectRouteParameters = Esfa.Recruit.Employer.Web.Utility.GetRedirectRouteParametersForVacancy(
+                vacancy, "the preview anchor which should be ignored if not redirecting to the preview page", currentRouteName);
+
+            redirectRouteParameters.RouteName.Should().Be(expectedRedirectRouteName);
+            redirectRouteParameters.RouteValues.VacancyId.Should().Be(vacancy.Id);
+            redirectRouteParameters.Fragment.Should().Be(null);
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -31,7 +31,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public bool IsDeleted { get; internal set; }
         public DateTime? DeletedDate { get; internal set; }
         public VacancyUser DeletedByUser { get; internal set; }
-        
+
         public string ApplicationInstructions { get; set; }
         public ApplicationMethod? ApplicationMethod { get; set; }
         public string ApplicationUrl { get; set; }
@@ -45,6 +45,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public Address EmployerLocation { get; set; }
         public string EmployerName { get; set; }
         public string EmployerWebsiteUrl { get; set; }
+        public bool HasCompletedPart1 { get; set; }
         public int? NumberOfPositions { get; set; }
         public string OutcomeDescription { get; set; }
         public string ProgrammeId { get; set; }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
@@ -16,11 +16,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
                 new IgnoreIfNullConvention(true)
             };
             ConventionRegistry.Register("recruit conventions", pack, t => true);
-
-            BsonClassMap.RegisterClassMap<Vacancy>(cm => {
-                cm.AutoMap();
-                cm.GetMemberMap(c => c.HasCompletedPart1).SetDefaultValue(true);
-            });
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbConventions.cs
@@ -1,4 +1,6 @@
-﻿using MongoDB.Bson.Serialization.Conventions;
+﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
 {
@@ -12,8 +14,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
                 new EnumRepresentationConvention(MongoDB.Bson.BsonType.String),
                 new IgnoreExtraElementsConvention(true),
                 new IgnoreIfNullConvention(true)
-        };
+            };
             ConventionRegistry.Register("recruit conventions", pack, t => true);
+
+            BsonClassMap.RegisterClassMap<Vacancy>(cm => {
+                cm.AutoMap();
+                cm.GetMemberMap(c => c.HasCompletedPart1).SetDefaultValue(true);
+            });
         }
     }
 }


### PR DESCRIPTION
I needed to add another bool property to the `Vacancy` entity called `HasCompletedPart1`.  I need this so I can tell if users have seen the Search Preview or not (Step 6 of 6).

So existing vacancies need to have `HasCompletedPart1` set to true if they have completed part one.  I've created an update script for this.

There is now 2 types of routing for Part 1. The step-by-step progression and the there-and-back from the vacancy preview.  To differentiate between the two I've introduce the term `wizard` to describe the step-by-step behaviour.
