### PR TITLE
ER-565 - Vacancies must contain the word 'apprentice' or 'apprenticeships' in the title.

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Esfa.Recruit.Vacancies.Client.Application.Configuration;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Application.Services.MinimumWage;
@@ -88,6 +89,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
         private void ValidateTitle()
         {
             RuleFor(x => x.Title)
+                .Cascade(CascadeMode.StopOnFirstFailure)
                 .NotEmpty()
                     .WithMessage("Enter the title of the vacancy")
                     .WithErrorCode("1")
@@ -97,6 +99,9 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                 .ValidFreeTextCharacters()
                     .WithMessage("The title contains some invalid characters")
                     .WithErrorCode("3")
+                .Matches(ValidationConstants.ContainsApprenticeOrApprenticeshipRegex)
+                    .WithMessage("The title must contain the word 'apprentice' or 'apprenticeship'")
+                    .WithErrorCode("200")
                 .RunCondition(VacancyRuleSet.Title)
                 .WithRuleId(VacancyRuleSet.Title);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/ValidationConstants.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/ValidationConstants.cs
@@ -13,5 +13,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation
         public static Regex UkprnRegex => new Regex(@"^((?!(0))[0-9]{8})$");
         public static Regex EmailAddressRegex => new Regex(@"^[a-zA-Z0-9\u0080-\uFFA7?$#()""'!,+\-=_:;.&€£*%\s\/]+@[a-zA-Z0-9\u0080-\uFFA7?$#()""'!,+\-=_:;.&€£*%\s\/]+\.([a-zA-Z0-9\u0080-\uFFA7]{2,10})$");
         public static Regex PhoneNumberRegex => new Regex(@"^[0-9+\s-()]{8,16}$");
+        public static Regex ContainsApprenticeOrApprenticeshipRegex = new Regex(@"(^|\s)(apprentice(ship)?)(\s|$)", RegexOptions.IgnoreCase);
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TitleValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TitleValidationTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
@@ -12,8 +11,8 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.
         public static IEnumerable<object[]> ValidTitles =>
             new List<object[]>
             {
-                new object[] { new String('a', 100) },
-                new object[] { new String('a', 1) }
+                new object[] { $"apprentice {new string('a', 89)}" },
+                new object[] { "apprentice" }
             };
 
         [Theory]
@@ -50,12 +49,54 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.
             result.Errors[0].RuleId.Should().Be((long)VacancyRuleSet.Title);
         }
 
+        [Theory]
+        [InlineData("Apprentice mage")]
+        [InlineData("Apprenticeship in sorcery")]
+        [InlineData("Mage apprentice")]
+        [InlineData("Witchcraft apprenticeship")]
+        [InlineData("junior apprentice mage")]
+        [InlineData("junior apprenticeship in sorcery")]
+        public void NoErrorsWhenTitleContainsTheWordApprenticeOrApprenticeship(string testValue)
+        {
+            var vacancy = new Vacancy
+            {
+                Title = testValue
+            };
+
+            var result = Validator.Validate(vacancy, VacancyRuleSet.Title);
+
+            result.HasErrors.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("mage")]
+        [InlineData("Apprenticeshipin sorcery")]
+        [InlineData("Mage apprenticesip")]
+        [InlineData("Witchcraft aprentice")]
+        [InlineData("aprentice mage")]
+        [InlineData("junior apprenteeship in sorcery")]
+        public void TitleMustContainTheWordApprenticeOrApprenticeship(string testValue)
+        {
+            var vacancy = new Vacancy
+            {
+                Title = testValue
+            };
+
+            var result = Validator.Validate(vacancy, VacancyRuleSet.Title);
+
+            result.HasErrors.Should().BeTrue();
+            result.Errors.Should().HaveCount(1);
+            result.Errors[0].PropertyName.Should().Be(nameof(vacancy.Title));
+            result.Errors[0].ErrorCode.Should().Be("200");
+            result.Errors[0].RuleId.Should().Be((long)VacancyRuleSet.Title);
+        }
+
         [Fact]
         public void TitleBeLongerThan100Characters()
         {
             var vacancy = new Vacancy 
             {
-                Title = new String('a', 110)
+                Title = $"apprentice {new string('a', 110)}"
             };
 
             var result = Validator.Validate(vacancy, VacancyRuleSet.Title);
@@ -68,9 +109,9 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.
         }
 
         [Theory]
-        [InlineData("<")]
-        [InlineData(">")]
-        public void TitleMustContainVaildCharacters(string testValue)
+        [InlineData("apprentice<")]
+        [InlineData("apprentice>")]
+        public void TitleMustContainValidCharacters(string testValue)
         {
             var vacancy = new Vacancy 
             {


### PR DESCRIPTION
Note that you can create a vacancy with the title being `apprentice`. This is valid and is what we allow on RAA V1 and the vacancy API.