### PR TITLE
Gtm csp update

### DIFF
--- a/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
+++ b/src/Employer/Employer.Web/Filters/CheckEmployerBlockedFilter.cs
@@ -57,7 +57,7 @@ namespace Esfa.Recruit.Employer.Web.Filters
         {
             var controllerName = (((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)context.ActionDescriptor).ControllerTypeInfo).Name;
 
-            var whitelistControllers = new List<string> { nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController) };
+            var whitelistControllers = new List<string> { nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController), nameof(ContentPolicyReportController) };
 
             return whitelistControllers.Contains(controllerName);
         }

--- a/src/Employer/Employer.Web/Filters/LevyDeclarationCheckFilter.cs
+++ b/src/Employer/Employer.Web/Filters/LevyDeclarationCheckFilter.cs
@@ -89,7 +89,7 @@ namespace Esfa.Recruit.Employer.Web.Filters
         {
             var controllerName = (((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)context.ActionDescriptor).ControllerTypeInfo).Name;
 
-            var whitelistControllers = new List<string>{ nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController) };
+            var whitelistControllers = new List<string>{ nameof(ErrorController), nameof(LogoutController), nameof(ExternalLinksController), nameof(ContentPolicyReportController) };
             
             return whitelistControllers.Contains(controllerName);
         }

--- a/src/Employer/Employer.Web/Startup.Configure.cs
+++ b/src/Employer/Employer.Web/Startup.Configure.cs
@@ -40,9 +40,18 @@ namespace Esfa.Recruit.Employer.Web
             app.UseCsp(options => options
                 .DefaultSources(s => s.Self())
                 .StyleSources(s => 
-                    s.Self()
-                    .CustomSources("https://www.googletagmanager.com/",
-                                    "https://www.tagmanager.google.com/")
+                    {
+                        s.Self()
+                        .CustomSources("https://www.googletagmanager.com/",
+                                        "https://www.tagmanager.google.com/",
+                                        "https://tagmanager.google.com/",
+                                        "https://fonts.googleapis.com/");
+
+                        if (!env.IsProduction())
+                        {
+                            s.UnsafeInline();
+                        }
+                    }
                 )
                 .ScriptSources(s => 
                     {
@@ -75,6 +84,7 @@ namespace Esfa.Recruit.Employer.Web
                     .CustomSources("https://maps.googleapis.com", 
                                     "https://www.google-analytics.com", 
                                     "https://ssl.gstatic.com",
+                                    "https://www.gstatic.com/",
                                     "data:")
                  )
                 .ReportUris(r => r.Uris("/ContentPolicyReport/Report")));

--- a/src/Employer/Employer.Web/Startup.Configure.cs
+++ b/src/Employer/Employer.Web/Startup.Configure.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Recruit.Employer.Web.Configuration;
+using Esfa.Recruit.Shared.Web.Configuration;
 using Esfa.Recruit.Shared.Web.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -47,7 +48,7 @@ namespace Esfa.Recruit.Employer.Web
                                         "https://tagmanager.google.com/",
                                         "https://fonts.googleapis.com/");
 
-                        if (!env.IsProduction())
+                        if (env.IsEnvironment(EnvironmentNames.PREPROD))
                         {
                             s.UnsafeInline();
                         }
@@ -64,7 +65,7 @@ namespace Esfa.Recruit.Employer.Web
                                         "https://services.postcodeanywhere.co.uk/")
                         .UnsafeInline();
 
-                        if (!env.IsProduction())
+                        if (env.IsEnvironment(EnvironmentNames.PREPROD))
                         {
                             s.UnsafeEval();
                         }


### PR DESCRIPTION

- Set 'unsafe' CSP rules only for PreProd
- Fixed CSP report as POST from the browser was failing due to filters. Added CSP controller to whitelist in filters.