### PR TITLE
RA-835 Fixes banned phrases not picked as prefixed by special chars

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/Rules/BaseRules/BaseBannedPhraseChecksRule.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Rules/BaseRules/BaseBannedPhraseChecksRule.cs
@@ -84,7 +84,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Rules.BaseRules
         {
             var count = foundBannedPhrases.Values.Sum();
             var terms = string.Join(",", foundBannedPhrases.Keys);
-            var narrative = $"{count} profanities '{terms}' found in '{fieldId}'";
+            var narrative = $"{count} banned phrases '{terms}' found in '{fieldId}'";
             var data = JsonConvert.SerializeObject(new BannedPhrasesData { BannedPhrase = terms, Occurrences = count });
 
             return new[]

--- a/src/Shared/Recruit.Vacancies.Client/Application/Rules/Extensions/StringExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Rules/Extensions/StringExtensions.cs
@@ -12,14 +12,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Rules.Extensions
         {
             if (string.IsNullOrWhiteSpace(value)) return string.Empty;
 
-            // strip delimiters
-            var delimeters = new[] {'"', '.', '?', '!', '_', ';', ':', ',', '-', '\'', '(', ')', '*'};
+            var rgx = new Regex("[^a-zA-Z0-9]");
+            var sanitized = rgx.Replace(value, " ");
 
-            var formatted = value.Replace(delimeters, " ");
+            sanitized = RemoveContiguousWhitespace(sanitized);
 
-            formatted = RemoveContiguousWhitespace(formatted);
-
-            return $" {formatted} ".ToLower();
+            return $" {sanitized} ";
         }
 
         public static string FormatForComparison(this string value, string[] stopWords = null)
@@ -48,16 +46,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Rules.Extensions
         {
             return items == null ? string.Empty : string.Join(delimiter, items);
         }
-
-        private static string Replace(this string value, char[] separators, string replacement)
-        {
-            if (string.IsNullOrWhiteSpace(value)) return string.Empty;
-
-            var temp = value.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-
-            return string.Join(replacement, temp);
-        }
-
+        
         private static string RemoveContiguousWhitespace(string value)
         {
             return Regex.Replace(value, @"\s+", " ");

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/TestVacancyBuilder.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/TestVacancyBuilder.cs
@@ -47,5 +47,13 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.R
             entity.Skills = skills.ToList();
             return entity;
         }
+
+        internal static Vacancy SetDetails(this Vacancy entity, string title, string description)
+        {
+            entity.Title = title;
+            entity.Description = description;
+
+            return entity;
+        }
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Rules;
+using Esfa.Recruit.Vacancies.Client.Application.Rules.BaseRules;
+using Esfa.Recruit.Vacancies.Client.Application.Rules.VacancyRules;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules;
+using FluentAssertions;
+using Microsoft.Azure.Amqp.Serialization;
+using Moq;
+using Xunit;
+
+namespace UnitTests.Vacancies.Client.Application.Rules.VacancyRules
+{
+    public class VacancyBannedPhraseChecksRuleTest
+    {
+        private readonly IBannedPhrasesProvider _bannedPhrasesProvider;
+        private readonly IEnumerable<string> _bannedPhrases = new[] { "school", "schools", "driving license", "over 18" };
+        public VacancyBannedPhraseChecksRuleTest()
+        {
+            var mockBannedPhraseProvider = new Mock<IBannedPhrasesProvider>();
+            mockBannedPhraseProvider.Setup(b => b.GetBannedPhrasesAsync()).Returns(Task.FromResult(_bannedPhrases));
+            _bannedPhrasesProvider = mockBannedPhraseProvider.Object;
+        }
+
+        [Fact]
+        public void ShouldIgnoreNonAlphaNumericCharacters()
+        {
+             var sut = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider);
+
+            var vacancy = new Fixture()
+                .Build<Vacancy>()
+                .With(v => v.Title,
+                    @"Dolore school leavers “school"" leaver 5pm, shifts, may work evenings and weekends school") 
+                .Create();
+
+
+            var result = sut.EvaluateAsync(vacancy).Result;
+
+            result.Details.First(d => d.Target == "Title");
+
+            result.Score.Should().Be(100);
+        }
+
+        [Fact]
+        public void ShouldWorkWithTheOnly()
+        {
+            var sut = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider);
+
+            var vacancy = new Fixture()
+                .Build<Vacancy>()
+                .With(v => v.Title,
+                    @"school")
+                .Create();
+
+
+            var result = sut.EvaluateAsync(vacancy).Result;
+
+            result.Details.First(d => d.Target == "Title");
+
+            result.Score.Should().Be(100);
+        }
+
+        [Theory]
+        [InlineData("a driving license is required", 1)]
+        [InlineData("driving - license required", 1)]
+        [InlineData("*driving*license* is required", 1)]
+        [InlineData("driving license", 100, 100)]
+        [InlineData("driving license, driving license, driving license", 100, 100)]
+        [InlineData("driving license over 18", 100, 100)]
+        [InlineData("*driving \t \n license* is required", 1)]
+        [InlineData("occasionally there may be some driving. licensees are required to like beer", 0)]
+        [InlineData("a great mover, 18 moves at least!", 0)]
+        [InlineData("school", 1)]
+        public void WhenInvoked_ItShouldReturnTheExpectedScore(string phrase, int expectedScore,
+            decimal weighting = 1.0m)
+        {
+            var rule = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider, ConsolidationOption.ConsolidateByField, weighting);
+
+            var entity = TestVacancyBuilder.Create().SetDetails(phrase, string.Empty);
+
+            var outcome = rule.EvaluateAsync(entity).Result;
+
+            outcome.Score.Should().Be(expectedScore);
+        }
+
+        [Fact]
+        public void ShouldReturnAnOverallUnconsolidatedNarrative()
+        {
+            var rule = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider);
+
+            var skills = new[] { "Juggling", "Running", "driving license" };
+
+            var entity = TestVacancyBuilder.Create()
+                .SetDetails("driving - license required", "must be over 18 years of age and hold a clean driving license, yes a driving license!")
+                .SetSkills(skills);
+
+            var outcome = rule.EvaluateAsync(entity).Result;
+
+            outcome.Narrative.Should().Contain("Banned phrase 'driving license' found in 'Title'");
+            outcome.Narrative.Should().Contain("Banned phrase 'driving license' found 2 times in 'Description'");
+            outcome.Narrative.Should().Contain("Banned phrase 'over 18' found in 'Description'");
+            outcome.Narrative.Should().Contain("Banned phrase 'driving license' found in 'Skills'");
+        }
+
+        [Fact]
+        public void ShouldReturnAnOverallConsolidatedNarrative()
+        {
+            var rule = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider, ConsolidationOption.ConsolidateByField);
+
+            var skills = new[] { "Juggling", "Running", "driving license" };
+
+            var entity = TestVacancyBuilder.Create()
+                .SetDetails("driving - license required", "must be over 18 years of age and hold a clean driving license, yes a driving license!")
+                .SetSkills(skills);
+
+            var outcome = rule.EvaluateAsync(entity).Result;
+
+            outcome.Narrative.Should().Contain("1 banned phrases 'driving license' found in 'Title'");
+            outcome.Narrative.Should().Contain("3 banned phrases 'driving license,over 18' found in 'Description'");
+            outcome.Narrative.Should().Contain("1 banned phrases 'driving license' found in 'Skills'");
+        }
+
+        [Fact]
+        public void WhenInvoked_ItShouldIncludeDetailsOfEachFieldOutcome()
+        {
+            var rule = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider);
+
+            var skills = new[] { "Juggling", "Running", "driving license" };
+
+            var entity = TestVacancyBuilder.Create()
+                .SetDetails("an apprenticeship", "must be over 18 years of age and hold a clean driving license")
+                .SetSkills(skills);
+
+            var outcome = rule.EvaluateAsync(entity).Result;
+
+            outcome.HasDetails.Should().BeTrue();
+
+            Assert.All(outcome.Details, a =>
+            {
+                a.Target.Should().NotBeEmpty();
+                a.Narrative.Should().NotBeEmpty();
+            });
+        }
+
+    }
+
+    
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
@@ -35,28 +35,8 @@ namespace UnitTests.Vacancies.Client.Application.Rules.VacancyRules
             var vacancy = new Fixture()
                 .Build<Vacancy>()
                 .With(v => v.Title,
-                    @"Dolore school leavers “school"" leaver 5pm, shifts, may work evenings and weekends school") 
+                    @"Dolore school leavers ï¿½school"" leaver 5pm, shifts, may work evenings and weekends school") 
                 .Create();
-
-
-            var result = sut.EvaluateAsync(vacancy).Result;
-
-            result.Details.First(d => d.Target == "Title");
-
-            result.Score.Should().Be(100);
-        }
-
-        [Fact]
-        public void ShouldWorkWithTheOnly()
-        {
-            var sut = new VacancyBannedPhraseChecksRule(_bannedPhrasesProvider);
-
-            var vacancy = new Fixture()
-                .Build<Vacancy>()
-                .With(v => v.Title,
-                    @"school")
-                .Create();
-
 
             var result = sut.EvaluateAsync(vacancy).Result;
 


### PR DESCRIPTION
The FormatForParsing was replacing only black listed special characters, I inverted it to white listing alpha-numerics so everything else gets replaced. 