### PR TITLE
Added VacancyReviewAssignationTimeoutMinutes to ARM template

### DIFF
--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -118,6 +118,10 @@
       "metadata": {
         "description" : "StorageConnectionString requires at least the Send claim for the relevant Service Bus endpoint"
       }
+    },
+    "VacancyReviewAssignationTimeoutMinutes": {
+      "type": "int",
+      "defaultValue": 180
     }
   },
   "variables": {
@@ -357,7 +361,11 @@
               {
                 "name": "ExternalLinks:StaffIdamsUrl",
                 "value": "[parameters('ExternalLinks').StaffIdamsUrl]"
-              }
+              },
+              {
+                "name": "VacancyReviewAssignationTimeoutMinutes",
+                "value": "[parameters('VacancyReviewAssignationTimeoutMinutes')]"
+              }              
             ]
           },
           "ConnectionStrings": {

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
@@ -94,6 +94,9 @@
       "value": {
         "StorageConnectionString": ""
       }
-    }
+    },
+    "VacancyReviewAssignationTimeoutMinutes": {
+      "value": ""
+    }    
   }
 }


### PR DESCRIPTION
Test this in AT. Default without setting the value in VSTS is 180. You can override it by passing the parameter in to the resource group deployment.