### PR TITLE
ER-651 - Persisting selected automated QA rules

### DIFF
--- a/src/QA/QA.Web/Orchestrators/ReviewOrchestrator.cs
+++ b/src/QA/QA.Web/Orchestrators/ReviewOrchestrator.cs
@@ -28,20 +28,15 @@ namespace Esfa.Recruit.Qa.Web.Orchestrators
             await EnsureUserIsAssignedAsync(review, user.UserId);
 
             var manualQaFieldIndicators = _mapper.GetManualQaFieldIndicators(m);
-
-            foreach (var automatedQaOutcomeIndicator in review.AutomatedQaOutcomeIndicators)
-            {
-                automatedQaOutcomeIndicator.IsReferred = m.SelectedAutomatedQaResults
-                    .Contains(automatedQaOutcomeIndicator.RuleOutcomeId.ToString());
-            }
+            var selectedAutomatedQaRuleOutcomeIds = m.SelectedAutomatedQaResults.Select(Guid.Parse).ToList();
 
             if (m.IsRefer)
             {
-                await _vacancyClient.ReferVacancyReviewAsync(m.ReviewId, m.ReviewerComment, manualQaFieldIndicators);
+                await _vacancyClient.ReferVacancyReviewAsync(m.ReviewId, m.ReviewerComment, manualQaFieldIndicators, selectedAutomatedQaRuleOutcomeIds);
             }
             else
             {
-                await _vacancyClient.ApproveVacancyReviewAsync(m.ReviewId, m.ReviewerComment, manualQaFieldIndicators);
+                await _vacancyClient.ApproveVacancyReviewAsync(m.ReviewId, m.ReviewerComment, manualQaFieldIndicators, selectedAutomatedQaRuleOutcomeIds);
             }
 
             var nextVacancyReviewId = await AssignNextVacancyReviewAsync(user);

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApproveVacancyReviewCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApproveVacancyReviewCommandHandler.cs
@@ -44,11 +44,18 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
                 _logger.LogWarning($"Unable to approve review {{reviewId}} due to review having a status of {review.Status}.", message.ReviewId);
                 return;
             }
+            
             review.ManualOutcome = ManualQaOutcome.Approved;
             review.Status = ReviewStatus.Closed;
             review.ClosedDate = _timeProvider.Now;
             review.ManualQaComment = message.ManualQaComment;
             review.ManualQaFieldIndicators = message.ManualQaFieldIndicators;
+
+            foreach (var automatedQaOutcomeIndicator in review.AutomatedQaOutcomeIndicators)
+            {
+                automatedQaOutcomeIndicator.IsReferred = message.SelectedAutomatedQaRuleOutcomeIds
+                    .Contains(automatedQaOutcomeIndicator.RuleOutcomeId);
+            }
 
             Validate(review);
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ReferVacancyReviewCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ReferVacancyReviewCommandHandler.cs
@@ -52,6 +52,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
             review.ManualQaComment = message.ManualQaComment;
             review.ManualQaFieldIndicators = message.ManualQaFieldIndicators;
 
+            foreach (var automatedQaOutcomeIndicator in review.AutomatedQaOutcomeIndicators)
+            {
+                automatedQaOutcomeIndicator.IsReferred = message.SelectedAutomatedQaRuleOutcomeIds
+                    .Contains(automatedQaOutcomeIndicator.RuleOutcomeId);
+            }
+
             Validate(review);
 
             await _reviewRepository.UpdateAsync(review);

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/ApproveVacancyReviewCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/ApproveVacancyReviewCommand.cs
@@ -11,5 +11,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
         public Guid ReviewId { get; internal set; }
         public string ManualQaComment { get; internal set; }
         public List<ManualQaFieldIndicator> ManualQaFieldIndicators { get; internal set; }
+        public List<Guid> SelectedAutomatedQaRuleOutcomeIds { get; internal set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/ReferVacancyReviewCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/ReferVacancyReviewCommand.cs
@@ -11,5 +11,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
         public Guid ReviewId { get; set; }
         public string ManualQaComment { get; internal set; }
         public List<ManualQaFieldIndicator> ManualQaFieldIndicators { get; internal set; }
+        public List<Guid> SelectedAutomatedQaRuleOutcomeIds { get; internal set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
@@ -12,9 +12,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<QaDashboard> GetDashboardAsync();
         Task<Vacancy> GetVacancyAsync(long vacancyReference);
         Task<IApprenticeshipProgramme> GetApprenticeshipProgrammeAsync(string programmeId);
-        Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators);
+        Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> automatedQaRuleOutcomeIds);
         Task<VacancyReview> GetVacancyReviewAsync(Guid reviewId);
-        Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators);
+        Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> automatedQaRuleOutcomeIds);
         Task ApproveReferredReviewAsync(Guid reviewId, string shortDescription, string vacancyDescription, string trainingDescription, string outcomeDescription, string thingsToConsider, string employerDescription);
         Task<Qualifications> GetCandidateQualificationsAsync();
         Task<List<VacancyReview>> GetSearchResultsAsync(string searchTerm);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -58,23 +58,25 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             });
         }
 
-        public Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators)
+        public Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> selectedAutomatedQaRuleOutcomeIds)
         {
             return _messaging.SendCommandAsync(new ApproveVacancyReviewCommand
             {
                 ReviewId = reviewId,
                 ManualQaComment = manualQaComment,
-                ManualQaFieldIndicators = manualQaFieldIndicators
+                ManualQaFieldIndicators = manualQaFieldIndicators,
+                SelectedAutomatedQaRuleOutcomeIds = selectedAutomatedQaRuleOutcomeIds
             });
         }
 
-        public Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators)
+        public Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> selectedAutomatedQaRuleOutcomeIds)
         {
             return _messaging.SendCommandAsync(new ReferVacancyReviewCommand
             {
                 ReviewId = reviewId,
                 ManualQaComment = manualQaComment,
-                ManualQaFieldIndicators = manualQaFieldIndicators
+                ManualQaFieldIndicators = manualQaFieldIndicators,
+                SelectedAutomatedQaRuleOutcomeIds = selectedAutomatedQaRuleOutcomeIds
             });
         }
 


### PR DESCRIPTION
Fixing a gap in the automated QA Web stories.  In QA Web the selected auto QA checkboxes were not being persisted so all the failed QA checks were being shown in Employer Web not just the selected ones.