### PR TITLE
Fix issue with startup of webjob

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -45,11 +45,11 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
             });
         }
 
-        internal static IRuleBuilderInitial<Vacancy, Vacancy> TrainingMustBeActiveForStartDate(this IRuleBuilder<Vacancy, Vacancy> ruleBuilder, IEnumerable<IApprenticeshipProgramme> programmes)
+        internal static IRuleBuilderInitial<Vacancy, Vacancy> TrainingMustBeActiveForStartDate(this IRuleBuilder<Vacancy, Vacancy> ruleBuilder, Lazy<IEnumerable<IApprenticeshipProgramme>> programmes)
         {
             return ruleBuilder.Custom((vacancy, context) =>
             {
-                var matchingProgramme = programmes.SingleOrDefault(x => x.Id.Equals(vacancy.ProgrammeId, StringComparison.InvariantCultureIgnoreCase));
+                var matchingProgramme = programmes.Value.SingleOrDefault(x => x.Id.Equals(vacancy.ProgrammeId, StringComparison.InvariantCultureIgnoreCase));
 
                 if (matchingProgramme.EffectiveTo != null && matchingProgramme.EffectiveTo < vacancy.StartDate)
                 {

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators.VacancyValidators;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
@@ -9,15 +11,15 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
     {
         private readonly ITimeProvider _timeProvider;
         private readonly IMinimumWageProvider _minimumWageService;
-        private readonly IApprenticeshipProgrammeProvider _apprenticeshipProgrammesProvider;
         private readonly IQualificationsProvider _qualificationsProvider;
+        private readonly Lazy<IEnumerable<IApprenticeshipProgramme>> _apprenticeshipProgrammes;
 
         public FluentVacancyValidator(ITimeProvider timeProvider, IMinimumWageProvider minimumWageService, IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider, IQualificationsProvider qualificationsProvider)
         {
             _timeProvider = timeProvider;
             _minimumWageService = minimumWageService;
-            _apprenticeshipProgrammesProvider = apprenticeshipProgrammesProvider;
             _qualificationsProvider = qualificationsProvider;
+            _apprenticeshipProgrammes = new Lazy<IEnumerable<IApprenticeshipProgramme>>(() => apprenticeshipProgrammesProvider.GetApprenticeshipProgrammesAsync().Result);
 
             SingleFieldValidations();
 
@@ -567,7 +569,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
             When(x => x.ProgrammeId != null && !string.IsNullOrWhiteSpace(x.ProgrammeId) && x.StartDate.HasValue, () =>
             {
                 RuleFor(x => x)
-                    .TrainingMustBeActiveForStartDate(_apprenticeshipProgrammesProvider.GetApprenticeshipProgrammesAsync().Result)
+                    .TrainingMustBeActiveForStartDate(_apprenticeshipProgrammes)
                 .RunCondition(VacancyRuleSet.TrainingExpiryDate)
                 .WithRuleId(VacancyRuleSet.TrainingExpiryDate);
             });


### PR DESCRIPTION
Webjobs failed to start if the apprenticeship programmes were not populated in the collection.
This was due to the Singleton instance of the vacancy validator making a call to get them on webjob initialisation
Have made it a lazy call in that validator setup.