### PR TITLE
Redirect to root if auth fails

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -133,6 +133,20 @@ namespace Esfa.Recruit.Employer.Web.Configuration
                     await PopulateAccountsClaim(ctx, vacancyClient);
                     await HandleUserSignedIn(ctx, vacancyClient);
                 };
+
+                options.Events.OnRemoteFailure = ctx =>
+                {
+                    if (ctx.Failure.Message.Contains("Correlation failed"))
+                    {
+                        var logger = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>().CreateLogger<Startup>();
+                        logger.LogDebug("Correlation Cookie was invalid - probably timed-out");
+
+                        ctx.Response.Redirect("/");
+                        ctx.HandleResponse();
+                    }
+
+                    return Task.CompletedTask;
+                };
             });
         }
         


### PR DESCRIPTION
We see 'Correlation Failed' error when the user has spent > 15 mins on logon page before logging in. This is a built in security feature. The timeout value can be configured.

This fix catches this exception and redirects to the root which in effect makes them start from the employer start page again.