### PR TITLE
ER-671 Display Auto QA Errors in Employer site

### DIFF
--- a/src/Employer/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer/Employer.Web/Configuration/IoC.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part2;
 using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Shared.Web.Configuration;
+using Esfa.Recruit.Shared.Web.RuleTemplates;
 using Esfa.Recruit.Shared.Web.Services;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.FAA;
 using Microsoft.AspNetCore.Http;
@@ -86,6 +87,8 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         private static void RegisterMapperDeps(IServiceCollection services)
         {
             services.AddTransient<DisplayVacancyViewModelMapper>();
+            services.AddTransient<ReviewFieldIndicatorMapper>();
+            services.AddScoped<IRuleMessageTemplateRunner, RuleTemplateMessageRunner>();
         }
     }
 }

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
@@ -73,7 +73,7 @@ namespace Esfa.Recruit.Employer.Web.Mappings
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, nameof(TitleEditModel.NumberOfPositions), "Number of positions for this apprenticeship requires edit")
         };
 
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> EmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetEmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, nameof(EmployerEditModel.AddressLine1), "Employer address requires edit"),
         };

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
@@ -1,163 +1,91 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using Esfa.Recruit.Employer.Web.Services;
-using Esfa.Recruit.Employer.Web.ViewModels;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.Employer;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.ShortDescription;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.Title;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.Training;
-using Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage;
 using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
-using Esfa.Recruit.Employer.Web.Views;
+using Esfa.Recruit.Shared.Web.Mappers;
+using Esfa.Recruit.Shared.Web.RuleTemplates;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FieldIdentifiers = Esfa.Recruit.Vacancies.Client.Domain.Entities.VacancyReview.FieldIdentifiers;
 
 namespace Esfa.Recruit.Employer.Web.Mappings
 {
-    public static class ReviewFieldIndicatorMapper
+    public sealed class ReviewFieldIndicatorMapper
     {
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetPreviewReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
+        private readonly IRuleMessageTemplateRunner _ruleTemplateRunner;
+
+        public ReviewFieldIndicatorMapper(IRuleMessageTemplateRunner ruleTemplateRunner)
         {
-            //These need to be added in display order
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, Anchors.Title, "Title requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, Anchors.ShortDescription, "Brief overview of the role requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, Anchors.ClosingDate, "Closing date requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, Anchors.WorkingWeek, "Working week requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.YearlyWage, "Yearly wage requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, Anchors.ExpectedDuration, "Expected duration requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, Anchors.PossibleStartDate, "Possible start date requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, Anchors.TrainingLevel, "Apprenticeship level requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, Anchors.NumberOfPositions, "Positions requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, Anchors.VacancyDescription, "Typical working day requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, Anchors.TrainingDescription, "Training requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, Anchors.OutcomeDescription, "Future prospects requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.Skills, "Skills requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.Qualifications, "Qualifications requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, Anchors.ThingsToConsider, "Things to consider requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, Anchors.EmployerDescription, "Employer description requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, Anchors.DisabilityConfident, "Disability confident requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, Anchors.EmployerWebsiteUrl, "Employer website requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerContact, Anchors.EmployerContact, "Contact details requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, Anchors.EmployerAddress, "Employer address requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, Anchors.Provider, "Training provider requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, Anchors.Training, "Training requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethod, "Application method requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, Anchors.ApplicationUrl, "Apply now web address requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, Anchors.ApplicationInstructions, "Application process requires edit")
+            _ruleTemplateRunner = ruleTemplateRunner;
+        }
+
+        private IDictionary<string, string> ManualQaMessages => new Dictionary<string, string> 
+        {
+            { FieldIdentifiers.Title, "Title requires edit" },
+            { FieldIdentifiers.ShortDescription, "Brief overview of the role requires edit" },
+            { FieldIdentifiers.ClosingDate, "Closing date requires edit" },
+            { FieldIdentifiers.WorkingWeek, "Working week requires edit" },
+            { FieldIdentifiers.Wage, "Yearly wage requires edit" },
+            { FieldIdentifiers.ExpectedDuration, "Expected duration requires edit" },
+            { FieldIdentifiers.PossibleStartDate, "Possible start date requires edit" },
+            { FieldIdentifiers.TrainingLevel, "Apprenticeship level requires edit" },
+            { FieldIdentifiers.NumberOfPositions, "Positions requires edit" },
+            { FieldIdentifiers.VacancyDescription, "Typical working day requires edit" },
+            { FieldIdentifiers.TrainingDescription, "Training requires edit" },
+            { FieldIdentifiers.OutcomeDescription, "Future prospects requires edit" },
+            { FieldIdentifiers.Skills, "Skills requires edit" },
+            { FieldIdentifiers.Qualifications, "Qualifications requires edit" },
+            { FieldIdentifiers.ThingsToConsider, "Things to consider requires edit" },
+            { FieldIdentifiers.EmployerDescription, "Employer description requires edit" },
+            { FieldIdentifiers.DisabilityConfident, "Disability confident requires edit" },
+            { FieldIdentifiers.EmployerWebsiteUrl, "Employer website requires edit" },
+            { FieldIdentifiers.EmployerContact, "Contact details requires edit" },
+            { FieldIdentifiers.EmployerAddress, "Employer address requires edit" },
+            { FieldIdentifiers.Provider, "Training provider requires edit" },
+            { FieldIdentifiers.Training, "Training requires edit" },
+            { FieldIdentifiers.ApplicationMethod, "Application method requires edit" },
+            { FieldIdentifiers.ApplicationUrl, "Apply now web address requires edit" },
+            { FieldIdentifiers.ApplicationInstructions, "Application process requires edit" }
         };
 
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetShortDescriptionReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
+        public IEnumerable<ReviewFieldIndicatorViewModel> MapFromFieldIndicators(ReviewFieldMappingLookupsForPage pageMappings, VacancyReview review)
         {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, nameof(ShortDescriptionEditModel.ShortDescription), "Brief overview of the role requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTrainingReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, nameof(TrainingEditModel.ClosingDay), "Closing date requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, nameof(TrainingEditModel.StartDay), "Possible start date requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, nameof(TrainingEditModel.SelectedProgrammeId), "Training requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, nameof(TrainingEditModel.SelectedProgrammeId), "Apprenticeship level requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, nameof(TrainingEditModel.IsDisabilityConfident), "Disability confident requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetWageReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, nameof(WageEditModel.Duration), "How long is the apprenticeship expected to last requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, nameof(WageEditModel.WorkingWeekDescription), "Working week requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.WageTypeHeading, "What is the salary requires edit")
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTitleFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, nameof(TitleEditModel.Title), "What do you want to call this vacancy requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, nameof(TitleEditModel.NumberOfPositions), "Number of positions for this apprenticeship requires edit")
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetEmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, nameof(EmployerEditModel.AddressLine1), "Employer address requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetVacancyDescriptionFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, nameof(VacancyDescriptionEditModel.VacancyDescription), "What does the apprenticeship involve requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, nameof(VacancyDescriptionEditModel.TrainingDescription), "What training will your apprentice get requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, nameof(VacancyDescriptionEditModel.OutcomeDescription), "What can the apprentice expect at the end of the apprenticeship requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetSkillsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.SkillsHeading, "Desired skills or personal qualities requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetQualificationsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.QualificationsHeading, "Qualifications requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetConsiderationsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, nameof(ConsiderationsEditModel.ThingsToConsider), "Things to consider requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetAboutEmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, nameof(AboutEmployerEditModel.EmployerDescription), "Tell us about your organisation requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, nameof(AboutEmployerEditModel.EmployerWebsiteUrl), "Your organisation's website requires edit")
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetEmployerContactDetailsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerContact, nameof(EmployerContactDetailsEditModel.EmployerContactName), "Contact details requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTrainingProviderFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, nameof(SelectTrainingProviderEditModel.Ukprn), "Training provider requires edit"),
-        };
-
-        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetApplicationProcessFieldIndicators => new List<ReviewFieldIndicatorViewModel>
-        {
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethodHeading, "Application process requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, nameof(ApplicationProcessEditModel.ApplicationUrl), "Enter the web address candidates should use to apply for this vacancy requires edit"),
-            new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, nameof(ApplicationProcessEditModel.ApplicationInstructions), "Explain the application process requires edit")
-        };
-
-        public static IEnumerable<ReviewFieldIndicatorViewModel> MapFromFieldIndicators(IEnumerable<ReviewFieldIndicatorViewModel> reviewFieldIndicatorsForPage, List<ManualQaFieldIndicator> reviewFieldIndicators, RuleSetOutcome automatedResult)
-        {
-            var selectedFieldIdentifiers = reviewFieldIndicators
-                .Where(r => r.IsChangeRequested)
+            var manualQaFieldIdentifierNames = review.ManualQaFieldIndicators
+                ?.Where(r => r.IsChangeRequested)
                 .Select(r => r.FieldIdentifier)
+                .ToList() ?? new List<string>();
+
+            var autoQaReferredOutcomeIds = review.AutomatedQaOutcomeIndicators
+                ?.Where(i => i.IsReferred)
+                .Select(i => i.RuleOutcomeId)
+                .ToList() ?? new List<Guid>();
+
+            var autoQaReferredOutcomes = review.AutomatedQaOutcome.RuleOutcomes
+                .SelectMany(d => d.Details)
+                .Where(x => autoQaReferredOutcomeIds.Contains(x.Id))
                 .ToList();
 
+            var uniqueFieldIdentifierNames =
+                manualQaFieldIdentifierNames.Union(
+                    autoQaReferredOutcomes.SelectMany(x => pageMappings.VacancyPropertyMappingsLookup.TryGetValue(x.Target, out var value) ? value : Enumerable.Empty<string>()));
 
-            var qaFailureOutcomeIndicators = automatedResult.RuleOutcomes
-                                                        ?.SelectMany(d => d.Details)
-                                                        .Where(x => x.Score > 0) ?? Enumerable.Empty<RuleOutcome>();
+            var indicatorsToDisplayLookup = pageMappings.FieldIdentifiersForPage
+                .Where(r => uniqueFieldIdentifierNames.Contains(r.ReviewFieldIdentifier))
+                .ToDictionary(x => x.ReviewFieldIdentifier, y => y);
 
-            // Add manual qa indicators
-            var indicators = reviewFieldIndicatorsForPage.Where(r => selectedFieldIdentifiers.Contains(r.ReviewFieldIdentifier)).ToDictionary(x => x.ReviewFieldIdentifier, y => y);
-
-            // Add automated qa indicators
-            foreach(var outcome in qaFailureOutcomeIndicators)
+            foreach(var indicator in indicatorsToDisplayLookup)
             {
-                if (indicators.ContainsKey(outcome.Target))
+                if (manualQaFieldIdentifierNames.Contains(indicator.Key))
                 {
-                    indicators[outcome.Target].Texts.Add(outcome.Narrative);
+                    indicator.Value.ManualQaText = ManualQaMessages[indicator.Key];
                 }
-                else
-                {
-                    var matchingField = reviewFieldIndicatorsForPage.SingleOrDefault(x => x.ReviewFieldIdentifier == outcome.Target);
 
-                    if (matchingField != null) // The field might not be on the current page.
-                    {
-                        matchingField.Texts[0] = outcome.Narrative; // Override default text as manual message not needed.
-                        indicators.Add(outcome.Target, reviewFieldIndicatorsForPage.Single(x => x.ReviewFieldIdentifier == outcome.Target));
-                    }
-                }
+                var autoQaOutcomes = autoQaReferredOutcomes.Where(x => pageMappings.VacancyPropertyMappingsLookup.TryGetValue(x.Target, out var value) && value.Contains(indicator.Key))
+                    .Select(x => _ruleTemplateRunner.ToText(x.RuleId, x.Data, FieldDisplayNameResolver.Resolve(x.Target)));
+
+                indicator.Value.AutoQaTexts.AddRange(autoQaOutcomes);
             }
-
-            return indicators.Values;
+            
+            return indicatorsToDisplayLookup.Values;
         }
     }
 }

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
@@ -16,7 +16,7 @@ namespace Esfa.Recruit.Employer.Web.Mappings
 {
     public static class ReviewFieldIndicatorMapper
     {
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> PreviewReviewFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetPreviewReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             //These need to be added in display order
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, Anchors.Title, "Title requires edit"),
@@ -46,12 +46,12 @@ namespace Esfa.Recruit.Employer.Web.Mappings
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, Anchors.ApplicationInstructions, "Application process requires edit")
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> ShortDescriptionReviewFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetShortDescriptionReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, nameof(ShortDescriptionEditModel.ShortDescription), "Brief overview of the role requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> TrainingReviewFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTrainingReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, nameof(TrainingEditModel.ClosingDay), "Closing date requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, nameof(TrainingEditModel.StartDay), "Possible start date requires edit"),
@@ -60,63 +60,63 @@ namespace Esfa.Recruit.Employer.Web.Mappings
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, nameof(TrainingEditModel.IsDisabilityConfident), "Disability confident requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> WageReviewFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetWageReviewFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, nameof(WageEditModel.Duration), "How long is the apprenticeship expected to last requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, nameof(WageEditModel.WorkingWeekDescription), "Working week requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.WageTypeHeading, "What is the salary requires edit")
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> TitleFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTitleFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, nameof(TitleEditModel.Title), "What do you want to call this vacancy requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, nameof(TitleEditModel.NumberOfPositions), "Number of positions for this apprenticeship requires edit")
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> EmployerFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> EmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, nameof(EmployerEditModel.AddressLine1), "Employer address requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> VacancyDescriptionFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetVacancyDescriptionFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, nameof(VacancyDescriptionEditModel.VacancyDescription), "What does the apprenticeship involve requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, nameof(VacancyDescriptionEditModel.TrainingDescription), "What training will your apprentice get requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, nameof(VacancyDescriptionEditModel.OutcomeDescription), "What can the apprentice expect at the end of the apprenticeship requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> SkillsFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetSkillsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.SkillsHeading, "Desired skills or personal qualities requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> QualificationsFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetQualificationsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.QualificationsHeading, "Qualifications requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> ConsiderationsFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetConsiderationsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, nameof(ConsiderationsEditModel.ThingsToConsider), "Things to consider requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> AboutEmployerFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetAboutEmployerFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, nameof(AboutEmployerEditModel.EmployerDescription), "Tell us about your organisation requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, nameof(AboutEmployerEditModel.EmployerWebsiteUrl), "Your organisation's website requires edit")
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> EmployerContactDetailsFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetEmployerContactDetailsFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerContact, nameof(EmployerContactDetailsEditModel.EmployerContactName), "Contact details requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> TrainingProviderFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetTrainingProviderFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, nameof(SelectTrainingProviderEditModel.Ukprn), "Training provider requires edit"),
         };
 
-        public static readonly IReadOnlyList<ReviewFieldIndicatorViewModel> ApplicationProcessFieldIndicators = new List<ReviewFieldIndicatorViewModel>
+        public static IReadOnlyList<ReviewFieldIndicatorViewModel> GetApplicationProcessFieldIndicators => new List<ReviewFieldIndicatorViewModel>
         {
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethodHeading, "Application process requires edit"),
             new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, nameof(ApplicationProcessEditModel.ApplicationUrl), "Enter the web address candidates should use to apply for this vacancy requires edit"),

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldIndicatorMapper.cs
@@ -59,10 +59,10 @@ namespace Esfa.Recruit.Employer.Web.Mappings
                 .Select(i => i.RuleOutcomeId)
                 .ToList() ?? new List<Guid>();
 
-            var autoQaReferredOutcomes = review.AutomatedQaOutcome.RuleOutcomes
+            var autoQaReferredOutcomes = review.AutomatedQaOutcome?.RuleOutcomes
                 .SelectMany(d => d.Details)
                 .Where(x => autoQaReferredOutcomeIds.Contains(x.Id))
-                .ToList();
+                .ToList() ?? new List<RuleOutcome>();
 
             var uniqueFieldIdentifierNames =
                 manualQaFieldIdentifierNames.Union(

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldMappingLookups.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldMappingLookups.cs
@@ -1,0 +1,326 @@
+using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.ViewModels;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.Employer;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.ShortDescription;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.Title;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.Training;
+using Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage;
+using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
+using Esfa.Recruit.Employer.Web.Views;
+using Esfa.Recruit.Vacancies.Client.Application.Services;
+using static Esfa.Recruit.Vacancies.Client.Domain.Entities.VacancyReview;
+
+namespace Esfa.Recruit.Employer.Web.Mappings
+{
+    public static class ReviewFieldMappingLookups
+    {
+        public static ReviewFieldMappingLookupsForPage GetPreviewReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, Anchors.Title),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, Anchors.ShortDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, Anchors.ClosingDate),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, Anchors.WorkingWeek),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.YearlyWage),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, Anchors.ExpectedDuration),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, Anchors.PossibleStartDate),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, Anchors.TrainingLevel),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, Anchors.NumberOfPositions),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, Anchors.VacancyDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, Anchors.TrainingDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, Anchors.OutcomeDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.Skills),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.Qualifications),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, Anchors.ThingsToConsider),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, Anchors.EmployerDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, Anchors.DisabilityConfident),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, Anchors.EmployerWebsiteUrl),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerContact, Anchors.EmployerContact),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, Anchors.EmployerAddress),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, Anchors.Provider),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, Anchors.Training),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethod),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, Anchors.ApplicationUrl),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, Anchors.ApplicationInstructions)
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerAccountId), new string[0]},
+                { FieldIdResolver.ToFieldId(v => v.Title), new[]{ FieldIdentifiers.Title} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerName), new string[0] },
+                { FieldIdResolver.ToFieldId(v => v.ShortDescription), new []{ FieldIdentifiers.ShortDescription} },
+                { FieldIdResolver.ToFieldId(v => v.ClosingDate), new []{ FieldIdentifiers.ClosingDate} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WeeklyHours), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WorkingWeekDescription), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageAdditionalInformation), new []{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageType),  new[]{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.FixedWageYearlyAmount), new []{ FieldIdentifiers.Wage }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.Duration), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.DurationUnit), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.StartDate), new []{ FieldIdentifiers.PossibleStartDate} },
+                { FieldIdResolver.ToFieldId(v => v.ProgrammeId), new []{ FieldIdentifiers.TrainingLevel, FieldIdentifiers.Training} },
+                { FieldIdResolver.ToFieldId(v => v.VacancyReference), new string[0] },
+                { FieldIdResolver.ToFieldId(v => v.NumberOfPositions), new []{ FieldIdentifiers.NumberOfPositions} },
+                { FieldIdResolver.ToFieldId(v => v.Description), new []{ FieldIdentifiers.VacancyDescription} },
+                { FieldIdResolver.ToFieldId(v => v.TrainingDescription), new []{ FieldIdentifiers.TrainingDescription} },
+                { FieldIdResolver.ToFieldId(v => v.OutcomeDescription), new []{ FieldIdentifiers.OutcomeDescription} },
+                { FieldIdResolver.ToFieldId(v => v.Skills), new []{ FieldIdentifiers.Skills} },
+                { FieldIdResolver.ToFieldId(v => v.Qualifications), new []{ FieldIdentifiers.Qualifications} },
+                { FieldIdResolver.ToFieldId(v => v.ThingsToConsider), new []{ FieldIdentifiers.ThingsToConsider} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerDescription), new [] { FieldIdentifiers.EmployerDescription }},
+                { FieldIdResolver.ToFieldId(v => v.DisabilityConfident), new []{ FieldIdentifiers.DisabilityConfident} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerWebsiteUrl), new []{ FieldIdentifiers.EmployerWebsiteUrl} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine1), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine2), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine3), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine4), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.Postcode), new[] { FieldIdentifiers.EmployerAddress}},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactEmail), new []{ FieldIdentifiers.EmployerContact} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactName), new [] { FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactPhone), new []{ FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.TrainingProvider.Ukprn) , new []{ FieldIdentifiers.Provider} },
+                { FieldIdResolver.ToFieldId(v => v.ApplicationInstructions), new [] { FieldIdentifiers.ApplicationInstructions }},
+                { FieldIdResolver.ToFieldId(v => v.ApplicationMethod), new [] { FieldIdentifiers.ApplicationMethod} },
+                { FieldIdResolver.ToFieldId(v => v.ApplicationUrl), new []{ FieldIdentifiers.ApplicationUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetShortDescriptionReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, nameof(ShortDescriptionEditModel.ShortDescription))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ShortDescription), new []{ FieldIdentifiers.ShortDescription} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetTrainingReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, nameof(TrainingEditModel.ClosingDay)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, nameof(TrainingEditModel.StartDay)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, nameof(TrainingEditModel.SelectedProgrammeId)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, nameof(TrainingEditModel.SelectedProgrammeId)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, nameof(TrainingEditModel.IsDisabilityConfident))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ClosingDate), new []{ FieldIdentifiers.ClosingDate} },
+                { FieldIdResolver.ToFieldId(v => v.StartDate), new []{ FieldIdentifiers.PossibleStartDate} },
+                { FieldIdResolver.ToFieldId(v => v.ProgrammeId), new []{ FieldIdentifiers.TrainingLevel, FieldIdentifiers.Training} },
+                { FieldIdResolver.ToFieldId(v => v.DisabilityConfident), new []{ FieldIdentifiers.DisabilityConfident} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetWageReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, nameof(WageEditModel.Duration)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, nameof(WageEditModel.WorkingWeekDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.WageTypeHeading),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WageAdditionalInfo, nameof(WageEditModel.WageAdditionalInformation))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Wage.WeeklyHours), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WorkingWeekDescription), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageAdditionalInformation), new []{ FieldIdentifiers.WageAdditionalInfo }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageType),  new[]{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.FixedWageYearlyAmount), new []{ FieldIdentifiers.Wage }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.Duration), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.DurationUnit), new []{ FieldIdentifiers.ExpectedDuration }},
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetTitleFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, nameof(TitleEditModel.Title)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, nameof(TitleEditModel.NumberOfPositions))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Title), new[]{ FieldIdentifiers.Title} },
+                { FieldIdResolver.ToFieldId(v => v.NumberOfPositions), new []{ FieldIdentifiers.NumberOfPositions} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetEmployerFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, nameof(EmployerEditModel.AddressLine1)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress1, nameof(EmployerEditModel.AddressLine1)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress2, nameof(EmployerEditModel.AddressLine2)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress3, nameof(EmployerEditModel.AddressLine3)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress4, nameof(EmployerEditModel.AddressLine4))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine1), new []{ FieldIdentifiers.EmployerAddress1 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine2), new []{ FieldIdentifiers.EmployerAddress2 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine3), new []{ FieldIdentifiers.EmployerAddress3 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine4), new []{ FieldIdentifiers.EmployerAddress4 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.Postcode), new[]{ FieldIdentifiers.EmployerAddress}}
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetVacancyDescriptionFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, nameof(VacancyDescriptionEditModel.VacancyDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, nameof(VacancyDescriptionEditModel.TrainingDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, nameof(VacancyDescriptionEditModel.OutcomeDescription)),
+
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Description), new []{ FieldIdentifiers.VacancyDescription} },
+                { FieldIdResolver.ToFieldId(v => v.TrainingDescription), new []{ FieldIdentifiers.TrainingDescription} },
+                { FieldIdResolver.ToFieldId(v => v.OutcomeDescription), new []{ FieldIdentifiers.OutcomeDescription} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetSkillsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.SkillsHeading),
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Skills), new []{ FieldIdentifiers.Skills} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetQualificationsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.QualificationsHeading)
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Qualifications), new []{ FieldIdentifiers.Qualifications} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetConsiderationsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, nameof(ConsiderationsEditModel.ThingsToConsider))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ThingsToConsider), new []{ FieldIdentifiers.ThingsToConsider} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetAboutEmployerFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, nameof(AboutEmployerEditModel.EmployerDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, nameof(AboutEmployerEditModel.EmployerWebsiteUrl))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerDescription), new [] { FieldIdentifiers.EmployerDescription }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerWebsiteUrl), new []{ FieldIdentifiers.EmployerWebsiteUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetEmployerContactDetailsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerContact, nameof(EmployerContactDetailsEditModel.EmployerContactName)),
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactEmail), new []{ FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactName), new []{ FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContactPhone), new []{ FieldIdentifiers.EmployerContact }}
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetTrainingProviderFieldIndicators()
+        {   
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, nameof(SelectTrainingProviderEditModel.Ukprn)),
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.TrainingProvider.Ukprn) , new []{ FieldIdentifiers.Provider} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetApplicationProcessFieldIndicators()
+        { 
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethodHeading),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, nameof(ApplicationProcessEditModel.ApplicationUrl)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, nameof(ApplicationProcessEditModel.ApplicationInstructions))
+            };
+
+            var mappings = new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ApplicationInstructions), new [] { FieldIdentifiers.ApplicationInstructions }},
+                { FieldIdResolver.ToFieldId(v => v.ApplicationMethod), new [] { FieldIdentifiers.ApplicationMethod} },
+                { FieldIdResolver.ToFieldId(v => v.ApplicationUrl), new []{ FieldIdentifiers.ApplicationUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Mappings/ReviewFieldMappingLookupsForPage.cs
+++ b/src/Employer/Employer.Web/Mappings/ReviewFieldMappingLookupsForPage.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
+
+namespace Esfa.Recruit.Employer.Web.Mappings
+{
+    public class ReviewFieldMappingLookupsForPage
+    {
+        public ReviewFieldMappingLookupsForPage(IReadOnlyList<ReviewFieldIndicatorViewModel> viewModels, IDictionary<string, IEnumerable<string>> vacancyMappings)
+        {
+            FieldIdentifiersForPage = viewModels;
+            VacancyPropertyMappingsLookup = vacancyMappings;
+        }
+
+        public IReadOnlyList<ReviewFieldIndicatorViewModel> FieldIdentifiersForPage { get; }
+
+        public IDictionary<string, IEnumerable<string>> VacancyPropertyMappingsLookup { get; }
+    }
+}

--- a/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -65,7 +65,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetEmployerFieldIndicators);
+                    ReviewFieldMappingLookups.GetEmployerFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -65,7 +65,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.EmployerFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetEmployerFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -37,7 +37,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel( vacancy.VacancyReference.Value, 
-                    ReviewFieldIndicatorMapper.GetShortDescriptionReviewFieldIndicators);
+                    ReviewFieldMappingLookups.GetShortDescriptionReviewFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -37,7 +37,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel( vacancy.VacancyReference.Value, 
-                    ReviewFieldIndicatorMapper.ShortDescriptionReviewFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetShortDescriptionReviewFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -49,7 +49,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.TitleFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetTitleFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -49,7 +49,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetTitleFieldIndicators);
+                    ReviewFieldMappingLookups.GetTitleFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -65,7 +65,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetTrainingReviewFieldIndicators);
+                    ReviewFieldMappingLookups.GetTrainingReviewFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -65,7 +65,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.TrainingReviewFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetTrainingReviewFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetWageReviewFieldIndicators);
+                    ReviewFieldMappingLookups.GetWageReviewFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.WageReviewFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetWageReviewFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -37,7 +37,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.AboutEmployerFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetAboutEmployerFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -37,7 +37,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetAboutEmployerFieldIndicators);
+                    ReviewFieldMappingLookups.GetAboutEmployerFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetApplicationProcessFieldIndicators);
+                    ReviewFieldMappingLookups.GetApplicationProcessFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.ApplicationProcessFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetApplicationProcessFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.ConsiderationsFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetConsiderationsFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetConsiderationsFieldIndicators);
+                    ReviewFieldMappingLookups.GetConsiderationsFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/EmployerContactDetailsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/EmployerContactDetailsOrchestrator.cs
@@ -38,7 +38,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetEmployerContactDetailsFieldIndicators);
+                    ReviewFieldMappingLookups.GetEmployerContactDetailsFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/EmployerContactDetailsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/EmployerContactDetailsOrchestrator.cs
@@ -38,7 +38,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.EmployerContactDetailsFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetEmployerContactDetailsFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.QualificationsFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetQualificationsFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetQualificationsFieldIndicators);
+                    ReviewFieldMappingLookups.GetQualificationsFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -57,7 +57,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetSkillsFieldIndicators);
+                    ReviewFieldMappingLookups.GetSkillsFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -57,7 +57,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.SkillsFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetSkillsFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
@@ -39,7 +39,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetTrainingProviderFieldIndicators);
+                    ReviewFieldMappingLookups.GetTrainingProviderFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
@@ -39,7 +39,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.TrainingProviderFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetTrainingProviderFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
@@ -38,7 +38,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.VacancyDescriptionFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetVacancyDescriptionFieldIndicators);
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
@@ -38,7 +38,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value,
-                    ReviewFieldIndicatorMapper.GetVacancyDescriptionFieldIndicators);
+                    ReviewFieldMappingLookups.GetVacancyDescriptionFieldIndicators());
             }
 
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -45,7 +45,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value, 
-                    ReviewFieldIndicatorMapper.PreviewReviewFieldIndicators);
+                    ReviewFieldIndicatorMapper.GetPreviewReviewFieldIndicators);
             }
             
             return vm;

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -45,7 +45,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (vacancy.Status == VacancyStatus.Referred)
             {
                 vm.Review = await _reviewSummaryService.GetReviewSummaryViewModel(vacancy.VacancyReference.Value, 
-                    ReviewFieldIndicatorMapper.GetPreviewReviewFieldIndicators);
+                    ReviewFieldMappingLookups.GetPreviewReviewFieldIndicators());
             }
             
             return vm;

--- a/src/Employer/Employer.Web/Services/IReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/IReviewSummaryService.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Mappings;
 using Esfa.Recruit.Employer.Web.ViewModels;
-using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
 
 namespace Esfa.Recruit.Employer.Web.Services
 {
     public interface IReviewSummaryService
     {
-        Task<ReviewSummaryViewModel> GetReviewSummaryViewModel(long vacancyReference, IEnumerable<ReviewFieldIndicatorViewModel> reviewFieldIndicatorsForPage);
+        Task<ReviewSummaryViewModel> GetReviewSummaryViewModel(long vacancyReference, ReviewFieldMappingLookupsForPage fieldMappingsLookup);
     }
 }

--- a/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
@@ -20,9 +20,12 @@ namespace Esfa.Recruit.Employer.Web.Services
         {
             ReviewSummaryViewModel vm;
             var review = await _client.GetCurrentReferredVacancyReviewAsync(vacancyReference);
+
+            var automatedResult = new RuleSetOutcome();
+
             if (review != null)
             {
-                var fieldIndicators = ReviewFieldIndicatorMapper.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review.ManualQaFieldIndicators).ToList();
+                var fieldIndicators = ReviewFieldIndicatorMapper.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review.ManualQaFieldIndicators, automatedResult).ToList();
 
                 vm = new ReviewSummaryViewModel
                 {
@@ -38,5 +41,49 @@ namespace Esfa.Recruit.Employer.Web.Services
 
             return vm;
         }
+    }
+    public enum RuleSetDecision
+    {
+        Unknown = 0,
+        Refer,
+        Approve,
+        Indeterminate
+    }
+
+    public sealed class RuleSetOutcome
+    {
+        public RuleSetOutcome()
+        {
+            Decision = RuleSetDecision.Refer;
+            TotalScore = 90;
+            RuleOutcomes = new List<RuleOutcome>
+            {
+                new RuleOutcome("ProfanityRule", "Some Narrative", new List<RuleOutcome>{ new RuleOutcome("TrainingDescription", "The Training Desc is well bad", null), new RuleOutcome("VacancyDescription", "The Vacancy Desc is well bad", null)  }),
+                new RuleOutcome("AddressCheckRule", "The Address is well bad", new List<RuleOutcome> { new RuleOutcome("EmployerAddress", "This is a bad address", null) })
+            };
+        }
+
+        public RuleSetDecision Decision { get; private set; }
+        public int TotalScore { get; set; }
+        public IEnumerable<RuleOutcome> RuleOutcomes { get; set; }
+    }
+
+    public sealed class RuleOutcome
+    {
+        public RuleOutcome(string target, string narrative, IEnumerable<RuleOutcome> childOutcomes)
+        {
+            Target = target;
+            Narrative = narrative;
+            Score = 80;
+            Details = childOutcomes ?? new List<RuleOutcome>();
+        }
+
+        public IEnumerable<RuleOutcome> Details { get; set; }
+        public bool HasDetails => Details.Any();
+        public string RuleId { get; }
+        public int Score { get; }
+        public string Narrative { get; }
+        public string Target { get; }
+
     }
 }

--- a/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
@@ -21,11 +21,9 @@ namespace Esfa.Recruit.Employer.Web.Services
             ReviewSummaryViewModel vm;
             var review = await _client.GetCurrentReferredVacancyReviewAsync(vacancyReference);
 
-            var automatedResult = new RuleSetOutcome();
-
             if (review != null)
             {
-                var fieldIndicators = ReviewFieldIndicatorMapper.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review.ManualQaFieldIndicators, automatedResult).ToList();
+                var fieldIndicators = ReviewFieldIndicatorMapper.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review.ManualQaFieldIndicators, review.AutomatedQaOutcome).ToList();
 
                 vm = new ReviewSummaryViewModel
                 {
@@ -41,49 +39,5 @@ namespace Esfa.Recruit.Employer.Web.Services
 
             return vm;
         }
-    }
-    public enum RuleSetDecision
-    {
-        Unknown = 0,
-        Refer,
-        Approve,
-        Indeterminate
-    }
-
-    public sealed class RuleSetOutcome
-    {
-        public RuleSetOutcome()
-        {
-            Decision = RuleSetDecision.Refer;
-            TotalScore = 90;
-            RuleOutcomes = new List<RuleOutcome>
-            {
-                new RuleOutcome("ProfanityRule", "Some Narrative", new List<RuleOutcome>{ new RuleOutcome("TrainingDescription", "The Training Desc is well bad", null), new RuleOutcome("VacancyDescription", "The Vacancy Desc is well bad", null)  }),
-                new RuleOutcome("AddressCheckRule", "The Address is well bad", new List<RuleOutcome> { new RuleOutcome("EmployerAddress", "This is a bad address", null) })
-            };
-        }
-
-        public RuleSetDecision Decision { get; private set; }
-        public int TotalScore { get; set; }
-        public IEnumerable<RuleOutcome> RuleOutcomes { get; set; }
-    }
-
-    public sealed class RuleOutcome
-    {
-        public RuleOutcome(string target, string narrative, IEnumerable<RuleOutcome> childOutcomes)
-        {
-            Target = target;
-            Narrative = narrative;
-            Score = 80;
-            Details = childOutcomes ?? new List<RuleOutcome>();
-        }
-
-        public IEnumerable<RuleOutcome> Details { get; set; }
-        public bool HasDetails => Details.Any();
-        public string RuleId { get; }
-        public int Score { get; }
-        public string Narrative { get; }
-        public string Target { get; }
-
     }
 }

--- a/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Mappings;
 using Esfa.Recruit.Employer.Web.ViewModels;
-using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 
 namespace Esfa.Recruit.Employer.Web.Services
@@ -11,19 +9,22 @@ namespace Esfa.Recruit.Employer.Web.Services
     public class ReviewSummaryService : IReviewSummaryService
     {
         private readonly IEmployerVacancyClient _client;
-        public ReviewSummaryService(IEmployerVacancyClient client)
+        private readonly ReviewFieldIndicatorMapper _fieldMappingsLookup;
+
+        public ReviewSummaryService(IEmployerVacancyClient client, ReviewFieldIndicatorMapper fieldMappingsLookup)
         {
             _client = client;
+            _fieldMappingsLookup = fieldMappingsLookup;
         }
 
-        public async Task<ReviewSummaryViewModel> GetReviewSummaryViewModel(long vacancyReference, IEnumerable<ReviewFieldIndicatorViewModel> reviewFieldIndicatorsForPage)
+        public async Task<ReviewSummaryViewModel> GetReviewSummaryViewModel(long vacancyReference, ReviewFieldMappingLookupsForPage reviewFieldIndicatorsForPage)
         {
             ReviewSummaryViewModel vm;
             var review = await _client.GetCurrentReferredVacancyReviewAsync(vacancyReference);
 
             if (review != null)
             {
-                var fieldIndicators = ReviewFieldIndicatorMapper.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review.ManualQaFieldIndicators, review.AutomatedQaOutcome).ToList();
+                var fieldIndicators = _fieldMappingsLookup.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review).ToList();
 
                 vm = new ReviewSummaryViewModel
                 {

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
@@ -4,15 +4,16 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
 {
     public class ReviewFieldIndicatorViewModel
     {
-        public ReviewFieldIndicatorViewModel(string reviewFieldIdentifier, string anchor, string manualQaText)
+        public ReviewFieldIndicatorViewModel(string reviewFieldIdentifier, string anchor)
         {
             ReviewFieldIdentifier = reviewFieldIdentifier;
             Anchor = anchor;
-            Texts = new List<string> { manualQaText };
+            AutoQaTexts = new List<string>();
         }
 
-        public string ReviewFieldIdentifier { get; set; }
-        public string Anchor { get; set; }
-        public IList<string> Texts { get; set; }
+        public string ReviewFieldIdentifier { get; }
+        public string Anchor { get; }
+        public string ManualQaText { get; set; }
+        public List<string> AutoQaTexts { get; }
     }
 }

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
+﻿using System.Collections.Generic;
+
+namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
 {
     public class ReviewFieldIndicatorViewModel
     {
@@ -6,11 +8,11 @@
         {
             ReviewFieldIdentifier = reviewFieldIdentifier;
             Anchor = anchor;
-            Text = text;
+            Texts = new List<string> { text };
         }
 
         public string ReviewFieldIdentifier { get; set; }
         public string Anchor { get; set; }
-        public string Text { get; set; }
+        public IList<string> Texts { get; set; }
     }
 }

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/ReviewFieldIndicatorViewModel.cs
@@ -4,11 +4,11 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
 {
     public class ReviewFieldIndicatorViewModel
     {
-        public ReviewFieldIndicatorViewModel(string reviewFieldIdentifier, string anchor, string text)
+        public ReviewFieldIndicatorViewModel(string reviewFieldIdentifier, string anchor, string manualQaText)
         {
             ReviewFieldIdentifier = reviewFieldIdentifier;
             Anchor = anchor;
-            Texts = new List<string> { text };
+            Texts = new List<string> { manualQaText };
         }
 
         public string ReviewFieldIdentifier { get; set; }

--- a/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
@@ -10,7 +10,12 @@
     <ul class="list">
         @foreach (var fieldIndicator in Model.FieldIndicators)
         {
-            foreach (var errorText in fieldIndicator.Texts)
+            if (!string.IsNullOrWhiteSpace(fieldIndicator.ManualQaText))
+            {
+                <li><a asp-fragment="@fieldIndicator.Anchor" class="summary-link">@fieldIndicator.ManualQaText</a></li>
+            }
+
+            foreach (var errorText in fieldIndicator.AutoQaTexts)
             {
                 <li><a asp-fragment="@fieldIndicator.Anchor" class="summary-link">@errorText</a></li>
             }

--- a/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
@@ -10,7 +10,10 @@
     <ul class="list">
         @foreach (var fieldIndicator in Model.FieldIndicators)
         {
-            <li><a asp-fragment="@fieldIndicator.Anchor" class="summary-link">@fieldIndicator.Text</a></li>
+            foreach (var errorText in fieldIndicator.Texts)
+            {
+                <li><a asp-fragment="@fieldIndicator.Anchor" class="summary-link">@errorText</a></li>
+            }
         }
     </ul>
 </div>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -382,12 +382,12 @@ public IHtmlContent EditLink(string routeName, VacancyPreviewSectionState state,
         <h2 asp-condition="@Model.ShowGeneralApplicationProcessSectionTitle" class="heading-large">Application process</h2>
         <h2 asp-condition="@Model.HasSpecifiedThroughExternalApplicationMethod" class="heading-large">Employer's application instructions</h2>
         <div asp-condition="@Model.HasNotSpecifiedApplicationMethod" class="@GetSectionClass(Model.ApplicationMethodSectionState)">
-            <h2 class="heading-small">How will the candidates apply for this vacancy?</h2>
+            <h2 id="@Anchors.ApplicationMethod" class="heading-small">How will the candidates apply for this vacancy?</h2>
             <span esfa-validation-message-for="ApplicationMethod" class="error-message"></span>
             @EditLink(RouteNames.ApplicationProcess_Get, Model.ApplicationMethodSectionState, "link-application-method")
         </div>
         <div asp-condition="@Model.HasSpecifiedThroughFaaApplicationMethod" class="@GetSectionClass(Model.ApplicationMethodSectionState)">
-            <p id="@Anchors.ApplicationMethod">
+            <p>
                 <img asp-condition="@Model.ApplicationMethodRequiresEdit" src="/img/red-cross.png"/>
                 Candidates will apply through the <a href="@Model.FindAnApprenticeshipUrl" target="_blank">find an apprenticeship service</a>
             </p>

--- a/src/QA/QA.Web/Views/Review/UnassignReview.cshtml
+++ b/src/QA/QA.Web/Views/Review/UnassignReview.cshtml
@@ -4,7 +4,7 @@
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h1 class="heading-large">Are you sure you want to unassign @Model.AdvisorName from this vacancy?≈
+        <h1 class="heading-large">Are you sure you want to unassign @Model.AdvisorName from this vacancy?
         <span class="heading-secondary">@Model.Title</span>
         </h1>
         <form asp-route=@RouteNames.Vacancy_Review_Unassign_Post class="form-inline">

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyReview.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyReview.cs
@@ -73,6 +73,10 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
             public const string EmployerContact = "EmployerContact";
             public const string DisabilityConfident = "DisabilityConfident";
             public const string EmployerAddress = "EmployerAddress";
+            public const string EmployerAddress1 = "EmployerAddress1";
+            public const string EmployerAddress2 = "EmployerAddress2";
+            public const string EmployerAddress3 = "EmployerAddress3";
+            public const string EmployerAddress4 = "EmployerAddress4";
             public const string EmployerDescription = "EmployerDescription";
             public const string EmployerWebsiteUrl = "EmployerWebsiteUrl";
             public const string ExpectedDuration = "ExpectedDuration";
@@ -91,6 +95,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
             public const string VacancyDescription = "VacancyDescription";
             public const string Wage = "Wage";
             public const string WorkingWeek = "WorkingWeek";
+            public const string WageAdditionalInfo = "WageAdditionalInfo";
         }
     }
 }


### PR DESCRIPTION
- Hooks into same code as manual qa indicators

**Note:** There is an outstanding task to make the field names contained in the messages 'friendly' as you get things like _EmployerAddress_ (all one word) at the moment, along with names that don't match the on screen text. Possible solution is to introduce a ```FieldDisplayName``` property into the ```ReviewFieldIndicatorViewModel``` class and use that to replace values in tokenised message texts added to the ```Texts``` property.