### PR TITLE
Reduce initial RU value for un-paritioned collections

### DIFF
--- a/src/Data/CosmosDb/Configuration.json
+++ b/src/Data/CosmosDb/Configuration.json
@@ -5,7 +5,7 @@
             "Collections": [
                 {
                     "CollectionName": "vacancies",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
@@ -16,12 +16,12 @@
                 },
                 {
                     "CollectionName": "referenceData",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
                     "CollectionName": "sequences",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
@@ -32,22 +32,22 @@
                 },
                 {
                     "CollectionName": "users",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
                     "CollectionName": "applicationReviews",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
                     "CollectionName": "configuration",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 },
                 {
                     "CollectionName": "reviews",
-                    "OfferThroughput": 1000,
+                    "OfferThroughput": 400,
                     "StoredProcedures": []
                 }
             ]


### PR DESCRIPTION
Reducing the initial RU values for the collections that don't have a shard key.

We have a story for DevOps to make this configurable but talking to Steve yesterday he doesn't think it's going to be easy to do.

We'll therefore need to manually set the RU's in the environments. For our Dev ones we can just default to the lowest value to keep costs down.