### PR TITLE
ER-835 Adds School to banned phrases

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BannedPhrases.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BannedPhrases.json
@@ -28,6 +28,8 @@
     "Mature",
     "Fingers",
     "Head",
-    "Jump"
+    "Jump",
+    "school",
+    "schools"
   ]
 }


### PR DESCRIPTION
Not sure why some of the words in the list starts with uppercase letter and some don't, do we need to make it consistent by having all the words in lowercase?