### PR TITLE
Going down the wrong path for nothing

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -18,6 +18,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
 
 namespace Esfa.Recruit.Employer.Web.Configuration
 {
@@ -121,6 +122,10 @@ namespace Esfa.Recruit.Employer.Web.Configuration
                 {
                     await PopulateAccountsClaim(ctx, vacancyClient);
                     await HandleUserSignedIn(ctx, vacancyClient);
+                };
+                options.Events.OnRedirectToIdentityProviderForSignOut = async (ctx) =>
+                {
+                    await ctx.HttpContext.SignOutEmployerWebAsync();
                 };
             });
         }

--- a/src/Employer/Employer.Web/Controllers/LogoutController.cs
+++ b/src/Employer/Employer.Web/Controllers/LogoutController.cs
@@ -24,8 +24,12 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpGet, Route("logout", Name = RouteNames.Logout_Get)]
         public async Task Logout()
         {
-            await HttpContext.SignOutEmployerWebAsync(_externalLinks.ManageApprenticeshipSiteUrl);
+            AuthenticationProperties properties = new AuthenticationProperties
+            {
+                RedirectUri = _externalLinks.ManageApprenticeshipSiteUrl
+            };
+
+            await HttpContext.SignOutAsync("oidc", properties);
         }
-            
     }
 }

--- a/src/Employer/Employer.Web/Controllers/LogoutController.cs
+++ b/src/Employer/Employer.Web/Controllers/LogoutController.cs
@@ -22,11 +22,10 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         }
 
         [HttpGet, Route("logout", Name = RouteNames.Logout_Get)]
-        public async Task<IActionResult> Logout()
+        public async Task Logout()
         {
-            await HttpContext.SignOutEmployerWebAsync();
-            
-            return Redirect(_externalLinks.ManageApprenticeshipSiteUrl);
+            await HttpContext.SignOutEmployerWebAsync(_externalLinks.ManageApprenticeshipSiteUrl);
         }
+            
     }
 }

--- a/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
@@ -6,21 +6,9 @@ namespace Esfa.Recruit.Employer.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext, string redirectUrl = null)
+        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext)
         {
-            AuthenticationProperties properties = null;
-
             await httpContext.SignOutAsync("Cookies");
-
-            if (redirectUrl != null)
-            {
-                properties = new AuthenticationProperties
-                {
-                    RedirectUri = redirectUrl
-                };
-            }
-
-            await httpContext.SignOutAsync("oidc", properties);
         }
     }
 }

--- a/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/HttpContextExtensions.cs
@@ -6,10 +6,21 @@ namespace Esfa.Recruit.Employer.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext)
+        public static async Task SignOutEmployerWebAsync(this HttpContext httpContext, string redirectUrl = null)
         {
+            AuthenticationProperties properties = null;
+
             await httpContext.SignOutAsync("Cookies");
-            await httpContext.SignOutAsync("oidc");
+
+            if (redirectUrl != null)
+            {
+                properties = new AuthenticationProperties
+                {
+                    RedirectUri = redirectUrl
+                };
+            }
+
+            await httpContext.SignOutAsync("oidc", properties);
         }
     }
 }


### PR DESCRIPTION
This is pure guesswork and hoping the `OnRedirectToIdentityProviderForSignOut` is something that might help.


This actually worked for me after signing into test-eas and being on my localhost employer web on two different tabs and signing out from my recruit website and refreshing the MA dashboard on the other tab. The recruit tab took me to a page:

![image](https://user-images.githubusercontent.com/10399742/47593161-398d6d80-d96e-11e8-8a89-952d6e990299.png)


and refreshing the MA dashboard in the other tab took me to:

![image](https://user-images.githubusercontent.com/10399742/47593193-4d38d400-d96e-11e8-9947-3213b7b67670.png)
