### PR TITLE
Making launch url for the employer web project use the employer account id set in an env variable.

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -34,7 +34,7 @@
             "internalConsoleOptions": "openOnSessionStart",
             "launchBrowser": {
                 "enabled": true,
-                "args": "${auto-detect-url}/accounts/MXD78R/dashboard",
+                "args": "${auto-detect-url}/accounts/${env:EmployerAccount}/",
                 "windows": {
                     "command": "cmd.exe",
                     "args": "/C start ${auto-detect-url}/accounts/MXD78R/dashboard"


### PR DESCRIPTION
This is so that the `launch.json` used by vs code can still be checked in for configurations but launching employer web can be specific for each user.

@leewadhams I just added `export EmployerAccount=MYJR4X` to the bottom of my `.bash_profile`

Will update the developer setup confluence page