### PR TITLE
ER-717 - Removing '/commitments/' from route

### DIFF
--- a/src/Employer/Employer.Web/appsettings.json
+++ b/src/Employer/Employer.Web/appsettings.json
@@ -44,7 +44,7 @@
     "ManageApprenticeshipSiteChangePasswordRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteChangeEmailAddressRoute": "/account/changepassword?clientId={0}&returnUrl={1}",
     "ManageApprenticeshipSiteAccountsFinanceRoute": "/accounts/{0}/finance",
-    "ManageApprenticeshipSiteAccountsApprenticesRoute": "/commitments/accounts/{0}/apprentices/home",
+    "ManageApprenticeshipSiteAccountsApprenticesRoute": "/accounts/{0}/apprentices/home",
     "ManageApprenticeshipSiteAccountsTeamsViewRoute": "/accounts/{0}/teams/view",
     "ManageApprenticeshipSiteAccountsAgreementsRoute": "/accounts/{0}/agreements",
     "ManageApprenticeshipSiteAccountsSchemesRoute": "/accounts/{0}/schemes"


### PR DESCRIPTION
Sultan tested existing behaviour on TEST, PRE & PROD. The only environment that is working is PRE. Both TEST and PROD need to have `/commitments/` removed from the url in order to work. With this in mind I’m going to fix so it works on TEST and PROD and add an item to Tech Debt to get this working on PRE. (Ideally commitments PRE env needs to be updated rather than us adding extra config).