### PR TITLE
ER-721 Hides incomplete fields message when editing rejected vacancy

### DIFF
--- a/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
@@ -19,26 +19,21 @@ namespace Esfa.Recruit.Employer.Web.Services
 
         public async Task<ReviewSummaryViewModel> GetReviewSummaryViewModel(long vacancyReference, ReviewFieldMappingLookupsForPage reviewFieldIndicatorsForPage)
         {
-            ReviewSummaryViewModel vm;
             var review = await _client.GetCurrentReferredVacancyReviewAsync(vacancyReference);
 
             if (review != null)
             {
                 var fieldIndicators = _fieldMappingsLookup.MapFromFieldIndicators(reviewFieldIndicatorsForPage, review).ToList();
 
-                vm = new ReviewSummaryViewModel
+                return new ReviewSummaryViewModel
                 {
                     HasBeenReviewed = true,
                     ReviewerComments = review.ManualQaComment,
                     FieldIndicators = fieldIndicators
                 };
-            }
-            else
-            {
-                vm = new ReviewSummaryViewModel { HasBeenReviewed = false };
-            }
+            }            
 
-            return vm;
+            return new ReviewSummaryViewModel();
         }
     }
 }

--- a/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
+++ b/src/Employer/Employer.Web/Services/ReviewSummaryService.cs
@@ -28,14 +28,14 @@ namespace Esfa.Recruit.Employer.Web.Services
 
                 vm = new ReviewSummaryViewModel
                 {
-                    CanDisplayReviewHeader = true,
+                    HasBeenReviewed = true,
                     ReviewerComments = review.ManualQaComment,
                     FieldIndicators = fieldIndicators
                 };
             }
             else
             {
-                vm = new ReviewSummaryViewModel { CanDisplayReviewHeader = false };
+                vm = new ReviewSummaryViewModel { HasBeenReviewed = false };
             }
 
             return vm;

--- a/src/Employer/Employer.Web/ViewModels/ReviewSummaryViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/ReviewSummaryViewModel.cs
@@ -5,7 +5,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels
 {
     public class ReviewSummaryViewModel
     {
-        public bool CanDisplayReviewHeader { get; internal set; }
+        public bool HasBeenReviewed { get; internal set; }
         public string ReviewerComments { get; internal set; }
         public IEnumerable<ReviewFieldIndicatorViewModel> FieldIndicators { get; internal set; } = new List<ReviewFieldIndicatorViewModel>();
     }

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
@@ -64,11 +64,11 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
                                                     || HasIncompleteEmployerWebsiteUrlSection
                                                     || HasIncompleteContactSection;
 
-        public bool HasIncompleteSections => HasIncompleteMandatorySections || HasIncompleteOptionalSections;
+        public bool ShowIncompleteSections => (HasIncompleteMandatorySections || HasIncompleteOptionalSections) && !Review.HasBeenReviewed;
 
         public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
 
-        public string SubmitButtonText => Review.CanDisplayReviewHeader ? "Resubmit vacancy" : "Submit vacancy";
+        public string SubmitButtonText => Review.HasBeenReviewed ? "Resubmit vacancy" : "Submit vacancy";
 
         public bool ApplicationInstructionsRequiresEdit => IsEditRequired(VacancyReview.FieldIdentifiers.ApplicationInstructions);
         public bool ApplicationMethodRequiresEdit => IsEditRequired(VacancyReview.FieldIdentifiers.ApplicationMethod);

--- a/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_ReviewSummary.cshtml
@@ -1,6 +1,6 @@
 ﻿@model ReviewSummaryViewModel
 
-<div asp-condition="@Model.CanDisplayReviewHeader" class="error-summary no-top-margin review-summary" role="alert" tabindex="-1">
+<div asp-show="@Model.HasBeenReviewed" class="error-summary no-top-margin review-summary" role="alert" tabindex="-1">
 
     <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
         <img src="/img/red-cross.png" class="red-cross-logo" alt="red cross"> Edits needed

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -36,7 +36,7 @@ public IHtmlContent EditLink(string routeName, VacancyPreviewSectionState state,
     <div class="column-full">
         <h1 asp-condition="@Model.CanShowDraftHeader" class="heading-xlarge small-bottom-margin">Complete your vacancy</h1>
         <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }' />
-        <div asp-condition="@Model.HasIncompleteSections" class="info-summary no-top-margin" role="alert">
+        <div asp-show="@Model.ShowIncompleteSections" class="info-summary no-top-margin" role="alert">
             <div asp-condition="@Model.HasIncompleteMandatorySections">
                 <p>You need to complete these sections:</p>
                 <ul class="list">
@@ -60,7 +60,7 @@ public IHtmlContent EditLink(string routeName, VacancyPreviewSectionState state,
     </div>
 </div>
 
-<div asp-condition="@Model.Review.CanDisplayReviewHeader" class="grid-row">
+<div asp-condition="@Model.Review.HasBeenReviewed" class="grid-row">
     <div class="column-full">
         <partial name="@PartialNames.ReviewSummary" for="Review" />
     </div>

--- a/src/Shared/Recruit.Shared.Web/TagHelpers/ConditionTagHelper.cs
+++ b/src/Shared/Recruit.Shared.Web/TagHelpers/ConditionTagHelper.cs
@@ -15,4 +15,32 @@ namespace Esfa.Recruit.Shared.Web.TagHelpers
             }
         }
     }
+
+    [HtmlTargetElement(Attributes = "asp-hide")]
+    public class HideTagHelper : TagHelper
+    {
+        public bool AspHide { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (AspHide)
+            {
+                output.SuppressOutput();
+            }
+        }
+    }
+
+    [HtmlTargetElement(Attributes = "asp-show")]
+    public class ShowTagHelper : TagHelper
+    {
+        public bool AspShow { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (!AspShow)
+            {
+                output.SuppressOutput();
+            }
+        }
+    }
 }


### PR DESCRIPTION
I have introduced couple of new tag helpers asp-show and asp-hide to replace asp-condition. These read a lot better on the page and also we can avoid creating negating booleans. I haven't applied it everywhere as it is a big undertaking, a tech debt task is open to address this refactoring. 