### PR TITLE
ER-766 - Legal entity agreement

### DIFF
--- a/src/Employer/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer/Employer.Web/Configuration/IoC.cs
@@ -53,6 +53,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             services.AddTransient<IGeocodeImageService>(_ => new GoogleMapsGeocodeImageService(configuration.GetValue<string>("GoogleMapsPrivateKey")));
             services.AddTransient<IFaaService, FaaService>();
             services.AddTransient<IReviewSummaryService, ReviewSummaryService>();
+            services.AddTransient<ILegalEntityAgreementService, LegalEntityAgreementService>();
         }
 
         private static void RegisterProviderApiClientDep(IServiceCollection services, IConfiguration configuration)

--- a/src/Employer/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer/Employer.Web/Configuration/IoC.cs
@@ -69,6 +69,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             services.AddTransient<ConsiderationsOrchestrator>();
             services.AddTransient<DashboardOrchestrator>();
             services.AddTransient<EmployerOrchestrator>();
+            services.AddTransient<LegalEntityAgreementOrchestrator>();
             services.AddTransient<EmployerContactDetailsOrchestrator>();
             services.AddTransient<TitleOrchestrator>();
             services.AddTransient<VacancyPreviewOrchestrator>();

--- a/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
@@ -23,9 +23,6 @@
         public const string Dashboard_AccountsSchemes = "Dashboard_AccountsSchemes";
         public const string Dashboard_Account_Home = "Dashboard_Account_Home";
 
-        public const string EmployerDetails_Index_Get = "EmployerDetails_Index_Get";
-        public const string EmployerDetails_Index_Post = "EmployerDetails_Index_Post";
-
         public const string EmployerContactDetails_Get = "EmployerContactDetails_Get";
         public const string EmployerContactDetails_Post = "EmployerContactDetails_Post";
 
@@ -60,6 +57,9 @@
         
         public const string CloseVacancy_Get = "CloseVacancy_Get";
         public const string CloseVacancy_Post = "CloseVacancy_Post";
+
+        public const string LegalEntityAgreement_SoftStop_Get = "LegalEntityAgreement_SoftStop_Get";
+        public const string LegalEntityAgreement_HardStop_Get = "LegalEntityAgreement_HardStop_Get";
 
         public const string DeleteVacancy_Delete_Get = "DeleteVacancy_Delete_Get";
         public const string DeleteVacancy_Delete_Post = "DeleteVacancy_Delete_Post";

--- a/src/Employer/Employer.Web/Controllers/ErrorController.cs
+++ b/src/Employer/Employer.Web/Controllers/ErrorController.cs
@@ -60,7 +60,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 if (exception is InvalidStateException)
                 {
                     _logger.LogError(exception, "Exception on path: {route}", routeWhereExceptionOccurred);
-                    TempData[TempDataKeys.DashboardErrorMessage] = exception.Message;
+                    AddDashboardMessage(exception.Message);
                     return RedirectToRoute(RouteNames.Dashboard_Index_Get, new { EmployerAccountId = accountId });
                 }
 
@@ -107,6 +107,14 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
             Response.StatusCode = (int)HttpStatusCode.Unauthorized;
             return View(ViewNames.BlockedEmployer);
+        }
+
+        private void AddDashboardMessage(string message)
+        {
+            if(TempData.ContainsKey(TempDataKeys.DashboardErrorMessage))
+                _logger.LogError($"Dashboard message already set in {nameof(ErrorController)}. Existing message:{TempData[TempDataKeys.DashboardErrorMessage]}. New message:{message}");
+
+            TempData[TempDataKeys.DashboardErrorMessage] = message;
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/ErrorController.cs
+++ b/src/Employer/Employer.Web/Controllers/ErrorController.cs
@@ -60,7 +60,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 if (exception is InvalidStateException)
                 {
                     _logger.LogError(exception, "Exception on path: {route}", routeWhereExceptionOccurred);
-                    TempData.Add(TempDataKeys.DashboardErrorMessage, exception.Message);
+                    TempData[TempDataKeys.DashboardErrorMessage] = exception.Message;
                     return RedirectToRoute(RouteNames.Dashboard_Index_Get, new { EmployerAccountId = accountId });
                 }
 

--- a/src/Employer/Employer.Web/Controllers/LegalEntityAgreementController.cs
+++ b/src/Employer/Employer.Web/Controllers/LegalEntityAgreementController.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.Orchestrators;
+using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Employer.Web.Views;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Esfa.Recruit.Employer.Web.Controllers
+{
+    [Route(RoutePrefixPaths.AccountVacancyRoutePath)]
+    public class LegalEntityAgreementController : Controller
+    {
+        private readonly LegalEntityAgreementOrchestrator _orchestrator;
+
+        public LegalEntityAgreementController(LegalEntityAgreementOrchestrator orchestrator)
+        {
+            _orchestrator = orchestrator;
+        }
+
+        [HttpGet("legal-entity-agreement", Name = RouteNames.LegalEntityAgreement_SoftStop_Get)]
+        public async Task<IActionResult> LegalEntityAgreementSoftStop(VacancyRouteModel vrm, [FromQuery] string wizard = "true")
+        {
+            var vm = await _orchestrator.GetLegalEntityAgreementSoftStopViewModelAsync(vrm);
+            vm.PageInfo.SetWizard(wizard);
+
+            if (vm.HasLegalEntityAgreement == false)
+                return View(vm);
+
+            return vm.PageInfo.IsWizard
+                    ? RedirectToRoute(RouteNames.Training_Get)
+                    : RedirectToRoute(RouteNames.Vacancy_Preview_Get, null, Anchors.AboutEmployerSection);
+        }
+
+        [HttpGet("legal-entity-agreement-stop", Name = RouteNames.LegalEntityAgreement_HardStop_Get)]
+        public async Task<IActionResult> LegalEntityAgreementHardStop(VacancyRouteModel vrm)
+        {
+            var vm = await _orchestrator.GetLegalEntityAgreementHardStopViewModelAsync(vrm);
+
+            if(vm.HasLegalEntityAgreement == false)
+                return View(vm);
+
+            return RedirectToRoute(RouteNames.Dashboard_Index_Get);
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
@@ -45,6 +45,9 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return View(vm);
             }
 
+            if (response.Data.HasLegalEntityAgreement == false)
+                return RedirectToRoute(RouteNames.LegalEntityAgreement_SoftStop_Get);
+
             return wizard
                 ? RedirectToRoute(RouteNames.Training_Get)
                 : RedirectToRoute(RouteNames.Vacancy_Preview_Get, null, Anchors.AboutEmployerSection);

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -55,6 +55,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
                 if (response.Data.HasLegalEntityAgreement == false)
                     return RedirectToRoute(RouteNames.LegalEntityAgreement_HardStop_Get);
+
+                throw new Exception("Unknown submit state");
             }
 
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -50,7 +50,11 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
             if (ModelState.IsValid)
             {
-                return RedirectToRoute(RouteNames.Submitted_Index_Get);
+                if (response.Data.IsSubmitted)
+                    return RedirectToRoute(RouteNames.Submitted_Index_Get);
+
+                if (response.Data.HasLegalEntityAgreement == false)
+                    return RedirectToRoute(RouteNames.LegalEntityAgreement_HardStop_Get);
             }
 
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -9,22 +9,28 @@
     <AssemblyName>Esfa.Recruit.Employer.Web</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2"/>
-    <PackageReference Include="Humanizer.Core.uk" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4"/>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.4"/>
-    <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="1.1.0"/>
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.4"/>
-    <PackageReference Include="NLog" Version="4.5.4"/>
-    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.2.0.62882"/>
-    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5"/>
-    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138"/>
-    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139"/>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1"/>
+    <Compile Remove="QueryStringModels\**" />
+    <Content Remove="QueryStringModels\**" />
+    <EmbeddedResource Remove="QueryStringModels\**" />
+    <None Remove="QueryStringModels\**" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj"/>
-    <ProjectReference Include="..\..\Shared\Recruit.Shared.Web\Recruit.Shared.Web.csproj"/>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2" />
+    <PackageReference Include="Humanizer.Core.uk" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.4" />
+    <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="1.1.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.4" />
+    <PackageReference Include="NLog" Version="4.5.4" />
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
+    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
+    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />
+    <ProjectReference Include="..\..\Shared\Recruit.Shared.Web\Recruit.Shared.Web.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="nlog.config">
@@ -32,8 +38,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="ViewModels\EditVacancyDates\"/>
-    <Folder Include="Views\EditVacancyDates\"/>
-    <Folder Include="QueryStringModels\"/>
+    <Folder Include="ViewModels\EditVacancyDates\" />
+    <Folder Include="Views\EditVacancyDates\" />
   </ItemGroup>
 </Project>

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>recruit-employer-web</UserSecretsId>
@@ -8,12 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Esfa.Recruit.Employer.Web</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="QueryStringModels\**" />
-    <Content Remove="QueryStringModels\**" />
-    <EmbeddedResource Remove="QueryStringModels\**" />
-    <None Remove="QueryStringModels\**" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2" />
     <PackageReference Include="Humanizer.Core.uk" Version="2.2.0" />

--- a/src/Employer/Employer.Web/Models/PostEmployerEditModelResponse.cs
+++ b/src/Employer/Employer.Web/Models/PostEmployerEditModelResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace Esfa.Recruit.Employer.Web.Models
+{
+    public class PostEmployerEditModelResponse
+    {
+        public bool HasLegalEntityAgreement { get; set; }
+    }
+}

--- a/src/Employer/Employer.Web/Models/SubmitVacancyResponse.cs
+++ b/src/Employer/Employer.Web/Models/SubmitVacancyResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Esfa.Recruit.Employer.Web.Models
+{
+    public class SubmitVacancyResponse
+    {
+        public bool HasLegalEntityAgreement { get; set; }
+        public bool IsSubmitted { get; set; }
+    }
+}

--- a/src/Employer/Employer.Web/Orchestrators/LegalEntityAgreementOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/LegalEntityAgreementOrchestrator.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Configuration.Routing;
+using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Employer.Web.Services;
+using Esfa.Recruit.Employer.Web.ViewModels.LegalEntityAgreement;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Employer.Web.Orchestrators
+{
+    public class LegalEntityAgreementOrchestrator
+    {
+        private readonly IEmployerVacancyClient _client;
+        private readonly ILegalEntityAgreementService _legalEntityAgreementService;
+
+        public LegalEntityAgreementOrchestrator(
+            IEmployerVacancyClient client, 
+            ILegalEntityAgreementService legalEntityAgreementService)
+        {
+            _client = client;
+            _legalEntityAgreementService = legalEntityAgreementService;
+        }
+
+        public async Task<LegalEntityAgreementSoftStopViewModel> GetLegalEntityAgreementSoftStopViewModelAsync(VacancyRouteModel vrm)
+        {
+            var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.LegalEntityAgreement_SoftStop_Get);
+            
+            return new LegalEntityAgreementSoftStopViewModel
+            {
+                HasLegalEntityAgreement = await _legalEntityAgreementService.HasLegalEntityAgreementAsync(vacancy.EmployerAccountId, vacancy.LegalEntityId),
+                LegalEntityName = vacancy.EmployerName,
+                PageInfo = Utility.GetPartOnePageInfo(vacancy)
+            };
+        }
+
+        public async Task<LegalEntityAgreementHardStopViewModel> GetLegalEntityAgreementHardStopViewModelAsync(VacancyRouteModel vrm)
+        {
+            var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.LegalEntityAgreement_SoftStop_Get);
+
+            return new LegalEntityAgreementHardStopViewModel
+            {
+                HasLegalEntityAgreement = await _legalEntityAgreementService.HasLegalEntityAgreementAsync(vacancy.EmployerAccountId, vacancy.LegalEntityId),
+            };
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -29,7 +29,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
 
         public async Task<EmployerViewModel> GetEmployerViewModelAsync(VacancyRouteModel vrm)
         {
-            var getEmployerDataTask = _client.GetEditVacancyInfo(vrm.EmployerAccountId);
+            var getEmployerDataTask = _client.GetEditVacancyInfoAsync(vrm.EmployerAccountId);
             var getVacancyTask = Utility.GetAuthorisedVacancyForEditAsync(_client, vrm, RouteNames.Employer_Get);
 
             await Task.WhenAll(getEmployerDataTask, getVacancyTask);
@@ -88,7 +88,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
         public async Task<OrchestratorResponse> PostEmployerEditModelAsync(EmployerEditModel m, VacancyUser user)
         {
             var vacancyTask = Utility.GetAuthorisedVacancyForEditAsync(_client, m, RouteNames.Employer_Post);
-            var employerVacancyInfoTask = _client.GetEditVacancyInfo(m.EmployerAccountId);
+            var employerVacancyInfoTask = _client.GetEditVacancyInfoAsync(m.EmployerAccountId);
 
             await Task.WhenAll(vacancyTask, employerVacancyInfoTask);
             var vacancy = vacancyTask.Result;

--- a/src/Employer/Employer.Web/Services/ILegalEntityAgreementService.cs
+++ b/src/Employer/Employer.Web/Services/ILegalEntityAgreementService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Esfa.Recruit.Employer.Web.Services
+{
+    public interface ILegalEntityAgreementService
+    {
+        Task<bool> HasLegalEntityAgreementAsync(string employerAccountId, long legalEntityId);
+    }
+}

--- a/src/Employer/Employer.Web/Services/LegalEntityAgreementService.cs
+++ b/src/Employer/Employer.Web/Services/LegalEntityAgreementService.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+
+namespace Esfa.Recruit.Employer.Web.Services
+{
+    public class LegalEntityAgreementService : ILegalEntityAgreementService
+    {
+        private readonly IEmployerVacancyClient _client;
+
+        public LegalEntityAgreementService(IEmployerVacancyClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<bool> HasLegalEntityAgreementAsync(string employerAccountId, long legalEntityId)
+        {
+            var legalEntity = await GetLegalEntityAsync(employerAccountId, legalEntityId);
+
+            if(legalEntity == null)
+                return false;
+            
+            if (legalEntity.HasLegalEntityAgreement)
+                return true;
+
+            //Agreement may have been signed since the projection was created. Check Employer Service.
+            var hasLegalEntityAgreement = await CheckEmployerServiceForLegalEntityAgreementAsync(employerAccountId, legalEntity.LegalEntityId);
+
+            if (hasLegalEntityAgreement)
+            {
+                //update the projection
+                await _client.SetupEmployerAsync(employerAccountId);
+            }
+
+            return hasLegalEntityAgreement;
+        }
+
+        private async Task<LegalEntity> GetLegalEntityAsync(string employerAccountId, long legalEntityId)
+        {
+            var employerData = await _client.GetEditVacancyInfoAsync(employerAccountId);
+
+            var legalEntity = employerData.LegalEntities.SingleOrDefault(l => l.LegalEntityId == legalEntityId);
+
+            return legalEntity;
+        }
+
+        private async Task<bool> CheckEmployerServiceForLegalEntityAgreementAsync(string employerAccountId, long legalEntityId)
+        {
+            var legalEntities = await _client.GetEmployerLegalEntitiesAsync(employerAccountId);
+
+            var legalEntity = legalEntities.SingleOrDefault(e => e.LegalEntityId == legalEntityId);
+
+            return legalEntity?.HasLegalEntityAgreement ?? false;
+        }
+    }
+}

--- a/src/Employer/Employer.Web/Services/LegalEntityAgreementService.cs
+++ b/src/Employer/Employer.Web/Services/LegalEntityAgreementService.cs
@@ -29,7 +29,6 @@ namespace Esfa.Recruit.Employer.Web.Services
 
             if (hasLegalEntityAgreement)
             {
-                //update the projection
                 await _client.SetupEmployerAsync(employerAccountId);
             }
 

--- a/src/Employer/Employer.Web/Utility.cs
+++ b/src/Employer/Employer.Web/Utility.cs
@@ -7,11 +7,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Exceptions;
-using Esfa.Recruit.Employer.Web.Mappings;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1;
-using Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 
 namespace Esfa.Recruit.Employer.Web
@@ -82,7 +80,7 @@ namespace Esfa.Recruit.Employer.Web
             if (string.IsNullOrWhiteSpace(vacancy.EmployerLocation?.Postcode))
                 return validRoutes;
             
-            validRoutes.AddRange(new[] { RouteNames.Training_Post, RouteNames.Training_Get});
+            validRoutes.AddRange(new[] {RouteNames.LegalEntityAgreement_SoftStop_Get, RouteNames.Training_Post, RouteNames.Training_Get});
             if (string.IsNullOrWhiteSpace(vacancy.ProgrammeId))
                 return validRoutes;
 

--- a/src/Employer/Employer.Web/ViewModels/LegalEntityAgreement/LegalEntityAgreementHardStopViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/LegalEntityAgreement/LegalEntityAgreementHardStopViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Esfa.Recruit.Employer.Web.ViewModels.LegalEntityAgreement
+{
+    public class LegalEntityAgreementHardStopViewModel
+    {
+        public bool HasLegalEntityAgreement { get; set; }
+    }
+}

--- a/src/Employer/Employer.Web/ViewModels/LegalEntityAgreement/LegalEntityAgreementSoftStopViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/LegalEntityAgreement/LegalEntityAgreementSoftStopViewModel.cs
@@ -1,0 +1,12 @@
+﻿using Esfa.Recruit.Employer.Web.ViewModels.Part1;
+
+namespace Esfa.Recruit.Employer.Web.ViewModels.LegalEntityAgreement
+{
+    public class LegalEntityAgreementSoftStopViewModel
+    {
+        public bool HasLegalEntityAgreement { get; set; }
+        public string LegalEntityName { get; set; }
+
+        public PartOnePageInfoViewModel PageInfo { get; set; }
+    }
+}

--- a/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementHardStop.cshtml
+++ b/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementHardStop.cshtml
@@ -1,0 +1,19 @@
+﻿@model Esfa.Recruit.Employer.Web.ViewModels.LegalEntityAgreement.LegalEntityAgreementHardStopViewModel
+<div class="grid-row">
+    <div class="column-two-thirds">
+
+        <div class="info-summary">
+            <h1 class="heading-medium no-top-margin">You can’t submit this vacancy until:</h1>
+            <ul class="list list-bullet">
+                <li>You’ve signed an
+                    <a asp-route="@RouteNames.Dashboard_AccountsAgreements">apprenticeship agreement</a>
+                    with the Education and Skills Funding Agency</li>
+            </ul>
+            <p>Your vacancy has been saved as a draft. Once the agreement has been signed, you will be able to
+                submit your vacancy for review.</p>
+        </div>
+            
+        <a asp-route="@RouteNames.Dashboard_Index_Get" class="button">Return to dashboard</a>
+    </div>
+
+</div>

--- a/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementSoftStop.cshtml
+++ b/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementSoftStop.cshtml
@@ -8,13 +8,19 @@
             <i class="icon icon-important">
                 <span class="visually-hidden">Warning</span>
             </i>
-            <strong class="bold-small">
-                @Model.LegalEntityName doesn’t have a signed agreement with the Education and Skills Funding Agency (ESFA).
-                Without a signed agreement you can create a draft vacancy, but won’t be able to submit for posting on Find an apprenticeship.
-                <br><br>
-                Only account owners can sign ESFA agreements. If you’re not sure who the owner is, you can
+            
+            <p>
+                <strong class="bold-small">
+                    @Model.LegalEntityName doesn’t have a signed agreement with the Education and Skills Funding Agency (ESFA).
+                    Without a signed agreement you can create a draft vacancy, but won’t be able to submit for posting on Find an apprenticeship.
+                </strong>
+            </p>
+            <p>
+                <strong class="bold-small">
+                    Only account owners can sign ESFA agreements. If you’re not sure who the owner is, you can
                     <a asp-route="@RouteNames.Dashboard_AccountsAgreements">check your team details.</a>
-            </strong>
+                </strong>
+                </p>
         </div>
         <a asp-route="@RouteNames.Dashboard_AccountsAgreements" class="button">Review agreement</a>
         

--- a/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementSoftStop.cshtml
+++ b/src/Employer/Employer.Web/Views/LegalEntityAgreement/LegalEntityAgreementSoftStop.cshtml
@@ -1,0 +1,24 @@
+﻿@model Esfa.Recruit.Employer.Web.ViewModels.LegalEntityAgreement.LegalEntityAgreementSoftStopViewModel
+
+<div class="grid-row employer-agreement-container">
+    <div class="column-two-thirds">
+        <h1 class="heading-large medium-bottom-margin">Agreement not signed</h1>
+
+        <div class="notice medium-bottom-margin">
+            <i class="icon icon-important">
+                <span class="visually-hidden">Warning</span>
+            </i>
+            <strong class="bold-small">
+                @Model.LegalEntityName doesn’t have a signed agreement with the Education and Skills Funding Agency (ESFA).
+                Without a signed agreement you can create a draft vacancy, but won’t be able to submit for posting on Find an apprenticeship.
+                <br><br>
+                Only account owners can sign ESFA agreements. If you’re not sure who the owner is, you can
+                    <a asp-route="@RouteNames.Dashboard_AccountsAgreements">check your team details.</a>
+            </strong>
+        </div>
+        <a asp-route="@RouteNames.Dashboard_AccountsAgreements" class="button">Review agreement</a>
+        
+        <a asp-show="@Model.PageInfo.IsWizard" asp-route="@RouteNames.Training_Get" class="button-link">Continue anyway</a>
+        <a asp-show="@Model.PageInfo.IsNotWizard" asp-route="@RouteNames.Vacancy_Preview_Get" asp-fragment="@Anchors.AboutEmployerSection" class="button-link">Continue anyway</a>
+    </div>
+</div>

--- a/src/Employer/Employer.Web/wwwroot/css/application.css
+++ b/src/Employer/Employer.Web/wwwroot/css/application.css
@@ -63,6 +63,10 @@
   margin-bottom:30px;
 }
 
+.medium-bottom-margin {
+  margin-bottom: 50px;
+}
+
 .small-top-margin {
   margin-top:30px;
 }
@@ -1712,3 +1716,6 @@ table.responsive thead {
     }
   }
   
+  .employer-agreement-container .notice .icon {
+    top:20px;
+  }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -44,10 +44,10 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public string EmployerContactPhone { get; set; }
         public string EmployerDescription { get; set; }
         public Address EmployerLocation { get; set; }
-        public long LegalEntityId { get; set; }
         public string EmployerName { get; set; }
-        public GeoCodeMethod? GeoCodeMethod { get; set; }
         public string EmployerWebsiteUrl { get; set; }
+        public GeoCodeMethod? GeoCodeMethod { get; set; }
+        public long LegalEntityId { get; set; }
         public int? NumberOfPositions { get; set; }
         public string OutcomeDescription { get; set; }
         public string ProgrammeId { get; set; }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -23,7 +23,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<EmployerDashboard> GetDashboardAsync(string employerAccountId);
         Task UserSignedInAsync(VacancyUser user);
-        Task<EditVacancyInfo> GetEditVacancyInfo(string employerAccountId);
+        Task<EditVacancyInfo> GetEditVacancyInfoAsync(string employerAccountId);
         EntityValidationResult Validate(Vacancy vacancy, VacancyRuleSet rules);
         Task<IEnumerable<IApprenticeshipProgramme>> GetActiveApprenticeshipProgrammesAsync();
         Task<IApprenticeshipProgramme> GetApprenticeshipProgrammeAsync(string programmeId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -186,7 +186,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _messaging.SendCommandAsync(command);
         }
 
-        public Task<EditVacancyInfo> GetEditVacancyInfo(string employerAccountId)
+        public Task<EditVacancyInfo> GetEditVacancyInfoAsync(string employerAccountId)
         {
             return _reader.GetEmployerVacancyDataAsync(employerAccountId);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/EditVacancyInfo/LegalEntity.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/EditVacancyInfo/LegalEntity.cs
@@ -5,5 +5,6 @@
         public long LegalEntityId { get; set; }
         public string Name { get; set; }
         public Address Address { get; set; }
+        public bool HasLegalEntityAgreement { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/LegalEntityMapper.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/LegalEntityMapper.cs
@@ -14,7 +14,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount
             {
                 LegalEntityId = data.LegalEntityId,
                 Name = data.Name,
-                Address = MapFromAddressLine(data.Address)
+                Address = MapFromAddressLine(data.Address),
+                HasLegalEntityAgreement = data.Agreements.Any(a =>
+                    a.Status == EmployerAgreementStatus.Signed)
             };
         }
 

--- a/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
+++ b/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="RestSharp" Version="106.2.2" />
-    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.2.0.62882" />
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
     <PackageReference Include="SimMetrics.Net" Version="1.0.5" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
     <PackageReference Include="FluentValidation" Version="7.5.2" />


### PR DESCRIPTION
Upgraded package `SFA.DAS.Account.Api.Client` to version 1.3.1331.

Added `LegalEntityAgreementService`. This is injected into orchestrators that need to know if a legal entity has a signed agreement.

- This service first checks the `EditVacancyInfo` projection to see if the `hasLegalEntityAgreement` is set to true. If `true` the journey continues as normal. (This will be the most common scenario)
- If `false` the service checks the Employer Service directly as the agreement could have been signed after the `EditVacancyInfo` projection was last rebuilt
- if the employer has signed an agreement then a command is fired for the jobs to rebuild the `EditVacancyInfo` projection (This will set  `hasLegalEntityAgreement` to true in the projection) and the journey continues as normal.
- if the employer does not have a signed agreement then the journey is diverted to one of the stop pages.

Also fixed an issue that sometimes happens on TEST in the ErrorController where TempData.Add was generating an "An item with the same key has already been added" error.

Removed unused folder `QueryStringModels`.


