### PR TITLE
Fixes issue with recreate method in mongo query store

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
@@ -14,7 +14,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         Task UpsertAsync<T>(T item) where T : QueryProjectionBase;
 
-        Task RecreateAsync<T>(IList<T> items) where T : QueryProjectionBase;
+        Task RecreateAsync<T>(string typeName, IList<T> items) where T : QueryProjectionBase;
 
         Task DeleteAsync<T>(string typeName, string key) where T : QueryProjectionBase;
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
@@ -81,14 +81,16 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return RetryPolicy.ExecuteAsync(context => collection.ReplaceOneAsync(filter, item, new UpdateOptions { IsUpsert = true }), new Context(nameof(IQueryStore.UpsertAsync)));
         }
 
-        async Task IQueryStore.RecreateAsync<T>(IList<T> items)
+        async Task IQueryStore.RecreateAsync<T>(string typeName, IList<T> items)
         {
             var collection = GetCollection<T>();
 
-            var filter = Builders<T>.Filter.Eq(d => d.ViewType, items.First().ViewType);
+            var filter = Builders<T>.Filter.Eq(d => d.ViewType, typeName);
 
             await RetryPolicy.ExecuteAsync(context => collection.DeleteManyAsync(filter), new Context(nameof(IQueryStore.RecreateAsync)));
 
+            if (items.Count == 0) return;
+            
             await RetryPolicy.ExecuteAsync(context => collection.InsertManyAsync(items), new Context(nameof(IQueryStore.RecreateAsync)));
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -85,12 +85,12 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         public Task RecreateLiveVacancies(IEnumerable<LiveVacancy> liveVacancies)
         {
-            return _queryStore.RecreateAsync(liveVacancies.ToList());
+            return _queryStore.RecreateAsync(QueryViewType.LiveVacancy.TypeName, liveVacancies.ToList());
         }
 
         public Task RecreateClosedVacancies(IEnumerable<ClosedVacancy> closedVacancies)
         {
-            return _queryStore.RecreateAsync(closedVacancies.ToList());
+            return _queryStore.RecreateAsync(QueryViewType.ClosedVacancy.TypeName, closedVacancies.ToList());
         }
         
         public Task UpdateVacancyApplicationsAsync(VacancyApplications vacancyApplications)


### PR DESCRIPTION
Recreate method in Mongo Query Store didn't account for no new items. It is required that we still delete any existing items. The item type cannot be derived from items in case there are no new ones, hence added typename as parameter.  