### PR TITLE
ER-667 custom skills added as checkboxes

### DIFF
--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "dotnet-test-explorer.testProjectPath": "./Shared/UnitTests/"
+    "dotnet-test-explorer.testProjectPath": "./Employer/UnitTests/"
 }

--- a/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
@@ -23,10 +23,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpGet("skills", Name = RouteNames.Skills_Get)]
         public async Task<IActionResult> Skills(VacancyRouteModel vrm)
         {
-            var vm = await _orchestrator.GetSkillsViewModelAsync(vrm);
+            var vm = await _orchestrator.GetSkillsViewModelAsync(vrm, TempData[TempDataKeys.Skills] as string[]);
 
-            TryUpdateSkillsFromTempData(vm);
-            
             return View(vm);
         }
 

--- a/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/SkillsController.cs
@@ -23,6 +23,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
         [HttpGet("skills", Name = RouteNames.Skills_Get)]
         public async Task<IActionResult> Skills(VacancyRouteModel vrm)
         {
+            // If adding/removing skill, tempdata will have the current draft list.
             var vm = await _orchestrator.GetSkillsViewModelAsync(vrm, TempData[TempDataKeys.Skills] as string[]);
 
             return View(vm);
@@ -52,15 +53,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
             }
 
             return RedirectToRoute(RouteNames.Vacancy_Preview_Get, SkillsViewModel.PreviewSectionAnchor);
-        }
-        
-        private void TryUpdateSkillsFromTempData(SkillsViewModel vm)
-        {
-            if (TempData.ContainsKey(TempDataKeys.Skills))
-            {
-                var tempDataSkills = TempData[TempDataKeys.Skills] as string[] ?? new string[0];
-                _orchestrator.SetViewModelSkills(vm, tempDataSkills);
-            }
         }
     }
 }

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -234,12 +234,9 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                 {
                     baseSkillList.Add(m.AddCustomSkillName);
                 }
-                else
+                else if (!CandidateSkills.Skills.Contains(m.AddCustomSkillName) && !customSkillList.Contains(m.AddCustomSkillName))
                 {
-                    if (!customSkillList.Contains(m.AddCustomSkillName))
-                    {
-                        customSkillList.Add(m.AddCustomSkillName);
-                    }
+                    customSkillList.Add(m.AddCustomSkillName);
                 }
             }
 

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -23,8 +23,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
         private readonly Lazy<CandidateSkills> _lazyCandidateSkills;
 
         private CandidateSkills CandidateSkills => _lazyCandidateSkills.Value;
-        private IEnumerable<string> Column1Skills => CandidateSkills.Skills.Take(ColumnOneCutOffIndex);
-        private IEnumerable<string> Column2Skills => CandidateSkills.Skills.Skip(ColumnOneCutOffIndex);
+        private IEnumerable<string> Column1BuiltInSkills => CandidateSkills.Skills.Take(ColumnOneCutOffIndex);
+        private IEnumerable<string> Column2BuiltInSkills => CandidateSkills.Skills.Skip(ColumnOneCutOffIndex);
 
         public SkillsOrchestrator(IEmployerVacancyClient client, ILogger<SkillsOrchestrator> logger) : base(logger)
         {
@@ -32,36 +32,87 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             _lazyCandidateSkills = new Lazy<CandidateSkills>(() => _client.GetCandidateSkillsAsync().Result);
         }
         
-        public async Task<SkillsViewModel> GetSkillsViewModelAsync(VacancyRouteModel vrm)
+        public async Task<SkillsViewModel> GetSkillsViewModelAsync(VacancyRouteModel vrm, string[] draftSkills = null)
         {
             var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.Skills_Get);
-            
+
             var vm = new SkillsViewModel
             {
                 Title = vacancy.Title
             };
 
-            SetViewModelSkills(vm, vacancy.Skills);
+            if (draftSkills == null)
+            {
+                SetViewModelSkills(vm, vacancy.Skills);
+            }
+            else
+            {
+                SetViewModelSkills(vm, draftSkills.ToList(), true);
+            }
             
             return vm;
+        }
+
+        private static IEnumerable<string> ExtractAndSort(string[] skills)
+        {
+            if (skills == null || skills.Length == 0)
+            {
+                return skills ?? new string[0];
+            }
+
+            var skillNames = new SortedList<int, string>();
+
+            foreach (var skillValue in skills)
+            {
+                var separatorIndex = skillValue.IndexOf('-');
+                if (int.TryParse(skillValue.Substring(0, separatorIndex), out int skillIndex))
+                {
+                    var skillName = skillValue.Substring(separatorIndex + 1);
+                    skillNames.Add(skillIndex, skillName);
+                }
+                else
+                {
+                    skillNames.Add(skillIndex, skillValue);
+                }
+            }
+
+            return skillNames.Select(x => x.Value);
         }
 
         public async Task<SkillsViewModel> GetSkillsViewModelAsync(SkillsEditModel m)
         {
             var vm = await GetSkillsViewModelAsync((VacancyRouteModel)m);
 
-            SetViewModelSkills(vm, m.Skills);
+            SetViewModelSkills(vm, m.Skills, true);
 
             vm.AddCustomSkillName = m.AddCustomSkillName;
             
             return vm;
         }
 
-        public void SetViewModelSkills(SkillsViewModel vm, IList<string> selectedSkills)
+        public void SetViewModelSkills(SkillsViewModel vm, IList<string> skills = null, bool areDraftSkills = false)
         {
-            vm.Column1Checkboxes = GetSkillsColumnViewModel(Column1Skills, selectedSkills).ToList();
-            vm.Column2Checkboxes = GetSkillsColumnViewModel(Column2Skills, selectedSkills).ToList();
-            vm.CustomSkills = GetCustomSkills(selectedSkills).ToList();
+            IEnumerable<string> orderedCustomSkills;
+            if (areDraftSkills)
+            {
+                orderedCustomSkills = ExtractAndSort(GetCustomSkills(skills).ToArray());
+            }
+            else
+            {
+                orderedCustomSkills = GetCustomSkills(skills).ToArray();
+            }
+
+            var baseSkills = GetBaseSkills(skills).ToArray();
+
+            var col1Skills = GetSkillsColumnViewModel(Column1BuiltInSkills, baseSkills);
+            var col2Skills = GetSkillsColumnViewModel(Column2BuiltInSkills, baseSkills);
+
+            var allDraftSkills = GetDraftSkillsColumnViewModel(orderedCustomSkills);
+            var col1DraftSkills = allDraftSkills.Where((_, index) => index % 2 == 1);
+            var col2DraftSkills = allDraftSkills.Where((_, index) => index % 2 == 0);
+
+            vm.Column1Checkboxes = col1Skills.Union(col1DraftSkills).ToList();
+            vm.Column2Checkboxes = col2Skills.Union(col2DraftSkills).ToList();
         }
 
         public async Task<OrchestratorResponse> PostSkillsEditModelAsync(SkillsEditModel m, VacancyUser user)
@@ -73,10 +124,17 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                 m.Skills = new List<string>();
             }
 
-            HandleCustomSkillChange(m);
+            var baseSkills = GetBaseSkills(m.Skills);
+            var customSkills = GetCustomSkills(m.Skills);
+            var extractedCustomSkills = ExtractAndSort(customSkills.ToArray()).ToList();
+
+            HandleCustomSkillChange(m, extractedCustomSkills);
+
+            extractedCustomSkills = extractedCustomSkills.Distinct().ToList();
             
-            vacancy.Skills = SortSkills(m.Skills).ToList();
-            m.Skills = vacancy.Skills;
+            vacancy.Skills = baseSkills.Union(extractedCustomSkills).ToList();
+
+            m.Skills = baseSkills.Union(AddOrdering(extractedCustomSkills)).ToList();
 
             //if we are adding/removing a skill then just validate and don't persist
             var validateOnly = m.IsAddingCustomSkill || m.IsRemovingCustomSkill;
@@ -85,12 +143,17 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                 v =>
                 {
                     var result = _client.Validate(v, ValidationRules);
-                    SyncErrorsAndModel(result.Errors, m);
+                    SyncErrorsAndModel(result.Errors, m, vacancy);
                     return result;
                 },
                 v => validateOnly ? Task.CompletedTask : _client.UpdateDraftVacancyAsync(v, user));
         }
-        
+
+        private IEnumerable<string> AddOrdering(List<string> extractedCustomSkills)
+        {
+            return extractedCustomSkills.Select((c, index) => $"{index + 1}-{c}");
+        }
+
         protected override EntityToViewModelPropertyMappings<Vacancy, SkillsEditModel> DefineMappings()
         {
             var mappings = new EntityToViewModelPropertyMappings<Vacancy, SkillsEditModel>
@@ -106,18 +169,29 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return skills.Select(c => new SkillViewModel
             {
                 Name = c,
-                Selected = selectedSkills != null && selectedSkills.Any(s => s == c)
+                Selected = selectedSkills != null && selectedSkills.Any(s => s == c),
+                Value = c
+            });
+        }
+
+        private IEnumerable<SkillViewModel> GetDraftSkillsColumnViewModel(IEnumerable<string> draftSkills)
+        {
+            return draftSkills.Select((c, index) => new SkillViewModel
+            {
+                Name = c,
+                Selected = true, // Always selected
+                Value = $"{index + 1}-{c}"
             });
         }
         
         private IEnumerable<string> GetCustomSkills(IEnumerable<string> selected)
         {
-            if (selected == null)
-            {
-                return new List<string>();
-            }
+            return selected == null ? new List<string>() : selected.Except(CandidateSkills.Skills);
+        }
 
-            return selected.Except(CandidateSkills.Skills);
+        private IEnumerable<string> GetBaseSkills(IEnumerable<string> selected)
+        {
+            return selected == null ? new List<string>() : selected.Intersect(CandidateSkills.Skills);
         }
 
         private IEnumerable<string> SortSkills(IList<string> selected)
@@ -130,9 +204,9 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             return orderedSkills.Where(filteredSelectedSkills.Contains);
         }
 
-        private void SyncErrorsAndModel(IList<EntityValidationError> errors, SkillsEditModel m)
+        private void SyncErrorsAndModel(ICollection<EntityValidationError> errors, SkillsEditModel m, Vacancy vacancy)
         {
-            var skillsPropertyName = nameof(Vacancy.Skills);
+            const string skillsPropertyName = nameof(Vacancy.Skills);
 
             //Get the first invalid skill
             var skillError = errors.FirstOrDefault(e => e.PropertyName.StartsWith($"{skillsPropertyName}["));
@@ -142,9 +216,10 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             }
 
             //Populate AddCustomSkillName so we can edit the invalid skill
-            var invalidSkill = m.Skills[skillError.GetIndexPosition().Value];
+            var invalidSkill = vacancy.Skills[skillError.GetIndexPosition().Value];
             m.AddCustomSkillName = invalidSkill;
-            m.Skills.Remove(invalidSkill);
+            m.Skills.RemoveAt(skillError.GetIndexPosition().Value);
+            vacancy.Skills.RemoveAt(skillError.GetIndexPosition().Value);
 
             //Attach the error to AddCustomSkillName
             skillError.PropertyName = nameof(m.AddCustomSkillName);
@@ -154,16 +229,16 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
                 .ForEach(r => errors.Remove(r));
         }
 
-        private void HandleCustomSkillChange(SkillsEditModel m)
+        private void HandleCustomSkillChange(SkillsEditModel m, IList<string> customSkillList)
         {
             if (m.IsAddingCustomSkill)
             {
-                m.Skills.Add(m.AddCustomSkillName);
+                customSkillList.Add(m.AddCustomSkillName);
             }
 
             if (m.IsRemovingCustomSkill)
             {
-                m.Skills.Remove(m.RemoveCustomSkill);
+               customSkillList.Remove(m.RemoveCustomSkill);
             }
         }
     }

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -72,7 +72,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             SetViewModelSkills(vm, baseSkills, orderedCustomSkills);
         }
 
-        private void SetViewModelSkillsFromDraftSkills(SkillsViewModel vm, IEnumerable<string> draftSkills)
+        private void SetViewModelSkillsFromDraftSkills(SkillsViewModel vm, IList<string> draftSkills)
         {
             var orderedCustomSkills = ExtractAndSort(GetCustomSkills(draftSkills).ToArray());
             var baseSkills = GetBaseSkills(draftSkills).ToArray();
@@ -80,7 +80,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             SetViewModelSkills(vm, baseSkills, orderedCustomSkills);
         }
 
-        private void SetViewModelSkills(SkillsViewModel vm, IEnumerable<string> baseSkills, IEnumerable<string> orderedCustomSkills)
+        private void SetViewModelSkills(SkillsViewModel vm, IList<string> baseSkills, IEnumerable<string> orderedCustomSkills)
         {
             var col1Skills = GetSkillsColumnViewModel(Column1BuiltInSkills, baseSkills);
             var col2Skills = GetSkillsColumnViewModel(Column2BuiltInSkills, baseSkills);
@@ -134,8 +134,6 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
 
             HandleCustomSkillChange(m, baseSkills, sortedCustomSkills);
 
-            sortedCustomSkills = sortedCustomSkills.ToList();
-            
             vacancy.Skills = baseSkills.Union(sortedCustomSkills).ToList();
 
             // Adding in the ordering of the custom skill entries
@@ -215,6 +213,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             var invalidSkill = vacancy.Skills[skillIndex];
             m.AddCustomSkillName = invalidSkill;
             
+            // Remove from vacancy and view model lists
             m.Skills.RemoveAt(skillIndex);
             vacancy.Skills.RemoveAt(skillIndex);
 

--- a/src/Employer/Employer.Web/ViewModels/Part2/Skills/SkillsViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part2/Skills/SkillsViewModel.cs
@@ -8,7 +8,6 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part2.Skills
         public string Title { get; internal set; }
         public List<SkillViewModel> Column1Checkboxes { get; set; }
         public List<SkillViewModel> Column2Checkboxes { get; set; }
-        public List<string> CustomSkills { get; set; }
         public static string PreviewSectionAnchor => PreviewAnchors.RequirementsAndProspectsSection;
         public IList<string> OrderedFieldNames => new List<string>
         {
@@ -20,6 +19,6 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part2.Skills
     {
         public string Name { get; set; }
         public bool Selected { get; set; }
+        public string Value { get; set; }
     }
-    
 }

--- a/src/Employer/Employer.Web/Views/Part2/Skills/Skills.cshtml
+++ b/src/Employer/Employer.Web/Views/Part2/Skills/Skills.cshtml
@@ -21,23 +21,23 @@
                 <div class="two-column-checkbox-container">
                     <fieldset class="two-column-checkbox">
                         @for (var i = 0; i < Model.Column1Checkboxes.Count; i++)
-                    {
-                        var checkbox = Model.Column1Checkboxes[i];
-                        <div class="multiple-choice">
-                            <input name="Skills" id="col1-@i" type="checkbox" value="@checkbox.Name" checked="@checkbox.Selected">
-                            <label for="col1-@i">@checkbox.Name</label>
-                        </div>
-                }
+                        {
+                            var checkbox = Model.Column1Checkboxes[i];
+                            <div class="multiple-choice">
+                                <input name="Skills" id="col1-@i" type="checkbox" value="@checkbox.Value" checked="@checkbox.Selected">
+                                <label for="col1-@i">@checkbox.Name</label>
+                            </div>
+                        }
                     </fieldset>
                     <fieldset class="two-column-checkbox">
                         @for (var i = 0; i < Model.Column2Checkboxes.Count; i++)
-                    {
-                        var checkbox = Model.Column2Checkboxes[i];
-                        <div class="multiple-choice">
-                            <input name="Skills" id="col2-@i" type="checkbox" value="@checkbox.Name" checked="@checkbox.Selected">
-                            <label for="col2-@i">@checkbox.Name</label>
-                        </div>
-                }
+                        {
+                            var checkbox = Model.Column2Checkboxes[i];
+                            <div class="multiple-choice">
+                                <input name="Skills" id="col2-@i" type="checkbox" value="@checkbox.Value" checked="@checkbox.Selected">
+                                <label for="col2-@i">@checkbox.Name</label>
+                            </div>
+                        }
                     </fieldset>
                 </div>
             </fieldset>
@@ -48,23 +48,6 @@
                 <span asp-validation-for="AddCustomSkillName" class="error-message"></span>
                 <input asp-for="AddCustomSkillName" value="@Model.AddCustomSkillName" type="text" class="form-control">
                 <button name="AddCustomSkillAction" id="add-custom-skill" value="AddCustomSkill" type="submit" class="button button-secondary save-button">+ Add this skill</button>
-            </div>
-
-            <div id="custom-skill-container" style="@(Model.CustomSkills.Any() == false ? "display:none" : null)">
-                <table>
-                    <tbody id="custom-skill-summary">
-                        @foreach (var customSkill in Model.CustomSkills)
-                    {
-                        <tr>
-                            <td>@customSkill</td>
-                            <td>
-                                <input name="Skills" type="hidden" value="@customSkill" />
-                                <button name="RemoveCustomSkill" value="@customSkill" type="submit" class="button-fake-link">Remove</button>
-                            </td>
-                        </tr>
-                }
-                    </tbody>
-                </table>
             </div>
 
             <br />

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
@@ -146,22 +146,6 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part2
         }
 
         [Fact]
-        public async Task WhenCustomDraftSkillsHaveBeenAdded_ShouldBeOrderedByTheirPrefix()
-        {
-            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
-
-            var draftSkills = new [] { "2-Draft2", "3-Draft3", "1-Draft1" };
-
-            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
-
-            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
-
-            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
-            result.Column1Checkboxes.FindIndex(x => x.Name == "Draft2").Should().Be(9); // 10th item in list
-            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft3").Should().Be(9); // 10th item in list
-        }
-
-        [Fact]
         public async Task WhenCustomDraftSkillsAdded_ShouldIncludeIndicatorOfItsOrder()
         {
             _testVacancy.Skills = new List<string>(); // No selected skills already persisted
@@ -175,6 +159,22 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part2
             result.Column2Checkboxes.Single(x => x.Name == "Draft1").Value.Should().Be("1-Draft1"); 
             result.Column1Checkboxes.Single(x => x.Name == "Draft2").Value.Should().Be("2-Draft2");
             result.Column2Checkboxes.Single(x => x.Name == "Draft3").Value.Should().Be("3-Draft3");
+        }
+        
+        [Fact]
+        public async Task WhenCustomDraftSkillsHaveBeenAdded_ShouldBeOrderedByTheirPrefix()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "2-Draft2", "3-Draft3", "1-Draft1" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
+            result.Column1Checkboxes.FindIndex(x => x.Name == "Draft2").Should().Be(9); // 10th item in list
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft3").Should().Be(9); // 10th item in list
         }
 
         private static Vacancy GetTestVacancy()

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
+using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Skills;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part2
+{
+    public class SkillOrchestratorTests
+    {
+        private const string TestEmployerAccountId = "ABC";
+        private readonly Mock<IEmployerVacancyClient> _mockClient;
+        private readonly SkillsOrchestrator _orchestrator;
+        private readonly Vacancy _testVacancy;
+        private readonly VacancyRouteModel _testRouteModel = new VacancyRouteModel { EmployerAccountId = TestEmployerAccountId, VacancyId = Guid.NewGuid() };
+
+        public SkillOrchestratorTests()
+        {
+            var mockLogger = new Mock<ILogger<SkillsOrchestrator>>();
+            var candidateSkills = GetBaseSkills();
+            _mockClient = new Mock<IEmployerVacancyClient>();
+            _orchestrator = new SkillsOrchestrator(_mockClient.Object, mockLogger.Object);
+            _testVacancy = GetTestVacancy();
+
+            _mockClient.Setup(x => x.GetCandidateSkillsAsync()).ReturnsAsync(candidateSkills);
+        }
+
+        [Fact]
+        public async Task WhenNoSkillsSaved_ShouldReturnListOfAllBasicSkillsUnchecked()
+        {
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel);
+
+            // Count that all 18 base skills are there
+            result.Column1Checkboxes.Count(x => x.Selected == false).Should().Be(9);
+            result.Column2Checkboxes.Count(x => x.Selected == false).Should().Be(8);
+        }
+
+        [Fact]
+        public async Task WhenSingleBaseSkillSaved_ShouldReturnListOfAllBasicSkillsWithSkillSelected()
+        {
+            _testVacancy.Skills = new List<string> { "Logical" }; // Set the saved skill
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel);
+
+            var allCheckboxes = result.Column1Checkboxes.Union(result.Column2Checkboxes);
+            allCheckboxes.Where(x => x.Selected).Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task WhenMultipleBaseSkillsSaved_ShouldReturnListOfAllBasicSkillsWithSkillsSelected()
+        {
+            _testVacancy.Skills = new List<string> { "Logical", "Patience" }; // Set the saved skill
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel);
+
+            var allCheckboxes = result.Column1Checkboxes.Union(result.Column2Checkboxes);
+            allCheckboxes.Where(x => x.Selected).Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task WhenCustomSkillHasBeenSaved_ShouldReturnCustomSkillsSelectedInLastItemInSecondColumn()
+        {
+            _testVacancy.Skills = new List<string> { "Custom1" }; // Set the saved skill
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel);
+
+            var lastCol2Item = result.Column2Checkboxes.Last();
+            lastCol2Item.Name.Should().Be("Custom1");
+            lastCol2Item.Selected.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task WhenMultipleCustomSkillsSaved_ShouldReturnTheCustomSkillsInAlternateColumnsStaringWithColumn2()
+        {
+            _testVacancy.Skills = new List<string> { "Custom1", "Custom2", "Custom3" }; // Set the saved skill
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Custom1").Should().Be(8); // 9th item in list
+            result.Column1Checkboxes.FindIndex(x => x.Name == "Custom2").Should().Be(9); // 10th item in list
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Custom3").Should().Be(9); // 10th item in list
+        }
+
+        [Fact]
+        public async Task WhenCustomDraftSkillHasBeenAdded_ShouldBeAddedToColumn2()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "1-Draft1" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
+        }
+
+        [Fact]
+        public async Task WhenCustomeDraftSkillsAdded_ShouldBeAddedToAlternateColumnsStartingWithColumn2()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "1-Draft1", "2-Draft2", "3-Draft3" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
+            result.Column1Checkboxes.FindIndex(x => x.Name == "Draft2").Should().Be(9); // 10th item in list
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft3").Should().Be(9); // 10th item in list
+        }
+
+        [Fact]
+        public async Task WhenCustomDraftSkillsAddedAndBaseSkillSelected_ShouldBeAddedToAlternateColumnsStartingWithColumn2()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "1-Draft1", "Patience", "2-Draft2", "3-Draft3" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
+            result.Column1Checkboxes.FindIndex(x => x.Name == "Draft2").Should().Be(9); // 10th item in list
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft3").Should().Be(9); // 10th item in list
+        }
+
+        [Fact]
+        public async Task WhenCustomDraftSkillsHaveBeenAdded_ShouldBeOrderedByTheirPrefix()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "2-Draft2", "3-Draft3", "1-Draft1" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft1").Should().Be(8); // 9th item in list
+            result.Column1Checkboxes.FindIndex(x => x.Name == "Draft2").Should().Be(9); // 10th item in list
+            result.Column2Checkboxes.FindIndex(x => x.Name == "Draft3").Should().Be(9); // 10th item in list
+        }
+
+        [Fact]
+        public async Task WhenCustomDraftSkillsAdded_ShouldIncludeIndicatorOfItsOrder()
+        {
+            _testVacancy.Skills = new List<string>(); // No selected skills already persisted
+
+            var draftSkills = new [] { "2-Draft2", "3-Draft3", "1-Draft1" };
+
+            _mockClient.Setup(x => x.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(_testVacancy);
+
+            var result = await _orchestrator.GetSkillsViewModelAsync(_testRouteModel, draftSkills);
+
+            result.Column2Checkboxes.Single(x => x.Name == "Draft1").Value.Should().Be("1-Draft1"); 
+            result.Column1Checkboxes.Single(x => x.Name == "Draft2").Value.Should().Be("2-Draft2");
+            result.Column2Checkboxes.Single(x => x.Name == "Draft3").Value.Should().Be("3-Draft3");
+        }
+
+        private static Vacancy GetTestVacancy()
+        {
+            return new Vacancy
+            {
+                EmployerAccountId = TestEmployerAccountId,
+                Title = "Test Title",
+                ShortDescription = "Test Short Description",
+                EmployerLocation = new Address
+                {
+                    Postcode = "AB1 2XZ"
+                },
+                ProgrammeId = "2",
+                Wage = new Wage
+                {
+                    WageType = WageType.NationalMinimumWage
+                }
+            };
+        }
+
+        private static CandidateSkills GetBaseSkills()
+        {
+            return new CandidateSkills
+            {
+                Skills = new List<string>
+                {
+                    "Communication skills",
+                    "IT skills",
+                    "Attention to detail",
+                    "Organisation skills",
+                    "Customer care skills",
+                    "Problem solving skills",
+                    "Presentation skills",
+                    "Administrative skills",
+                    "Number skills",
+                    "Analytical skills",
+                    "Logical",
+                    "Team working",
+                    "Creative",
+                    "Initiative",
+                    "Non judgemental",
+                    "Patience",
+                    "Physical fitness"
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
There may well be a much simpler/better way to do this.

To retain ordering of the custom skills entered before they are saved I've introduced an order number for them. It surfaces as a prefix of the `value` on the checkbox `e.g. 1-Programming Ability`

