### PR TITLE
ER-807 - Closing date extension

### DIFF
--- a/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Employer/Employer.Web/Configuration/Routing/RouteNames.cs
@@ -94,7 +94,6 @@
         public const string VacancyEdit_Get = "VacancyEdit_Get";
         public const string VacancyEditDates_Get = "VacancyEditDates_Get";
         public const string VacancyEditDates_Post = "VacancyEditDates_Post";
-        public const string VacancyEditDatesCancel_Get = "VacancyEditDatesCancel_Get";
 
         public const string SubmitVacancyChanges_Post = "SubmitVacancyChanges_Post";
         public const string CancelVacancyChanges_Get = "CancelVacancyChanges_Get";

--- a/src/Employer/Employer.Web/Controllers/ErrorController.cs
+++ b/src/Employer/Employer.Web/Controllers/ErrorController.cs
@@ -1,21 +1,17 @@
-﻿using System;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using System.Diagnostics;
-using System.Linq;
-using Esfa.Recruit.Employer.Web.ViewModels.Error;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Diagnostics;
-using Esfa.Recruit.Employer.Web.Configuration;
-using System.Net;
-using System.Threading.Tasks;
-using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
+﻿using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Exceptions;
-using Esfa.Recruit.Employer.Web.Extensions;
-using Esfa.Recruit.Employer.Web.Filters;
+using Esfa.Recruit.Employer.Web.ViewModels.Error;
+using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Exceptions;
-using StackExchange.Redis;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
 {

--- a/src/Employer/Employer.Web/Extensions/CookiesExtensions.cs
+++ b/src/Employer/Employer.Web/Extensions/CookiesExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Configuration;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace Esfa.Recruit.Employer.Web.Extensions
+{
+    public static class CookiesExtensions
+    {
+        public static void SetProposedClosingDate(this IResponseCookies cookies, IHostingEnvironment hostingEnvironment, Guid vacancyId, DateTime date)
+        {
+            cookies.Append(string.Format(CookieNames.VacancyProposedClosingDate, vacancyId), date.ToShortDateString(), EsfaCookieOptions.GetSessionLifetimeHttpCookieOption(hostingEnvironment));
+        }
+
+        public static void ClearProposedClosingDate(this IResponseCookies cookies, IHostingEnvironment hostingEnvironment, Guid vacancyId)
+        {
+            cookies.Delete(string.Format(CookieNames.VacancyProposedClosingDate, vacancyId), EsfaCookieOptions.GetSessionLifetimeHttpCookieOption(hostingEnvironment));
+        }
+
+        public static DateTime? GetProposedClosingDate(this IRequestCookieCollection cookies, Guid vacancyId)
+        {
+            var proposedClosingDateCookieData = cookies[string.Format(CookieNames.VacancyProposedClosingDate, vacancyId)]?.Trim();
+
+            if (DateTime.TryParse(proposedClosingDateCookieData, out var proposedClosingDate))
+                return proposedClosingDate;
+
+            return null;
+        }
+
+        public static void SetProposedStartDate(this IResponseCookies cookies, IHostingEnvironment hostingEnvironment, Guid vacancyId, DateTime date)
+        {
+            cookies.Append(string.Format(CookieNames.VacancyProposedStartDate, vacancyId), date.ToShortDateString(), EsfaCookieOptions.GetSessionLifetimeHttpCookieOption(hostingEnvironment));
+        }
+
+        public static void ClearProposedStartDate(this IResponseCookies cookies, IHostingEnvironment hostingEnvironment, Guid vacancyId)
+        {
+            cookies.Delete(string.Format(CookieNames.VacancyProposedStartDate, vacancyId), EsfaCookieOptions.GetSessionLifetimeHttpCookieOption(hostingEnvironment));
+        }
+
+        public static DateTime? GetProposedStartDate(this IRequestCookieCollection cookies, Guid vacancyId)
+        {
+            var proposedStartDateCookieData = cookies[string.Format(CookieNames.VacancyProposedStartDate, vacancyId)]?.Trim();
+
+            if (DateTime.TryParse(proposedStartDateCookieData, out var proposedStartDate))
+                return proposedStartDate;
+
+            return null;
+        }
+
+        
+    }
+}

--- a/src/Employer/Employer.Web/Orchestrators/EditVacancyDatesOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/EditVacancyDatesOrchestrator.cs
@@ -40,7 +40,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             Utility.CheckAuthorisedAccess(vacancy, vrm.EmployerAccountId);
 
             if (vacancy.CanExtendStartAndClosingDates == false)
-                throw new InvalidStateException(string.Format(ViewModels.ErrorMessages.VacancyNotAvailableForEditing, vacancy.Title));
+                throw new InvalidStateException(string.Format(ViewModels.ErrorMessages.VacancyDatesCannotBeEdited, vacancy.Title));
 
             return vacancy;
         }

--- a/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -35,10 +35,8 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return vacancy;
         }
 
-        public async Task<ManageVacancyViewModel> GetManageVacancyViewModel(VacancyRouteModel vrm)
+        public async Task<ManageVacancyViewModel> GetManageVacancyViewModel(Vacancy vacancy)
         {
-            var vacancy = await GetVacancy(vrm);
-
             var viewModel = new ManageVacancyViewModel();
 
             viewModel.Title = vacancy.Title;
@@ -48,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             viewModel.PossibleStartDate = vacancy.StartDate?.AsGdsDate();
             viewModel.IsDisabilityConfident = vacancy.IsDisabilityConfident;
             viewModel.IsApplyThroughFaaVacancy = vacancy.ApplicationMethod == ApplicationMethod.ThroughFindAnApprenticeship;
-            viewModel.CanShowEditVacancyLink = vacancy.Status == VacancyStatus.Live;
+            viewModel.CanShowEditVacancyLink = vacancy.CanExtendStartAndClosingDates;
             viewModel.CanShowCloseVacancyLink = vacancy.CanClose;
 
             var vacancyApplicationsTask =  await _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
@@ -64,17 +62,17 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             return viewModel;
         }
 
-        public async Task<EditVacancyViewModel> GetEditVacancyViewModel(VacancyRouteModel vrm, DateTime proposedClosingDate, DateTime proposedStartDate)
+        public async Task<EditVacancyViewModel> GetEditVacancyViewModel(VacancyRouteModel vrm, DateTime? proposedClosingDate, DateTime? proposedStartDate)
         {
             var vacancy = await GetVacancy(vrm);
 
             var viewModel = new EditVacancyViewModel();
             await _vacancyDisplayMapper.MapFromVacancyAsync(viewModel, vacancy);
 
-            if (proposedClosingDate != DateTime.MinValue)
+            if (proposedClosingDate.HasValue)
                 viewModel.ProposedClosingDate = proposedClosingDate;
 
-            if (proposedStartDate != DateTime.MinValue)
+            if (proposedStartDate.HasValue)
                 viewModel.ProposedStartDate = proposedStartDate;
 
             return viewModel;

--- a/src/Employer/Employer.Web/ViewModels/ErrorMessages.cs
+++ b/src/Employer/Employer.Web/ViewModels/ErrorMessages.cs
@@ -6,5 +6,6 @@
         public const string VacancyNotAvailableForEditing = "The vacancy '{0}' has been edited by one of your colleagues. Your changes have not been saved.";
         public const string VacancyNotAvailableForClosing = "The vacancy '{0}' cannot be closed as it is not currently published.";
         public const string VacancyNotSubmittedSuccessfully = "The vacancy '{0}' has not been submitted successfully.";
+        public const string VacancyDatesCannotBeEdited = "The dates of vacancy '{0}' can't be edited.";
     }
 }

--- a/src/Employer/Employer.Web/Views/EditVacancyDates/EditVacancyDates.cshtml
+++ b/src/Employer/Employer.Web/Views/EditVacancyDates/EditVacancyDates.cshtml
@@ -67,7 +67,7 @@
                     <p>@Model.ProgammeName</p>
                 </div>
                 <button type="submit" class="button save-button">Preview changes</button>
-                <a asp-route="@RouteNames.VacancyEditDatesCancel_Get" class="button-link">Cancel</a>
+                <a asp-route="@RouteNames.VacancyEdit_Get" class="button-link">Cancel</a>
             </form>
         </div>
     </div>

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Vacancy.cs
@@ -101,5 +101,10 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public bool CanSendForReview => Status == VacancyStatus.Submitted && IsDeleted == false;
 
         public bool IsDisabilityConfident => DisabilityConfident == DisabilityConfident.Yes;
+
+        /// <summary>
+        /// We can extend the ClosingDate and StartDate for Live vacancies that have not been deleted
+        /// </summary>
+        public bool CanExtendStartAndClosingDates => Status == VacancyStatus.Live && IsDeleted == false;
     }
 }


### PR DESCRIPTION
No longer clearing the cookies when Cancelling from the Edit Dates page.  Instead I'm ensuring cookies are cleared when we land on the Manage vacancy page.

Added handling of AggregateException in ErrorController. This is thrown from Task.WaitAll.

Refactored the Start/Closing date extending functionality to make the controller more skinny & move logic into orch as per other pages in employer Web.

Simplifying state handling by just throwing an InvalidStateException rather than marshalling redirects should a vacancy be in the wrong state.