### PR TITLE
ER-757 - Delete candidate data

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/DomainEventsJob.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/DomainEventsJob.cs
@@ -32,6 +32,11 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents
             await ExecuteHandler(nameof(ApplicationWithdrawnEvent), message);
         }
 
+        public async Task HandleCandidateDeleteEvent([QueueTrigger(QueueNames.CandidateDeleteQueueName, Connection = "EventQueueConnectionString")] string message, TextWriter log)
+        {
+            await ExecuteHandler(nameof(CandidateDeleteEvent), message);
+        }
+
         public async Task HandleVacancyEvent([QueueTrigger(QueueNames.DomainEventsQueueName, Connection = "EventQueueConnectionString")] string message, TextWriter log)
         {
             try

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Application/ApplicationWithdrawnHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Application/ApplicationWithdrawnHandler.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Domain.Events;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Candidate/DeleteCandidateHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Candidate/DeleteCandidateHandler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Candidate
+{
+    public class DeleteCandidateHandler : DomainEventHandler, IDomainEventHandler<CandidateDeleteEvent>
+    {
+        private readonly ILogger<DeleteCandidateHandler> _logger;
+        private readonly IJobsVacancyClient _client;
+
+        public DeleteCandidateHandler(ILogger<DeleteCandidateHandler> logger, IJobsVacancyClient client) : base(logger)
+        {
+            _logger = logger;
+            _client = client;
+        }
+
+        public async Task HandleAsync(string eventPayload)
+        {
+            var @event = DeserializeEvent<CandidateDeleteEvent>(eventPayload);
+
+            try
+            {
+                _logger.LogInformation($"Processing {nameof(CandidateDeleteEvent)} for candidate: {{CandidateId}}", @event.CandidateId);
+
+                await _client.HardDeleteApplicationReviewsForCandidate(@event.CandidateId);
+                
+                _logger.LogInformation($"Finished Processing {nameof(CandidateDeleteEvent)} for vacancy: candidate: {{CandidateId}}", @event.CandidateId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unable to process {eventBody}", @event);
+                throw;
+            }
+
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -6,6 +6,7 @@ using Esfa.Recruit.Vacancies.Jobs.ApprenticeshipProgrammes;
 using Esfa.Recruit.Vacancies.Jobs.BankHoliday;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Application;
+using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Candidate;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.VacancyReview;
 using Esfa.Recruit.Vacancies.Jobs.EmployerDashboardGenerator;
@@ -170,7 +171,10 @@ namespace Esfa.Recruit.Vacancies.Jobs
 
             // Employer
             services.AddScoped<IDomainEventHandler<IEvent>, DomainEvents.Handlers.Employer.SetupEmployerHandler>();
-            
+
+            //Candidate
+            services.AddScoped<IDomainEventHandler<IEvent>, DeleteCandidateHandler>();
+
 
             return services;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteApplicationReviewsCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteApplicationReviewsCommandHandler.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Services;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
+{
+    public class DeleteApplicationReviewsCommandHandler : IRequestHandler<DeleteApplicationReviewsCommand>
+    {
+        private readonly ILogger<DeleteApplicationReviewsCommandHandler> _logger;
+        private readonly IApplicationReviewRepository _applicationReviewRepository;
+        private readonly IMessaging _messaging;
+
+        public DeleteApplicationReviewsCommandHandler(
+            ILogger<DeleteApplicationReviewsCommandHandler> logger,
+            IApplicationReviewRepository applicationReviewRepository,
+            IMessaging messaging)
+        {
+            _logger = logger;
+            _applicationReviewRepository = applicationReviewRepository;
+            _messaging = messaging;
+        }
+
+        public async Task Handle(DeleteApplicationReviewsCommand message, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Deleting all application reviews for candidateId:{candidateId}",message.CandidateId);
+
+            var candidateApplicationReviews = await _applicationReviewRepository.GetForCandidateAsync(message.CandidateId);
+
+            foreach (var applicationReview in candidateApplicationReviews)
+            {
+                await _applicationReviewRepository.HardDelete(applicationReview.Id);
+
+                await _messaging.PublishEvent(new ApplicationReviewDeletedEvent
+                {
+                    EmployerAccountId = applicationReview.EmployerAccountId,
+                    VacancyReference = applicationReview.VacancyReference
+                });
+
+                _logger.LogInformation("Deleted application review id:{applicationReviewId} for candidateId:{candidateId}", applicationReview.Id, message.CandidateId);
+            }
+
+            _logger.LogInformation($"Deleted {candidateApplicationReviews.Count} application reviews for candidateId:{{candidateId}}", message.CandidateId);
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/DeleteApplicationReviewsCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/DeleteApplicationReviewsCommand.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Commands
+{
+    public class DeleteApplicationReviewsCommand : ICommand, IRequest
+    {
+        public Guid CandidateId { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/ApplicationReviewDeletedEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/ApplicationReviewDeletedEvent.cs
@@ -1,0 +1,12 @@
+﻿using Esfa.Recruit.Vacancies.Client.Domain.Events.Interfaces;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    public class ApplicationReviewDeletedEvent : EventBase, INotification, IApplicationReviewEvent
+    {
+        public string EmployerAccountId { get; set; }
+        public long VacancyReference { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/CandidateDeleteEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/CandidateDeleteEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    // Note: This is an externally published event.
+    public class CandidateDeleteEvent : EventBase, INotification
+    {
+        public Guid CandidateId { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IApplicationReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IApplicationReviewRepository.cs
@@ -12,6 +12,8 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
         Task<ApplicationReview> GetAsync(long vacancyReference, Guid candidateId);
         Task UpdateAsync(ApplicationReview applicationReview);
         Task<List<T>> GetForEmployerAsync<T>(string employerAccountId);
-        Task<List<T>> GetForVacancyAsync<T>(long vacancyReference);
+        Task<List<ApplicationReview>> GetForVacancyAsync(long vacancyReference);
+        Task<List<ApplicationReview>> GetForCandidateAsync(Guid candidateId);
+        Task HardDelete(Guid applicationReviewId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
@@ -21,5 +21,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task CreateApplicationReviewAsync(Domain.Entities.Application application);
         Task PerformRulesCheckAsync(Guid reviewId);
         Task WithdrawApplicationAsync(long vacancyReference, Guid candidateId);
+        Task HardDeleteApplicationReviewsForCandidate(Guid candidateId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -344,6 +344,14 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             });
         }
 
+        public Task HardDeleteApplicationReviewsForCandidate(Guid candidateId)
+        {
+            return _messaging.SendCommandAsync(new DeleteApplicationReviewsCommand
+            {
+                CandidateId = candidateId
+            });
+        }
+
         public Task PerformRulesCheckAsync(Guid reviewId)
         {
             return _vacancyService.PerformRulesCheckAsync(reviewId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateEmployerDashboardOnChange.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateEmployerDashboardOnChange.cs
@@ -17,6 +17,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                                             INotificationHandler<VacancyClosedEvent>,
                                             INotificationHandler<ApplicationReviewCreatedEvent>,
                                             INotificationHandler<ApplicationReviewWithdrawnEvent>,
+                                            INotificationHandler<ApplicationReviewDeletedEvent>,
                                             INotificationHandler<ApplicationReviewedEvent>,
                                             INotificationHandler<SetupEmployerEvent>,
                                             INotificationHandler<VacancyReferredEvent>
@@ -73,6 +74,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
         }
 
         public Task Handle(ApplicationReviewWithdrawnEvent notification, CancellationToken cancellationToken)
+        {
+            return Handle(notification);
+        }
+
+        public Task Handle(ApplicationReviewDeletedEvent notification, CancellationToken cancellationToken)
         {
             return Handle(notification);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateVacancyApplicationsOnApplicationReviewChange.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateVacancyApplicationsOnApplicationReviewChange.cs
@@ -15,6 +15,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
     public class UpdateVacancyApplicationsOnApplicationReviewChange :
         INotificationHandler<ApplicationReviewCreatedEvent>,
         INotificationHandler<ApplicationReviewWithdrawnEvent>,
+        INotificationHandler<ApplicationReviewDeletedEvent>,
         INotificationHandler<ApplicationReviewedEvent>
     {
         private readonly IVacancyRepository _vacancyRepository;
@@ -45,12 +46,17 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
             return Handle(notification);
         }
 
+        public Task Handle(ApplicationReviewDeletedEvent notification, CancellationToken cancellationToken)
+        {
+            return Handle(notification);
+        }
+
         private async Task Handle(IApplicationReviewEvent notification)
         {
             _logger.LogInformation("Handling {notificationType} for vacancyReference: {vacancyReference}", notification.GetType().Name, notification?.VacancyReference);
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(notification.VacancyReference);
-            var vacancyApplicationReviews = await _applicationReviewRepository.GetForVacancyAsync<ApplicationReview>(vacancy.VacancyReference.Value);
+            var vacancyApplicationReviews = await _applicationReviewRepository.GetForVacancyAsync(vacancy.VacancyReference.Value);
 
             var vacancyApplications = new VacancyApplications
             {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventStore/QueueNames.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventStore/QueueNames.cs
@@ -8,5 +8,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventStore
         public const string GeneratePublishedVacanciesQueueName = "generate-published-vacancies-queue";
         public const string ApplicationSubmittedQueueName = "application-submitted-queue";
         public const string ApplicationWithdrawnQueueName = "application-withdrawn-queue";
+        public const string CandidateDeleteQueueName = "candidate-delete-queue";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
@@ -102,7 +102,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
             var filter = Builders<ApplicationReview>.Filter.Eq(Id, applicationReviewId);
             var collection = GetCollection<ApplicationReview>();
 
-            var result = await RetryPolicy.ExecuteAsync(context => collection.DeleteManyAsync(filter),
+            var result = await RetryPolicy.ExecuteAsync(context => collection.DeleteOneAsync(filter),
                 new Context(nameof(GetForVacancyAsync)));
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
@@ -16,6 +16,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
     {
         private const string EmployerAccountId = "employerAccountId";
         private const string VacancyReference = "vacancyReference";
+        private const string CandidateId = "candidateId";
         private const string Id = "_id";
 
         public MongoDbApplicationReviewRepository(ILogger<MongoDbApplicationReviewRepository> logger, IOptions<MongoDbConnectionDetails> details)
@@ -74,15 +75,35 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
             return await result.ToListAsync();
         }
 
-        public async Task<List<T>> GetForVacancyAsync<T>(long vacancyReference)
+        public async Task<List<ApplicationReview>> GetForVacancyAsync(long vacancyReference)
         {
-            var filter = Builders<BsonDocument>.Filter.Eq(VacancyReference, vacancyReference);
-            var collection = GetCollection<BsonDocument>();
+            var filter = Builders<ApplicationReview>.Filter.Eq(VacancyReference, vacancyReference);
+            var collection = GetCollection<ApplicationReview>();
 
-            var result = await RetryPolicy.ExecuteAsync(context => collection.FindAsync<T>(filter),
+            var result = await RetryPolicy.ExecuteAsync(context => collection.FindAsync<ApplicationReview>(filter),
                 new Context(nameof(GetForVacancyAsync)));
 
             return await result.ToListAsync();
+        }
+
+        public async Task<List<ApplicationReview>> GetForCandidateAsync(Guid candidateId)
+        {
+            var filter = Builders<ApplicationReview>.Filter.Eq(CandidateId, candidateId);
+            var collection = GetCollection<ApplicationReview>();
+
+            var result = await RetryPolicy.ExecuteAsync(context => collection.FindAsync<ApplicationReview>(filter),
+                new Context(nameof(GetForVacancyAsync)));
+
+            return await result.ToListAsync();
+        }
+
+        public async Task HardDelete(Guid applicationReviewId)
+        {
+            var filter = Builders<ApplicationReview>.Filter.Eq(Id, applicationReviewId);
+            var collection = GetCollection<ApplicationReview>();
+
+            var result = await RetryPolicy.ExecuteAsync(context => collection.DeleteManyAsync(filter),
+                new Context(nameof(GetForVacancyAsync)));
         }
     }
 }


### PR DESCRIPTION
Hard deletes all data regarding a candidate.

Is triggered by a candidate deleting themselves from FAA.
FAA calls the legacy client which drops a message onto the `candidate-delete-queue` queue.

For each applicationReview deleted a `ApplicationReviewDeletedEvent` event is raised which rebuilds the relevant projections.