### PR TITLE
Filter out warning logs for the oidc handler

### DIFF
--- a/src/Employer/Employer.Web/appsettings.json
+++ b/src/Employer/Employer.Web/appsettings.json
@@ -5,7 +5,8 @@
       "LogLevel": {
         "Default": "Debug",
         "System": "Information",
-        "Microsoft": "Information"
+        "Microsoft": "Information",
+        "Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler": "Error"
       }
     },
     "LogLevel": {


### PR DESCRIPTION
Filtering out the warning messages like 
`
'.AspNetCore.Correlation.oidc.1v9oZ16D5qHsoLyu7xYWAviHVoK1l1lZIzCWSwZTymE' cookie not found
`
from our logs.

It does mean all logs that are not errors from that oidc handler wont be logged.