### PR TITLE
ER-811 - Training provider input changed from number to text

### DIFF
--- a/src/Employer/Employer.Web/Controllers/Part2/TrainingProviderController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part2/TrainingProviderController.cs
@@ -41,7 +41,10 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part2
                 return View(vm);
             }
 
-            var providerExists = await _orchestrator.ConfirmProviderExists(long.Parse(m.Ukprn));
+            if (long.TryParse(m.Ukprn, out var ukprnAsLong) == false)
+                return await ProviderNotFound(m);
+
+            var providerExists = await _orchestrator.ConfirmProviderExists(ukprnAsLong);
             
             if (providerExists == false)
                 return await ProviderNotFound(m);

--- a/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/TrainingProviderOrchestrator.cs
@@ -33,7 +33,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
             var vm = new SelectTrainingProviderViewModel
             {
                 Title = vacancy.Title,
-                Ukprn = vacancy.TrainingProvider?.Ukprn
+                Ukprn = vacancy.TrainingProvider?.Ukprn?.ToString()
             };
 
             if (vacancy.Status == VacancyStatus.Referred)
@@ -48,7 +48,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part2
         public async Task<SelectTrainingProviderViewModel> GetSelectTrainingProviderViewModel(SelectTrainingProviderEditModel m)
         {
             var vm = await GetSelectTrainingProviderViewModel((VacancyRouteModel)m);
-            vm.Ukprn = long.TryParse(m.Ukprn, out var submittedUkprn) ? submittedUkprn : default(long);
+            vm.Ukprn = m.Ukprn;
             return vm;
         }
 

--- a/src/Employer/Employer.Web/ViewModels/Part2/TrainingProvider/SelectTrainingProviderViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part2/TrainingProvider/SelectTrainingProviderViewModel.cs
@@ -7,7 +7,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels
     {
         public string Title { get; set; }
         [Display(Name = "UKPRN")]
-        public long? Ukprn { get; set; }
+        public string Ukprn { get; set; }
         public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
     }
 }

--- a/src/Employer/Employer.Web/Views/Part2/TrainingProvider/SelectTrainingProvider.cshtml
+++ b/src/Employer/Employer.Web/Views/Part2/TrainingProvider/SelectTrainingProvider.cshtml
@@ -15,7 +15,7 @@
                     Your provider must also have a recruit an apprentice account<br>
                     The UKPRN must only be 8 digits (For example, 12345678)
                 </span>
-                <input asp-for="Ukprn" type="number" maxlength="8" class="form-control" />
+                <input asp-for="Ukprn" type="text" maxlength="8" class="form-control" />
             </div>
             <div class="form-group">
                 <input type="submit" value="Select provider" esfa-automation="btn-continue" class="button" />


### PR DESCRIPTION
This fixes a couple of issues:

In IE Edge the implementation of `type='number'` allows you to enter alphanumerics but prevents the form from being submitted.  We have code to disable submit buttons to prevent multiple form submits so the button gets disabled and never gets re-enabled.

The other issue is you can increment/decrement the number using up/down arrows & mouse scroll wheel. This is not useful behaviour with regard to UKPRNs.

So to fix this issue I'm changing the input from number to text. We have regex as part of server-side validation already to ensure numbers are used