### PR TITLE
ER-820 Correct call to write levy cookie

### DIFF
--- a/src/Employer/Employer.Web/Controllers/LevyDeclarationController.cs
+++ b/src/Employer/Employer.Web/Controllers/LevyDeclarationController.cs
@@ -56,9 +56,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
         private void SetLevyDeclarationCookie(ClaimsPrincipal user, string employerAccountId)
         {
-            var protectedUserId = _dataProtector.Protect(user.GetUserId());
-
-            _levyCookieWriter.WriteCookie(Response, protectedUserId, employerAccountId);
+            _levyCookieWriter.WriteCookie(Response, user.GetUserId(), employerAccountId);
         }
     }
 }


### PR DESCRIPTION

When writing the levy cookie after selecting the 'yes' option, the cookie contents was being written incorrectly. The result of this is that the next page they request will correctly say the cookie is invalid and remove it. It will then correctly regenerate the cookie. Subsequent requests will work as expected.