### PR TITLE
ER-831 - Redirect to blocked employer error page from action filter

### DIFF
--- a/src/Employer/Employer.Web/Controllers/ErrorController.cs
+++ b/src/Employer/Employer.Web/Controllers/ErrorController.cs
@@ -90,12 +90,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 {   
                     return AccessDenied();
                 }
-
-                if (exception is BlockedEmployerException)
-                {
-                    _logger.LogInformation($"{exception.Message}. Path: {routeWhereExceptionOccurred}");
-                    return RedirectToRoute(RouteNames.BlockedEmployer_Get, new { EmployerAccountId = employerAccountId });
-                }
             }
 
             Response.StatusCode = (int)HttpStatusCode.InternalServerError;
@@ -117,8 +111,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpGet("error/blocked-employer/{employerAccountId}", Name = RouteNames.BlockedEmployer_Get)]
         public IActionResult BlockedEmployer(string employerAccountId)
         {
+            _logger.LogInformation($"Handling redirection of blocked employer: {employerAccountId}.");
             Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-
             return View(ViewNames.BlockedEmployer);
         }
 

--- a/src/Employer/Employer.Web/Exceptions/BlockedEmployerException.cs
+++ b/src/Employer/Employer.Web/Exceptions/BlockedEmployerException.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Esfa.Recruit.Employer.Web.Exceptions
-{
-    public class BlockedEmployerException : Exception
-    {
-        public BlockedEmployerException(string message) : base(message){}
-    }
-}

--- a/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
+++ b/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
@@ -6,6 +6,7 @@ using Esfa.Recruit.Employer.Web.Controllers;
 using Esfa.Recruit.Employer.Web.Exceptions;
 using Esfa.Recruit.Vacancies.Client.Application.Cache;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Esfa.Recruit.Employer.Web.Filters
@@ -38,19 +39,26 @@ namespace Esfa.Recruit.Employer.Web.Filters
 
                 if (blockedEmployerAccountIds.Contains(accountIdFromUrl))
                 {
-                    throw new BlockedEmployerException($"Employer account '{accountIdFromUrl}' is blocked");
+                    var ctrlr = context.Controller as Controller;
+                    context.Result = ctrlr.RedirectToRoute(RouteNames.BlockedEmployer_Get);
+                }
+                else
+                {
+                    await next();
                 }
             }
-
-            await next();
+            else
+            {
+                await next();
+            }
         }
 
         private bool RequestIsForWhiteListedPage(ActionExecutingContext context)
         {
             var controllerName = (((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)context.ActionDescriptor).ControllerTypeInfo).Name;
 
-            var whitelistControllers = new List<string>{ nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController) };
-            
+            var whitelistControllers = new List<string> { nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController) };
+
             return whitelistControllers.Contains(controllerName);
         }
     }


### PR DESCRIPTION
This is very crude and done to address the unhandled exception we are seeing on PROD.

Writing a custom middleware to intercept the exception was troublesome and I am not sure whether we need to throw an exception to intercept.

I also think it may be worth turning the `CheckEmployerBlockedFilter` into an `AuthorizationFilter`