### PR TITLE
Generate Dashboard if not available

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
@@ -17,6 +17,13 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
         public async Task<DashboardViewModel> GetDashboardViewModelAsync(string employerAccountId)
         {            
             var dashboard = await _vacancyClient.GetDashboardAsync(employerAccountId);
+
+            if (dashboard == null)
+            {
+                await _vacancyClient.GenerateDashboard(employerAccountId);
+                dashboard = await _vacancyClient.GetDashboardAsync(employerAccountId);
+            }
+
             var vm = DashboardMapper.MapFromEmployerDashboard(dashboard);
             return vm;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -14,6 +14,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
     {
         Task<Vacancy> GetVacancyAsync(Guid vacancyId);
         Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, int numberOfPositions, string employerAccountId, VacancyUser user);
+        Task GenerateDashboard(string employerAccountId);
         Task<Guid> CloneVacancyAsync(Guid vacancyId, VacancyUser user);
         Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task UpdatePublishedVacancyAsync(Vacancy vacancy, VacancyUser user);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -16,6 +16,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacanc
 using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Qualifications;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Projections;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
@@ -32,6 +33,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         private readonly IVacancyReviewRepository _vacancyReviewRepository;
         private readonly ICandidateSkillsProvider _candidateSkillsProvider;
         private readonly IVacancyService _vacancyService;
+        private readonly IEmployerDashboardProjectionService _dashboardService;
 
         public VacancyClient(
             IVacancyRepository repository,
@@ -44,7 +46,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             IApplicationReviewRepository applicationReviewRepository,
             IVacancyReviewRepository vacancyReviewRepository,
             ICandidateSkillsProvider candidateSkillsProvider,
-            IVacancyService vacancyService)
+            IVacancyService vacancyService,
+            IEmployerDashboardProjectionService dashboardService)
         {
             _repository = repository;
             _reader = reader;
@@ -57,6 +60,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             _vacancyReviewRepository = vacancyReviewRepository;
             _candidateSkillsProvider = candidateSkillsProvider;
             _vacancyService = vacancyService;
+            _dashboardService = dashboardService;
         }
 
         public Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user)
@@ -151,6 +155,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         public Task<EmployerDashboard> GetDashboardAsync(string employerAccountId)
         {
             return _reader.GetEmployerDashboardAsync(employerAccountId);
+        }
+
+        public Task GenerateDashboard(string employerAccountId)
+        {
+            return _dashboardService.ReBuildDashboardAsync(employerAccountId);
         }
 
         public Task UserSignedInAsync(VacancyUser user)


### PR DESCRIPTION
From the conversation with @mgwilliam and @sachpatel have added some safety around getting dashboard.

- If user navigates to the dashboard page and it's missing then it'll generate.
- Occurrence of this scenario should be limited now we've got the re-generate Dashboard job but this has been added for safety.