### PR TITLE
ER-850 - Fixing recreation of published vacancies

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
@@ -88,8 +88,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             await RetryPolicy.ExecuteAsync(context => collection.DeleteManyAsync(filter), new Context(nameof(IQueryStore.RecreateAsync)));
 
             if (items.Count == 0) return;
-            
-            await RetryPolicy.ExecuteAsync(context => collection.InsertManyAsync(items), new Context(nameof(IQueryStore.RecreateAsync)));
+
+            foreach (var item in items)
+            {
+                await RetryPolicy.ExecuteAsync(context => collection.InsertOneAsync(item), new Context(nameof(IQueryStore.RecreateAsync)));
+            }
         }
     }
 }


### PR DESCRIPTION
Recreating the published vacancies was failing during the bulk insertion of vacancies to the querystore.  This is due to the RU limit being reached and throwing `Error executing Mongo Command for method RecreateAsync Reason: A bulk write operation resulted in one or more errors. Message: {"Errors":["Request rate is large"]}`.

The retry would then execute then we would get duplicate key errors `Error executing Mongo Command for method RecreateAsync Reason: A bulk write operation resulted in one or more errors.
  E11000 duplicate key error collection: recruit.queryStore Failed _id or unique key constraint. Retrying in 2 secs...attempt: 2`

So I've changed the inserting of entities to be done one at a time.