### PR TITLE
ER 746 update banned phrases

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BannedPhrases.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BannedPhrases.json
@@ -1,15 +1,33 @@
 ﻿{
   "_id": "BannedPhrases",
-  "lastUpdatedDate": "2018-09-19T00:00:00.000Z",
+  "lastUpdatedDate": "2018-10-11T00:00:00.000Z",
   "bannedPhrases": [
     "driving licence",
-    "permanant",
+    "permanent",
     "under 16",
     "under sixteen",
     "car",
     "drive",
     "unpaid",
     "young people",
-    "young person"
+    "young person",
+    "Male",
+    "Female",
+    "Man",
+    "woman",
+    "Lady",
+    "Hand",
+    "Eye",
+    "Foot",
+    "Kick",
+    "Run",
+    "Stand",
+    "Physically strong",
+    "Physically active",
+    "Young",
+    "Mature",
+    "Fingers",
+    "Head",
+    "Jump"
   ]
 }

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
@@ -9,9 +9,9 @@ try {
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/QualificationTypes.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/MinimumWageRanges.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BannedPhrases.json" -o true
-    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" -o false # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
+    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
 
-    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRules.json" -o false
+    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRules.json"
 }
 catch {
     throw $_


### PR DESCRIPTION

- This PR also covers ER-711 which is also an earlier update to the banned phrase list.
- Removal of flag in .ps file that was causing reference data to be replaced instead of skipped. Default without flag if to skip if reference data exists.

