### PR TITLE
ER-858 - Removing script unsafe-inline and using nonce instead

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ApplicationInsightsConfiguration.cs
+++ b/src/Employer/Employer.Web/Configuration/ApplicationInsightsConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Esfa.Recruit.Employer.Web.Configuration
+{
+    public class ApplicationInsightsConfiguration
+    {
+        public string InstrumentationKey { get; set; }
+    }
+}

--- a/src/Employer/Employer.Web/Configuration/IoC.cs
+++ b/src/Employer/Employer.Web/Configuration/IoC.cs
@@ -25,6 +25,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             services.AddRecruitStorageClient(configuration);
 
             //Configuration
+            services.Configure<ApplicationInsightsConfiguration>(configuration.GetSection("ApplicationInsights"));
             services.Configure<ExternalLinksConfiguration>(configuration.GetSection("ExternalLinks"));
             services.Configure<ManageApprenticeshipsRoutes>(configuration.GetSection("ManageApprenticeshipsRoutes"));
             services.AddSingleton<ManageApprenticeshipsLinkHelper>();

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.7.0" />
     <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
-    <PackageReference Include="NWebsec.Mvc" Version="5.1.1" />
     <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138" />

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -9,20 +9,23 @@
     <AssemblyName>Esfa.Recruit.Employer.Web</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2"/>
-    <PackageReference Include="Humanizer.Core.uk" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.App"/>
-    <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="1.1.0"/>
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.7.0"/>
-    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331"/>
-    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5"/>
-    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138"/>
-    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139"/>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1"/>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.5.2" />
+    <PackageReference Include="Humanizer.Core.uk" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
+    <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.7.0" />
+    <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
+    <PackageReference Include="NWebsec.Mvc" Version="5.1.1" />
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
+    <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
+    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj"/>
-    <ProjectReference Include="..\..\Shared\Recruit.Shared.Web\Recruit.Shared.Web.csproj"/>
+    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />
+    <ProjectReference Include="..\..\Shared\Recruit.Shared.Web\Recruit.Shared.Web.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="nlog.config">

--- a/src/Employer/Employer.Web/Startup.Configure.cs
+++ b/src/Employer/Employer.Web/Startup.Configure.cs
@@ -52,29 +52,31 @@ namespace Esfa.Recruit.Employer.Web
                                         "https://tagmanager.google.com/",
                                         "https://fonts.googleapis.com/");
 
+                        //Google tag manager uses inline styles when administering tags. This is done on PREPROD only
                         if (env.IsEnvironment(EnvironmentNames.PREPROD))
                         {
                             s.UnsafeInline();
                         }
                     }
                 )
-                .ScriptSources(s => 
+                .ScriptSources(s =>
                     {
                         s.Self()
-                        .CustomSources("https://az416426.vo.msecnd.net", 
-                                        "https://www.google-analytics.com/analytics.js", 
-                                        "https://www.googletagmanager.com/",
-                                        "https://www.tagmanager.google.com/", 
-                                        "https://tagmanager.google.com/", 
-                                        "https://services.postcodeanywhere.co.uk/")
-                        .UnsafeInline();
+                            .CustomSources("https://az416426.vo.msecnd.net",
+                                "https://www.google-analytics.com/analytics.js",
+                                "https://www.googletagmanager.com/",
+                                "https://www.tagmanager.google.com/",
+                                "https://tagmanager.google.com/",
+                                "https://services.postcodeanywhere.co.uk/");
 
+                        //Google tag manager uses inline scripts when administering tags. This is done on PREPROD only
                         if (env.IsEnvironment(EnvironmentNames.PREPROD))
                         {
+                            s.UnsafeInline();
                             s.UnsafeEval();
                         }
                     }
-                ) // TODO: Look at moving AppInsights inline js code.
+                )
                 .FontSources(s => 
                     s.Self()
                     .CustomSources("data:",

--- a/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReview.cshtml
+++ b/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReview.cshtml
@@ -313,7 +313,7 @@
     </div>
 </div>
 
-<script>
+<script nws-csp-add-nonce="true">
     $(function () {
         var showHideContent = new GOVUK.ShowHideContent();
         showHideContent.init();

--- a/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Employer/Employer.cshtml
@@ -74,7 +74,7 @@
 </div>
 @section HeadJS
 {
-<script>
+<script nws-csp-add-nonce="true">
 window.EsfaRecruit.PcaConfig = {
     key: '@PcaConfig.Value.Key',
     findEndpoint: '@PcaConfig.Value.FindEndpoint',
@@ -84,7 +84,7 @@ window.EsfaRecruit.PcaConfig = {
 }
 @section FooterJS
 {
-<script asp-show="@Model.HasMoreThanOneOrganisation">
+<script nws-csp-add-nonce="true" asp-show="@Model.HasMoreThanOneOrganisation">
 $(document).ready(function() {
     var orgInputName = "@nameof(EmployerViewModel.SelectedOrganisationId)";
 	var addresses = @Json.Serialize(Model.Organisations);

--- a/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
@@ -99,7 +99,7 @@
 @section FooterJS
 {
 <script src="/lib/select2/select2.min.js"></script>
-<script>
+<script nws-csp-add-nonce="true">
     $(function () {
         $('#SelectedProgrammeId').select2();
     });

--- a/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
@@ -93,7 +93,7 @@
     </div>
 </div>
 
-<script>
+<script nws-csp-add-nonce="true">
     $(function () {
         var showHideContent = new GOVUK.ShowHideContent();
         showHideContent.init();

--- a/src/Employer/Employer.Web/Views/Part2/ApplicationProcess/ApplicationProcess.cshtml
+++ b/src/Employer/Employer.Web/Views/Part2/ApplicationProcess/ApplicationProcess.cshtml
@@ -56,7 +56,7 @@
 </div>
 @section footerJS
 {
-    <script>
+    <script nws-csp-add-nonce="true">
         $(function () {
             var showHideContent = new GOVUK.ShowHideContent();
             showHideContent.init();

--- a/src/Employer/Employer.Web/Views/PartialNames.cs
+++ b/src/Employer/Employer.Web/Views/PartialNames.cs
@@ -2,6 +2,7 @@
 {
     public static class PartialNames
     {
+        public const string ApplicationInsightsPartial = "_ApplicationInsightsPartial";
         public const string DisabilityConfident = "_DisabilityConfidentPartial";
         public const string GoogleTagManagerHeadPartial = "_GoogleTagManagerHeadPartial";
         public const string GoogleTagManagerBodyPartial = "_GoogleTagManagerBodyPartial";

--- a/src/Employer/Employer.Web/Views/Shared/_ApplicationInsightsPartial.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_ApplicationInsightsPartial.cshtml
@@ -1,0 +1,13 @@
+﻿@using Microsoft.Extensions.Options
+@inject IOptions<ApplicationInsightsConfiguration> ApplicationInsights
+
+<!-- AppInsights script -->
+<script type="text/javascript" nws-csp-add-nonce="true">
+    var appInsights=window.appInsights||function(a){
+        function b(a){c[a]=function(){var b=arguments;c.queue.push(function(){c[a].apply(c,b)})}}var c={config:a},d=document,e=window;setTimeout(function(){var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)});try{c.cookie=d.cookie}catch(a){}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){var i=g&&g(a,b,d,e,h);return!0!==i&&c["_"+f](a,b,d,e,h),i}}return c
+    }({
+        instrumentationKey: '@ApplicationInsights.Value.InstrumentationKey'
+    });
+
+    window.appInsights=appInsights,appInsights.queue&&0===appInsights.queue.length&&appInsights.trackPageView();
+</script>

--- a/src/Employer/Employer.Web/Views/Shared/_Layout.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_Layout.cshtml
@@ -1,7 +1,6 @@
-﻿@using Esfa.Recruit.Employer.Web.Configuration;
-@using Esfa.Recruit.Employer.Web.Configuration.Routing;
-@using Esfa.Recruit.Shared.Web.Configuration
+﻿@using Esfa.Recruit.Shared.Web.Configuration
 @inject ManageApprenticeshipsLinkHelper ExternalLinks
+
 @functions
 {
 public bool ParseHideNavFromViewBag()
@@ -70,26 +69,28 @@ public bool IsErrorPage()
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:image" content="/lib/esfa-govuk/assets/images/opengraph-image.png">
     <link asp-append-version="true" rel="stylesheet" media="screen" href="/css/application.css" />
+    <partial name="@PartialNames.ApplicationInsightsPartial" />
     <script src="@Url.Content("/lib/jquery/dist/jquery.js")"></script>
     <script src="@Url.Content("/lib/jquery-are-you-sure/jquery.are-you-sure.js")"></script>
     <environment exclude="@EnvironmentNames.GetTestEnvironmentNamesCommaDelimited()">
         <partial name="@PartialNames.GoogleTagManagerHeadPartial" />
     </environment>
-    @Html.Raw(JavaScriptSnippet.FullScript) <!-- AppInsights script -->
-    <script>window.EsfaRecruit = {};</script>
+    <script nws-csp-add-nonce="true">
+        window.EsfaRecruit = {};
+    </script>
     @RenderSection(RazorSections.HeadJS, required: false)
+
 </head>
 <body>
     <environment exclude="@EnvironmentNames.GetTestEnvironmentNamesCommaDelimited()">
         <partial name="@PartialNames.GoogleTagManagerBodyPartial" />
     </environment>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script nws-csp-add-nonce="true">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <div id="skiplink-container">
         <div>
             <a href="#content" class="skiplink">Skip to main content</a>
         </div>
     </div>
-
     <div asp-show="@ViewContext.ViewData[ViewDataKeys.CanShowOutageMessage] as bool?" id="global-outage-message" class="global-message">
         <p>@ViewContext.ViewData[ViewDataKeys.PlannedOutageMessage]</p>
         <form asp-route="@RouteNames.DismissOutageMessage_Post" novalidate>
@@ -97,11 +98,9 @@ public bool IsErrorPage()
             <button type="submit" class="button-fake-link">Dismiss</button>
         </form>
     </div>
-
     <div id="global-cookie-message">
         <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
     </div>
-
     <header role="banner" id="global-header" class="with-proposition">
         <div class="header-wrapper">
             <div class="header-global">

--- a/src/Employer/Employer.Web/Views/Shared/_LayoutWithoutNavigation.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_LayoutWithoutNavigation.cshtml
@@ -18,53 +18,53 @@ public string GetTitle()
 <html lang="en">
 <!--<![endif]-->
 <head>
-	<meta charset="utf-8" />
-	<title>@GetTitle()</title>
-	<!-- TEMPLATE STYLES - START -->
-	<!--[if gt IE 8]><!-->
-	<link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template.min.css?0.23.0" /><!--<![endif]-->
-	<!--[if IE 6]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie6.min.css?0.23.0" /><![endif]-->
-	<!--[if IE 7]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie7.min.css?0.23.0" /><![endif]-->
-	<!--[if IE 8]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie8.min.css?0.23.0" /><![endif]-->
-	<link rel="stylesheet" media="print" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-print.min.css?0.23.0" />
-	<!--[if IE 8]><link rel="stylesheet" media="all" href="/lib/esfa-govuk/assets/stylesheets/fonts-ie8.min.css?0.23.0" /><![endif]-->
-	<!--[if gte IE 9]><!-->
-	<link rel="stylesheet" media="all" href="/lib/esfa-govuk/assets/stylesheets/fonts.min.css?0.23.0" /><!--<![endif]-->
-	<!-- TEMPLATE STYLES - END -->
-	<!-- ELEMENTS AND TOOLKIT STYLES - START -->
-	<!--[if gt IE 8]><!-->
-	<link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-base.min.css?3.1.2" /><!--<![endif]-->
-	<!--[if IE 6]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie6.min.css?3.1.2" /><![endif]-->
-	<!--[if IE 7]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie7.min.css?3.1.2" /><![endif]-->
-	<!--[if IE 8]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie8.min.css?3.1.2" /><![endif]-->
-	<!-- ELEMENTS AND TOOLKIT STYLES - END -->
-	<!--[if lt IE 9]><script src="/lib/esfa-govuk/assets/javascripts/ie.js?0.23.0"></script><![endif]-->
-	<link rel="shortcut icon" href="/lib/esfa-govuk/assets/images/favicon.ico" type="image/x-icon" />
-	<link rel="mask-icon" href="/lib/esfa-govuk/assets/images/gov.uk_logotype_crown.svg" color="#0b0c0c">
-	<link rel="apple-touch-icon" sizes="180x180" href="/lib/esfa-govuk/assets/images/apple-touch-icon-180x180.png">
-	<link rel="apple-touch-icon" sizes="167x167" href="/lib/esfa-govuk/assets/images/apple-touch-icon-167x167.png">
-	<link rel="apple-touch-icon" sizes="152x152" href="/lib/esfa-govuk/assets/images/apple-touch-icon-152x152.png">
-	<link rel="apple-touch-icon" href="/lib/esfa-govuk/assets/images/apple-touch-icon.png">
-	<meta name="theme-color" content="#0b0c0c" />
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta property="og:image" content="/lib/esfa-govuk/assets/images/opengraph-image.png">
-	<link asp-append-version="true" rel="stylesheet" media="screen" href="/css/application.css" />
-	<script src="/lib/jquery/dist/jquery.js"></script>
-	<environment exclude="@EnvironmentNames.GetTestEnvironmentNamesCommaDelimited()">
-    <partial name="@PartialNames.GoogleTagManagerHeadPartial" />
+    <meta charset="utf-8" />
+    <title>@GetTitle()</title>
+    <!-- TEMPLATE STYLES - START -->
+    <!--[if gt IE 8]><!-->
+    <link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template.min.css?0.23.0" /><!--<![endif]-->
+    <!--[if IE 6]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie6.min.css?0.23.0" /><![endif]-->
+    <!--[if IE 7]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie7.min.css?0.23.0" /><![endif]-->
+    <!--[if IE 8]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-ie8.min.css?0.23.0" /><![endif]-->
+    <link rel="stylesheet" media="print" href="/lib/esfa-govuk/assets/stylesheets/govuk-template-print.min.css?0.23.0" />
+    <!--[if IE 8]><link rel="stylesheet" media="all" href="/lib/esfa-govuk/assets/stylesheets/fonts-ie8.min.css?0.23.0" /><![endif]-->
+    <!--[if gte IE 9]><!-->
+    <link rel="stylesheet" media="all" href="/lib/esfa-govuk/assets/stylesheets/fonts.min.css?0.23.0" /><!--<![endif]-->
+    <!-- TEMPLATE STYLES - END -->
+    <!-- ELEMENTS AND TOOLKIT STYLES - START -->
+    <!--[if gt IE 8]><!-->
+    <link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-base.min.css?3.1.2" /><!--<![endif]-->
+    <!--[if IE 6]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie6.min.css?3.1.2" /><![endif]-->
+    <!--[if IE 7]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie7.min.css?3.1.2" /><![endif]-->
+    <!--[if IE 8]><link rel="stylesheet" media="screen" href="/lib/esfa-govuk/assets/stylesheets/esfa-govuk-ie8.min.css?3.1.2" /><![endif]-->
+    <!-- ELEMENTS AND TOOLKIT STYLES - END -->
+    <!--[if lt IE 9]><script src="/lib/esfa-govuk/assets/javascripts/ie.js?0.23.0"></script><![endif]-->
+    <link rel="shortcut icon" href="/lib/esfa-govuk/assets/images/favicon.ico" type="image/x-icon" />
+    <link rel="mask-icon" href="/lib/esfa-govuk/assets/images/gov.uk_logotype_crown.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/lib/esfa-govuk/assets/images/apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/lib/esfa-govuk/assets/images/apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/lib/esfa-govuk/assets/images/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/lib/esfa-govuk/assets/images/apple-touch-icon.png">
+    <meta name="theme-color" content="#0b0c0c" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:image" content="/lib/esfa-govuk/assets/images/opengraph-image.png">
+    <link asp-append-version="true" rel="stylesheet" media="screen" href="/css/application.css" />
+    <partial name="@PartialNames.ApplicationInsightsPartial" />
+    <script src="/lib/jquery/dist/jquery.js"></script>
+    <environment exclude="@EnvironmentNames.GetTestEnvironmentNamesCommaDelimited()">
+        <partial name="@PartialNames.GoogleTagManagerHeadPartial" />
     </environment>
-	@Html.Raw(JavaScriptSnippet.FullScript) <!-- AppInsights script -->
-	<script>
-		window.EsfaRecruit = {};
-	</script>
-	@RenderSection(RazorSections.HeadJS, required: false)
+    <script nws-csp-add-nonce="true">
+        window.EsfaRecruit = {};
+    </script>
+    @RenderSection(RazorSections.HeadJS, required: false)
 </head>
 
 <body>
     <environment exclude="@EnvironmentNames.GetTestEnvironmentNamesCommaDelimited()">
     <partial name="@PartialNames.GoogleTagManagerBodyPartial" />
     </environment>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script nws-csp-add-nonce="true">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <div id="skiplink-container">
         <div>
             <a href="#content" class="skiplink">Skip to main content</a>

--- a/src/Employer/Employer.Web/Views/_ViewImports.cshtml
+++ b/src/Employer/Employer.Web/Views/_ViewImports.cshtml
@@ -11,4 +11,5 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Recruit.Shared.Web
 @addTagHelper *, Esfa.Recruit.Employer.Web
+@addTagHelper *, NWebsec.AspNetCore.Mvc.TagHelpers
 @inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet

--- a/src/Shared/Recruit.Shared.Web/Views/Shared/_GoogleTagManagerHeadPartial.cshtml
+++ b/src/Shared/Recruit.Shared.Web/Views/Shared/_GoogleTagManagerHeadPartial.cshtml
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Options;
 @inject IOptions<GoogleAnalyticsConfiguration> GaConfig
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script nws-csp-add-nonce="true">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);


### PR DESCRIPTION
In readiness for the HTML editor we want to add for ER-822 to use I've tightened our CSP.  Previously we allowed unsafe-inline for script sources which I have now removed and replaced with nonces.

- Upgraded NWebSec and added NWebSec MVC & HtmlHelpers
- Added a partial for ApplicationInsights to replace the helper function so we can add a nonce to the script tag