### PR TITLE
Downgrade aspnetcore2.2

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -27,7 +27,7 @@
             "request": "launch",
             "preLaunchTask": "build-emp-web",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Employer/Employer.Web/bin/Debug/netcoreapp2.2/Esfa.Recruit.Employer.Web.dll",
+            "program": "${workspaceFolder}/Employer/Employer.Web/bin/Debug/netcoreapp2.1/Esfa.Recruit.Employer.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Employer/Employer.Web",
             "stopAtEntry": false,
@@ -59,7 +59,7 @@
             "request": "launch",
             "preLaunchTask": "build-prov-web",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Provider/Provider.Web/bin/Debug/netcoreapp2.2/Esfa.Recruit.Provider.Web.dll",
+            "program": "${workspaceFolder}/Provider/Provider.Web/bin/Debug/netcoreapp2.1/Esfa.Recruit.Provider.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Provider/Provider.Web",
             "stopAtEntry": false,
@@ -91,7 +91,7 @@
             "request": "launch",
             "preLaunchTask": "build-qa-web",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/QA/QA.Web/bin/Debug/netcoreapp2.2/Esfa.Recruit.Qa.Web.dll",
+            "program": "${workspaceFolder}/QA/QA.Web/bin/Debug/netcoreapp2.1/Esfa.Recruit.Qa.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/QA/QA.Web",
             "stopAtEntry": false,

--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -92,7 +92,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
                 opts.AddTrimModelBinderProvider(loggerFactory);
             })
             .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>())
-            .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 
         public static void AddAuthenticationService(this IServiceCollection services, AuthenticationConfiguration authConfig, IEmployerVacancyClient vacancyClient, IHostingEnvironment hostingEnvironment)

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />

--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>recruit-employer-web</UserSecretsId>
     <RootNamespace>Esfa.Recruit.Employer.Web</RootNamespace>
   </PropertyGroup>

--- a/src/Employer/Employer.Web/Program.cs
+++ b/src/Employer/Employer.Web/Program.cs
@@ -35,7 +35,7 @@ namespace Esfa.Recruit.Employer.Web
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureKestrel(c => c.AddServerHeader = false)
+                .UseKestrel(c => c.AddServerHeader = false)
                 .UseStartup<Startup>()
                 .UseUrls("http://localhost:5020")
                 .UseNLog()

--- a/src/Employer/Employer.Web/Startup.ConfigureServices.cs
+++ b/src/Employer/Employer.Web/Startup.ConfigureServices.cs
@@ -1,14 +1,12 @@
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using StackExchange.Redis;
 
 namespace Esfa.Recruit.Employer.Web
 {
@@ -33,9 +31,6 @@ namespace Esfa.Recruit.Employer.Web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddIoC(_configuration);
-
-            var redis = ConnectionMultiplexer.Connect(_configuration.GetConnectionString("StorageRedis"));
-            services.AddDataProtection().PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys");
 
             // Routing has to come before adding Mvc
             services.AddRouting(opt =>

--- a/src/Employer/UnitTests/UnitTests.csproj
+++ b/src/Employer/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Esfa.Recruit.Employer.UnitTests</RootNamespace>
   </PropertyGroup>

--- a/src/Provider/Provider.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Provider/Provider.Web/Configuration/ConfigurationExtensions.cs
@@ -66,7 +66,7 @@ namespace Esfa.Recruit.Provider.Web.Configuration
                 opts.AddTrimModelBinderProvider(loggerFactory);
             })
             .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>())
-            .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 
         public static void AddAuthenticationService(this IServiceCollection services, AuthenticationConfiguration authConfig, IEmployerVacancyClient vacancyClient, IHostingEnvironment hostingEnvironment)

--- a/src/Provider/Provider.Web/Program.cs
+++ b/src/Provider/Provider.Web/Program.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Provider.Web
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureKestrel(c => c.AddServerHeader = false)
+                .UseKestrel(c => c.AddServerHeader = false)
                 .UseStartup<Startup>()
                 .UseUrls("https://localhost:5030")
                 .UseNLog()

--- a/src/Provider/Provider.Web/Provider.Web.csproj
+++ b/src/Provider/Provider.Web/Provider.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>recruit-provider-web</UserSecretsId>
     <RootNamespace>Esfa.Recruit.Provider.Web</RootNamespace>
   </PropertyGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />

--- a/src/Provider/Provider.Web/Provider.Web.csproj
+++ b/src/Provider/Provider.Web/Provider.Web.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />

--- a/src/Provider/Provider.Web/Startup.ConfigureServices.cs
+++ b/src/Provider/Provider.Web/Startup.ConfigureServices.cs
@@ -1,12 +1,10 @@
 using Esfa.Recruit.Provider.Web.Configuration;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using StackExchange.Redis;
 
 namespace Esfa.Recruit.Provider.Web
 {
@@ -29,9 +27,6 @@ namespace Esfa.Recruit.Provider.Web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddIoC(_configuration);
-
-            var redis = ConnectionMultiplexer.Connect(_configuration.GetConnectionString("StorageRedis"));
-            services.AddDataProtection().PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys");
 
             // Routing has to come before adding Mvc
             services.AddRouting(opt =>

--- a/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
+++ b/src/QA/QA.Web/Configuration/ServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace Esfa.Recruit.Qa.Web.Configuration
                 }
             })
             .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>())
-            .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
     }
 }

--- a/src/QA/QA.Web/Program.cs
+++ b/src/QA/QA.Web/Program.cs
@@ -47,10 +47,7 @@ namespace Esfa.Recruit.Qa.Web
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureKestrel(c =>
-                {
-                    c.AddServerHeader = false;
-                })
+                .UseKestrel(c => c.AddServerHeader = false)
                 .UseStartup<Startup>()
                 .UseUrls("https://localhost:5025")
                 .UseNLog()

--- a/src/QA/QA.Web/QA.Web.csproj
+++ b/src/QA/QA.Web/QA.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>recruit-qa-web</UserSecretsId>
     <RootNamespace>Esfa.Recruit.Qa.Web</RootNamespace>
   </PropertyGroup>
@@ -13,7 +13,7 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.4"/>
     <PackageReference Include="NLog" Version="4.5.4"/>
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5"/>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.2.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.1.2"/>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1"/>
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.375"/>
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0"/>

--- a/src/QA/QA.Web/QA.Web.csproj
+++ b/src/QA/QA.Web/QA.Web.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.375"/>
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0"/>
     <PackageReference Include="Humanizer.Core.uk" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="nlog.config" CopyToOutputDirectory="PreserveNewest"/>

--- a/src/QA/QA.Web/Startup.ConfigureServices.cs
+++ b/src/QA/QA.Web/Startup.ConfigureServices.cs
@@ -4,13 +4,11 @@ using Esfa.Recruit.Qa.Web.Orchestrators;
 using Esfa.Recruit.Qa.Web.Security;
 using Esfa.Recruit.Shared.Web.RuleTemplates;
 using Esfa.Recruit.Shared.Web.Services;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using StackExchange.Redis;
 
 namespace Esfa.Recruit.Qa.Web
 {
@@ -38,9 +36,6 @@ namespace Esfa.Recruit.Qa.Web
         {
             //A service provider for resolving services configured in IoC
             var sp = services.BuildServiceProvider();
-
-            var redis = ConnectionMultiplexer.Connect(_configuration.GetConnectionString("StorageRedis"));
-            services.AddDataProtection().PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys");
 
             // Routing has to come before adding Mvc
             services.AddRouting(opt =>

--- a/src/QA/UnitTests/UnitTests.csproj
+++ b/src/QA/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The issues that were being logged during deployment such as:

- Startup assembly Microsoft.AspNetCore.AzureAppServices.HostingStartup failed to execute. See the inner exception for more details.
- Startup assembly StartupBootstrapper failed to execute. See the inner exception for more details.
- Could not load file or assembly 'D:\home\site\wwwroot\Recruit.Shared.Web.Views.dll'. The process cannot access the file because it is being used by another process. (Exception from HRESULT: 0x80070020) 
- Other process locks like above

No longer occur after deploying this branch on AT and test multiple times.

We will need to revisit the aspnet core 2.2 upgrade again in the future. The same with the usage of DataProtection through Redis.

We have been seeing some issues such as `An attempt was made to access a socket in a way forbidden by its access permissions` to do with the kestrel server startup. This seems to have stopped but will have to continue to monitor. It is also likely we will move to the ISS based in process hosting method in the future for the apps on the Azure envs.

I will bump the minor version number because we are downgrading but not breaking anything that is already in the branch.

