### PR TITLE
ER-580 - Allowing DisabilityStatus to be null

### DIFF
--- a/src/Employer/Employer.Web/Extensions/ApplicationReviewExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/ApplicationReviewExtensions.cs
@@ -30,7 +30,7 @@ namespace Esfa.Recruit.Employer.Web.Extensions
                 AddressLine3 = r.Application.AddressLine3,
                 AddressLine4 = r.Application.AddressLine4,
                 CandidateFeedback = r.CandidateFeedback,
-                DisabilityStatus = r.Application.DisabilityStatus,
+                DisabilityStatus = r.Application.DisabilityStatus ?? ApplicationReviewDisabilityStatus.Unknown,
                 EducationFromYear = r.Application.EducationFromYear,
                 EducationInstitution = r.Application.EducationInstitution,
                 EducationToYear = r.Application.EducationToYear,

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Application.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Application.cs
@@ -13,7 +13,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public string AddressLine4 { get; set; }
         public DateTime ApplicationDate { get; set; }
         public DateTime BirthDate { get; set; }
-        public ApplicationReviewDisabilityStatus DisabilityStatus { get; set; }
+        public ApplicationReviewDisabilityStatus? DisabilityStatus { get; set; }
         public int EducationFromYear { get; set; }
         public string EducationInstitution { get; set; }
         public int EducationToYear { get; set; }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateVacancyApplicationsOnApplicationReviewChange.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateVacancyApplicationsOnApplicationReviewChange.cs
@@ -55,7 +55,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                     SubmittedDate = r.SubmittedDate,
                     ApplicationReviewId = r.Id,
                     CandidateName = r.Application.FullName,
-                    DisabilityStatus = r.Application.DisabilityStatus
+                    DisabilityStatus = r.Application.DisabilityStatus ?? ApplicationReviewDisabilityStatus.Unknown
                 }).ToList()
             };
 


### PR DESCRIPTION
Its possible to create an application in FAA without specifying any preference for disability status.  So we need to handle `null` values.

I didn't want to default this value to `Unknown` as I wanted to accurately represent what is passed in from FAA. Instead if this value is null then we'll display `Unknown` where appropriate.