### PR TITLE
ER-453 - Handling authentication callback on 'Review First Vacancy' POST

### DIFF
--- a/src/QA/QA.Web/Controllers/DashboardController.cs
+++ b/src/QA/QA.Web/Controllers/DashboardController.cs
@@ -36,5 +36,12 @@ namespace Esfa.Recruit.Qa.Web.Controllers
 
             return RedirectToRoute(RouteNames.Vacancy_Review_Get, new {reviewId = vacancyReviewId});
         }
+
+        [HttpGet("next-vacancy", Name = RouteNames.Dashboard_Next_Vacancy_Post)]
+        public IActionResult NextVacancyCallback()
+        {
+            //This GET handles the authentication callback when NextVacancy is POSTed after a session timeout
+            return RedirectToRoute(RouteNames.Dashboard_Index_Get);
+        }
     }
 }


### PR DESCRIPTION
Bug fix. 

If the session has timed out and the 'Review First Vacancy' button is clicked then the authentication callback fails as there isn't a corresponding GET for the POST and it causes an error.  So I've added a GET which will handle the callback.