### PR TITLE
ER-663 blocked employers

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Console.RecruitSeedDataWriter.csproj
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Console.RecruitSeedDataWriter.csproj
@@ -14,6 +14,9 @@
     <Folder Include="Sequence\" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Data\BlockedEmployers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Data\CandidateSkills.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BlockedEmployers.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BlockedEmployers.json
@@ -1,0 +1,4 @@
+{
+  "_id": "BlockedEmployers",
+  "employerAccountIds": []
+}

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
@@ -10,7 +10,8 @@ try {
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/MinimumWageRanges.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BannedPhrases.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
-
+	
+	& dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/BlockedEmployers.json"
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRules.json"
 }
 catch {

--- a/src/Employer/Employer.Web/Attributes/CheckEmployerBlockedAttribute.cs
+++ b/src/Employer/Employer.Web/Attributes/CheckEmployerBlockedAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Esfa.Recruit.Employer.Web.Caching;
+using Esfa.Recruit.Employer.Web.Filters;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Esfa.Recruit.Employer.Web.Attributes
+{
+    public class CheckEmployerBlockedAttribute : Attribute, IFilterFactory
+    {
+        public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+        {
+            var blockedEmployersProvider = (IBlockedEmployersProvider)serviceProvider.GetService(typeof(IBlockedEmployersProvider));
+            var cache = (ICache)serviceProvider.GetService(typeof(ICache));
+
+            return new CheckEmployerBlockedFilter(blockedEmployersProvider, cache);
+        }
+
+        public bool IsReusable => false;
+    }
+}

--- a/src/Employer/Employer.Web/Caching/Cache.cs
+++ b/src/Employer/Employer.Web/Caching/Cache.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Esfa.Recruit.Employer.Web.Caching
+{
+    public class Cache : ICache
+    {
+        private readonly IMemoryCache _memoryCache;
+
+        public Cache(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+        }
+
+        public Task<T> CacheAsideAsync<T>(string key, DateTime absoluteExpiration, Func<Task<T>> objectToCache)
+        {
+            return _memoryCache.GetOrCreate(key, entry =>
+            {
+                entry.AbsoluteExpiration = absoluteExpiration;
+
+                return objectToCache();
+            });
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Caching/Cache.cs
+++ b/src/Employer/Employer.Web/Caching/Cache.cs
@@ -15,7 +15,7 @@ namespace Esfa.Recruit.Employer.Web.Caching
 
         public Task<T> CacheAsideAsync<T>(string key, DateTime absoluteExpiration, Func<Task<T>> objectToCache)
         {
-            return _memoryCache.GetOrCreate(key, entry =>
+            return _memoryCache.GetOrCreateAsync(key, entry =>
             {
                 entry.AbsoluteExpiration = absoluteExpiration;
 

--- a/src/Employer/Employer.Web/Caching/ICache.cs
+++ b/src/Employer/Employer.Web/Caching/ICache.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Employer.Web.Caching
+{
+    public interface ICache
+    {
+        Task<T> CacheAsideAsync<T>(string key, DateTime absoluteExpiration, Func<Task<T>> objectToCache);
+    }
+}

--- a/src/Employer/Employer.Web/Configuration/CacheKeys.cs
+++ b/src/Employer/Employer.Web/Configuration/CacheKeys.cs
@@ -1,0 +1,7 @@
+﻿namespace Esfa.Recruit.Employer.Web.Configuration
+{
+    public class CacheKeys
+    {
+        public const string BlockedEmployersCacheKey = "blockedEmployers";
+    }
+}

--- a/src/Employer/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer/Employer.Web/Configuration/IoC.cs
@@ -1,4 +1,5 @@
-﻿using Esfa.Recruit.Employer.Web.Configuration.Routing;
+﻿using Esfa.Recruit.Employer.Web.Caching;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Mappings;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
@@ -30,6 +31,8 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             services.Configure<GoogleAnalyticsConfiguration>(configuration.GetSection("GoogleAnalytics"));
             services.Configure<PostcodeAnywhereConfiguration>(configuration.GetSection("PostcodeAnywhere"));
             services.Configure<FaaConfiguration>(configuration.GetSection("FaaConfiguration"));
+
+            services.AddTransient<ICache, Cache>();
 
             services.AddFeatureToggle();
 

--- a/src/Employer/Employer.Web/Configuration/ViewNames.cs
+++ b/src/Employer/Employer.Web/Configuration/ViewNames.cs
@@ -19,5 +19,6 @@
 
         public const string AccessDenied = "AccessDenied";
         public const string PageNotFound = "PageNotFound";
+        public const string BlockedEmployer = "BlockedEmployer";
     }
 }

--- a/src/Employer/Employer.Web/Controllers/ApplicationReviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/ApplicationReviewController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Attributes;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
@@ -18,6 +19,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             _orchestrator = orchestrator;
         }
 
+        [CheckEmployerBlocked]
         [HttpGet("", Name = RouteNames.ApplicationReview_Get)]
         public async Task<IActionResult> ApplicationReview(ApplicationReviewRouteModel rm)
         {
@@ -25,6 +27,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             return View(vm);
         }
 
+        [CheckEmployerBlocked]
         [HttpPost("", Name = RouteNames.ApplicationReview_Post)]
         public async Task<IActionResult> ApplicationReview(ApplicationReviewEditModel m)
         {

--- a/src/Employer/Employer.Web/Controllers/CreateVacancyOptionsController.cs
+++ b/src/Employer/Employer.Web/Controllers/CreateVacancyOptionsController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Attributes;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Orchestrators;
@@ -18,6 +19,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             _orchestrator = orchestrator;
         }
 
+        [CheckEmployerBlocked]
         [HttpGet("create-options", Name = RouteNames.CreateVacancyOptions_Get)]
         public async Task<IActionResult> Options([FromRoute]string employerAccountId)
         {

--- a/src/Employer/Employer.Web/Controllers/DashboardController.cs
+++ b/src/Employer/Employer.Web/Controllers/DashboardController.cs
@@ -3,6 +3,7 @@ using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Attributes;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
 {
@@ -16,6 +17,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             _orchestrator = orchestrator;
         }
 
+        [CheckEmployerBlocked]
         [HttpGet("", Name = RouteNames.Dashboard_Index_Get)]
         public async Task<IActionResult> Dashboard([FromRoute]string employerAccountId)
         {

--- a/src/Employer/Employer.Web/Controllers/LogoutController.cs
+++ b/src/Employer/Employer.Web/Controllers/LogoutController.cs
@@ -2,9 +2,9 @@
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Extensions;
 using Microsoft.AspNetCore.Hosting;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
@@ -24,9 +24,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpGet, Route("logout", Name = RouteNames.Logout_Get)]
         public async Task<IActionResult> Logout()
         {
-            await HttpContext.SignOutAsync("Cookies");
-            await HttpContext.SignOutAsync("oidc");
-
+            await HttpContext.SignOutEmployerWebAsync();
+            
             return Redirect(_externalLinks.ManageApprenticeshipSiteUrl);
         }
     }

--- a/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Attributes;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.RouteModel;
@@ -26,6 +27,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             _hostingEnvironment = hostingEnvironment;
         }
 
+        [CheckEmployerBlocked]
         [HttpGet("manage", Name = RouteNames.VacancyManage_Get)]
         public async Task<IActionResult> ManageVacancy(VacancyRouteModel vrm)
         {
@@ -44,6 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             return View(viewModel);
         }
 
+        [CheckEmployerBlocked]
         [HttpGet("edit", Name = RouteNames.VacancyEdit_Get)]
         public async Task<IActionResult> EditVacancy(VacancyRouteModel vrm)
         {

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Attributes;
 using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
 using Esfa.Recruit.Employer.Web.RouteModel;
@@ -35,7 +36,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
             return View(viewModel);
         }
-        
+
+        [CheckEmployerBlocked]
         [HttpPost("preview", Name = RouteNames.Preview_Submit_Post)]
         public async Task<IActionResult> Submit(SubmitEditModel m)
         {

--- a/src/Employer/Employer.Web/Exceptions/BlockedEmployerException.cs
+++ b/src/Employer/Employer.Web/Exceptions/BlockedEmployerException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Esfa.Recruit.Employer.Web.Exceptions
+{
+    public class BlockedEmployerException : Exception
+    {
+        public BlockedEmployerException(string message) : base(message){}
+    }
+}

--- a/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
@@ -6,7 +6,7 @@ namespace Esfa.Recruit.Employer.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext, bool signOutOidc = true)
+        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext)
         {
             await httpContext.SignOutAsync("Cookies");
             await httpContext.SignOutAsync("oidc");

--- a/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Esfa.Recruit.Employer.Web.Extensions
+{
+    public static class HttpContextExtensions
+    {
+        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext, bool signOutOidc = true)
+        {
+            await httpContext.SignOutAsync("Cookies");
+            await httpContext.SignOutAsync("oidc");
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
+++ b/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Caching;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Exceptions;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Esfa.Recruit.Employer.Web.Filters
+{
+    public class CheckEmployerBlockedFilter : IAsyncActionFilter
+    {
+        private const string BlockedEmployersCacheKey = "blockedEmployers";
+
+        private readonly IBlockedEmployersProvider _blockedEmployersProvider;
+        private readonly ICache _cache;
+
+        private DateTime CacheAbsoluteExpiryTime => DateTime.Today.ToUniversalTime().AddDays(1);
+
+        public CheckEmployerBlockedFilter(IBlockedEmployersProvider blockedEmployersProvider, ICache cache)
+        {
+            _blockedEmployersProvider = blockedEmployersProvider;
+            _cache = cache;
+        }
+
+        public async Task OnActionExecutionAsync(
+            ActionExecutingContext context,
+            ActionExecutionDelegate next)
+        {
+            var blockedEmployerAccountIds = await _cache.CacheAsideAsync(
+                BlockedEmployersCacheKey, 
+                CacheAbsoluteExpiryTime, 
+                () =>  _blockedEmployersProvider.GetBlockedEmployerAccountIdsAsync());
+
+            var accountIdFromUrl = context.RouteData.Values[RouteValues.EmployerAccountId].ToString().ToUpper();
+
+            if (blockedEmployerAccountIds.Contains(accountIdFromUrl))
+            {
+                throw new BlockedEmployerException($"Employer account '{accountIdFromUrl}' is blocked");
+            }
+
+            await next();
+        }
+    }
+
+}

--- a/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
+++ b/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Caching;
+using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
@@ -10,8 +11,6 @@ namespace Esfa.Recruit.Employer.Web.Filters
 {
     public class CheckEmployerBlockedFilter : IAsyncActionFilter
     {
-        private const string BlockedEmployersCacheKey = "blockedEmployers";
-
         private readonly IBlockedEmployersProvider _blockedEmployersProvider;
         private readonly ICache _cache;
 
@@ -28,7 +27,7 @@ namespace Esfa.Recruit.Employer.Web.Filters
             ActionExecutionDelegate next)
         {
             var blockedEmployerAccountIds = await _cache.CacheAsideAsync(
-                BlockedEmployersCacheKey, 
+                CacheKeys.BlockedEmployersCacheKey, 
                 CacheAbsoluteExpiryTime, 
                 () =>  _blockedEmployersProvider.GetBlockedEmployerAccountIdsAsync());
 

--- a/src/Employer/Employer.Web/Startup.Configure.cs
+++ b/src/Employer/Employer.Web/Startup.Configure.cs
@@ -91,7 +91,7 @@ namespace Esfa.Recruit.Employer.Web
             app.UseXDownloadOptions();
             app.UseXRobotsTag(options => options.NoIndex().NoFollow());
 
-            app.UseNoCacheHttpHeaders(); // Affectively forces the browser to always request dynamic pages
+            app.UseNoCacheHttpHeaders(); // Effectively forces the browser to always request dynamic pages
 
             app.UseMvc(routes =>
             {

--- a/src/Employer/Employer.Web/Startup.ConfigureServices.cs
+++ b/src/Employer/Employer.Web/Startup.ConfigureServices.cs
@@ -49,6 +49,8 @@ namespace Esfa.Recruit.Employer.Web
                 o.ViewLocationFormats.Add("/Views/Part2/{1}/{0}" + RazorViewEngine.ViewExtension);
             });
 
+            services.AddMemoryCache();
+
             services.AddMvcService(_hostingEnvironment, _isAuthEnabled, _loggerFactory);
 
             services.AddApplicationInsightsTelemetry(_configuration);

--- a/src/Employer/Employer.Web/Views/Error/BlockedEmployer.cshtml
+++ b/src/Employer/Employer.Web/Views/Error/BlockedEmployer.cshtml
@@ -1,0 +1,22 @@
+﻿@{
+    ViewBag.Title = "Blocked employer";
+    ViewBag.ShowNav = false;
+}
+<div id="js-breadcrumbs" class="breadcrumbs">
+    <a asp-route="@RouteNames.Dashboard_Account_Home" asp-route-employerAccountId="@ViewBag.EmployerAccountId" class="link-back">Back</a>
+</div>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <header class="page-header group">
+            <h1 class="heading-xlarge small-bottom-margin">You don't have access to this section</h1>
+        </header>
+        <div class="article-container">
+            <article role="article" class="group">
+                <div class="inner">
+                    <p>Call us on 0800 015 0400 to resolve this issue.</p>
+                </div>
+            </article>
+        </div>
+    </div>
+</div>

--- a/src/Shared/Recruit.Vacancies.Client/Application/Configuration/BlockedEmployers.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Configuration/BlockedEmployers.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Configuration
+{
+    public class BlockedEmployers
+    {
+        public string Id { get; set; }
+        public List<string> EmployerAccountIds { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Providers/IBlockedEmployersProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Providers/IBlockedEmployersProvider.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Providers
+{
+    public interface IBlockedEmployersProvider
+    {
+        Task<List<string>> GetBlockedEmployerAccountIdsAsync();
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/BlockedEmployers/BlockedEmployersProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/BlockedEmployers/BlockedEmployersProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Configuration;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.BlockedEmployers
+{
+    public class BlockedEmployersProvider : IBlockedEmployersProvider
+    {
+        private readonly IConfigurationReader _configurationReader;
+
+        public BlockedEmployersProvider(IConfigurationReader configurationReader)
+        {
+            _configurationReader = configurationReader;
+        }
+
+        public async Task<List<string>> GetBlockedEmployerAccountIdsAsync()
+        {
+            var blockedEmployers = await _configurationReader.GetAsync<Application.Configuration.BlockedEmployers>("BlockedEmployers");
+
+            return blockedEmployers.EmployerAccountIds.Select(s => s.ToUpper()).ToList();
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Wages;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.SequenceStore;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.BlockedEmployers;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.FAA;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Geocode;
@@ -124,6 +125,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<ICandidateSkillsProvider, CandidateSkillsProvider>();
             services.AddTransient<IProfanityListProvider, ProfanityListProvider>();
             services.AddTransient<IBannedPhrasesProvider, BannedPhrasesProvider>();
+            services.AddTransient<IBlockedEmployersProvider, BlockedEmployersProvider>();
 
             // Reference Data update services
             services.AddTransient<IApprenticeshipProgrammeUpdateService, ApprenticeshipProgrammeUpdateService>();


### PR DESCRIPTION
- Added In-Memory cache and our own `Cache.cs` abstraction wrapper around it
- As this 'blocking' is not part of normal system behaviour and more of a authorisation concern I have implemented as an MVC attribute/filter and have kept it outside of the Recruit Client.
- Added seeding json to populate `configuration` collection
- To add an employer account id just add a string to the array
`{
  "_id": "BlockedEmployers",
  "employerAccountIds": ["AAAAAA", "BBBBB"]
}`
- The blocked employers list will be cached once a day.  If we need a block to happen quicker than that we'll need to bounce the application.  Keeping it simple for now.
