### PR TITLE
Defensive code around framework and standards job

### DIFF
--- a/src/Employer/Employer.Web/Employer.Web.csproj
+++ b/src/Employer/Employer.Web/Employer.Web.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
     <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />
-    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Employer/UnitTests/UnitTests.csproj
+++ b/src/Employer/UnitTests/UnitTests.csproj
@@ -8,11 +8,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-    <PackageReference Include="Moq" Version="4.10.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-    <PackageReference Include="FluentAssertions" Version="5.5.3"/>
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Provider/UnitTests/UnitTests.csproj
+++ b/src/Provider/UnitTests/UnitTests.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QA/UnitTests/UnitTests.csproj
+++ b/src/QA/UnitTests/UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/UpdateApprenticeshipProgrammesCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/UpdateApprenticeshipProgrammesCommandHandler.cs
@@ -10,11 +10,11 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     public class UpdateApprenticeshipProgrammesCommandHandler : IRequestHandler<UpdateApprenticeshipProgrammesCommand>
     {
         private readonly ILogger<UpdateApprenticeshipProgrammesCommandHandler> _logger;
-        private readonly IApprenticeshipProgrammeUpdateService _updaterService;
+        private readonly IApprenticeshipProgrammesUpdateService _updaterService;
 
         public UpdateApprenticeshipProgrammesCommandHandler(
             ILogger<UpdateApprenticeshipProgrammesCommandHandler> logger,
-            IApprenticeshipProgrammeUpdateService updaterService)
+            IApprenticeshipProgrammesUpdateService updaterService)
         {
             _logger = logger;
             _updaterService = updaterService;

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/ReferenceData/IApprenticeshipProgrammesUpdateService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/ReferenceData/IApprenticeshipProgrammesUpdateService.cs
@@ -2,7 +2,7 @@
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Services.ReferenceData
 {
-    public interface IApprenticeshipProgrammeUpdateService
+    public interface IApprenticeshipProgrammesUpdateService
     {
         Task UpdateApprenticeshipProgrammesAsync();
     }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammeEqualityComparer.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammeEqualityComparer.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes
+{
+    public class ApprenticeshipProgrammeEqualityComparer : IEqualityComparer<ApprenticeshipProgramme>
+    {
+        public bool Equals(ApprenticeshipProgramme x, ApprenticeshipProgramme y)
+        {
+            return x.Id.Equals(y.Id)
+                    && x.Level == y.Level
+                    && x.ApprenticeshipType == y.ApprenticeshipType;
+        }
+
+        public int GetHashCode(ApprenticeshipProgramme obj)
+        {
+            return obj.Id.GetHashCode();
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
@@ -9,15 +9,15 @@ using SFA.DAS.Apprenticeships.Api.Client;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes
 {
-    public class ApprenticeshipProgrammeUpdateService : IApprenticeshipProgrammeUpdateService
+    public class ApprenticeshipProgrammesUpdateService : IApprenticeshipProgrammesUpdateService
     {
-        private readonly ILogger<ApprenticeshipProgrammeUpdateService> _logger;
+        private readonly ILogger<ApprenticeshipProgrammesUpdateService> _logger;
         private readonly IStandardApiClient _standardsClient;
         private readonly IFrameworkApiClient _frameworksClient;
         private readonly IReferenceDataWriter _referenceDataWriter;
 
-        public ApprenticeshipProgrammeUpdateService(
-            ILogger<ApprenticeshipProgrammeUpdateService> logger, 
+        public ApprenticeshipProgrammesUpdateService(
+            ILogger<ApprenticeshipProgrammesUpdateService> logger, 
             IStandardApiClient standardsClient,
             IFrameworkApiClient frameworksClient,
             IReferenceDataWriter referenceDataWriter)
@@ -47,7 +47,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Apprentices
 
                 await _referenceDataWriter.UpsertReferenceData(new ApprenticeshipProgrammes
                 {
-                    Data = newList
+                    Data = newList.Distinct(new ApprenticeshipProgrammeEqualityComparer()).ToList()
                 });
 
                 _logger.LogInformation("Inserted: {standardCount} standards and {frameworkCount} frameworks.", standardsFromApi.Count, frameworksFromApi.Count);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Application.Services.ReferenceData;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Exceptions;
 using Microsoft.Extensions.Logging;
 using Polly;
 using SFA.DAS.Apprenticeships.Api.Client;
@@ -40,6 +41,12 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Apprentices
 
                 var standardsFromApi = standardsTask.Result.ToList();
                 var frameworksFromApi = frameworksTask.Result.ToList();
+
+                if (standardsFromApi.Count == 0)
+                    throw new InfrastructureException("Retrieved 0 standards from the apprenticeships api.");
+                
+                if (frameworksFromApi.Count == 0)
+                    throw new InfrastructureException("Retrieved 0 frameworks from the apprenticeships api.");
 
                 var newList = new List<ApprenticeshipProgramme>();
                 newList.AddRange(standardsFromApi);

--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -128,10 +128,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<ITrainingProviderService, TrainingProviderService>();
 
             // Reference Data update services
-            services.AddTransient<IApprenticeshipProgrammeUpdateService, ApprenticeshipProgrammeUpdateService>();
+            services.AddTransient<IApprenticeshipProgrammesUpdateService, ApprenticeshipProgrammesUpdateService>();
             services.AddTransient<IBankHolidayUpdateService, BankHolidayUpdateService>();
             services.AddTransient<IBankHolidayProvider, BankHolidayProvider>();
-            
+
             // External client dependencies
             services.AddApprenticeshipsApi(configuration);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
+++ b/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
     <PackageReference Include="FluentValidation" Version="7.5.2" />
     <PackageReference Include="Polly" Version="6.0.1" />
-    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.10.138" />
-    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.10.139" />
-    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.10.138" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Client" Version="0.11.98" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.98" />
+    <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Shared/UnitTests/TestHelpers/TestCache.cs
+++ b/src/Shared/UnitTests/TestHelpers/TestCache.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Application.Cache;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.TestHelpers
+namespace Esfa.Recruit.UnitTests.TestHelpers
 {
     public class TestCache : ICache
     {

--- a/src/Shared/UnitTests/UnitTests.csproj
+++ b/src/Shared/UnitTests/UnitTests.csproj
@@ -5,12 +5,12 @@
     <RootNamespace>Esfa.Recruit.Vacancies.Client.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="FluentAssertions" Version="5.2.0" />
-    <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="AutoFixture" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="AutoFixture" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloneVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloneVacancyCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-using Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation;
+using Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation;
 using FluentAssertions;
 using Xunit;
 using Moq;
@@ -14,8 +14,7 @@ using System.Threading;
 using System;
 using AutoFixture;
 
-
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.CommandHandlers
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
 {
     public class CloneVacancyCommandHandlerTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/EntityValidatorTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/EntityValidatorTests.cs
@@ -1,11 +1,11 @@
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent;
-using Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation;
+using Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation;
 using FluentAssertions;
 using FluentValidation;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application
 {
     public class EntityValidatorTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/TestVacancyBuilder.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/TestVacancyBuilder.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
 {
     internal static class TestVacancyBuilder
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyBannedPhraseChecksRuleTest.cs
@@ -8,13 +8,13 @@ using Esfa.Recruit.Vacancies.Client.Application.Rules;
 using Esfa.Recruit.Vacancies.Client.Application.Rules.BaseRules;
 using Esfa.Recruit.Vacancies.Client.Application.Rules.VacancyRules;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules;
+using Esfa.Recruit.UnitTests.Vacancies.Client.Application.Rules.VacancyRules;
 using FluentAssertions;
 using Microsoft.Azure.Amqp.Serialization;
 using Moq;
 using Xunit;
 
-namespace UnitTests.Vacancies.Client.Application.Rules.VacancyRules
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
 {
     public class VacancyBannedPhraseChecksRuleTest
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyProfanityChecksRuleTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyProfanityChecksRuleTests.cs
@@ -9,7 +9,7 @@ using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
 {
     public class VacancyProfanityChecksRuleTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyTitlePopularityCheckRuleTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Rules/VacancyRules/VacancyTitlePopularityCheckRuleTests.cs
@@ -13,7 +13,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Rules.VacancyRules
 {
     public class VacancyTitlePopularityCheckRuleTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Services/HtmlSanitizerServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Services/HtmlSanitizerServiceTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Services
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Services
 {
     public class HtmlSanitizerServiceTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Services/NextVacancyReviewServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Services/NextVacancyReviewServiceTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Services
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Services
 {
     public class NextVacancyReviewServiceTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Services/SlaServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Services/SlaServiceTests.cs
@@ -7,7 +7,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Services
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Services
 {
     public class SlaServiceTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Services/VacancyComparerServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Services/VacancyComparerServiceTests.cs
@@ -7,7 +7,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Services
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.Services
 {
     public class VacancyComparerServiceTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/TestData.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/TestData.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application
 {
     public static class TestData
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/ApplicationReviewTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/ApplicationReviewTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.VacancyValidation
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
 {
     public class ApplicationReviewTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.CrossField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.CrossField
 {
     public class FixedWageAmountValidation : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/StartDateClosingDateTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/StartDateClosingDateTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.CrossField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.CrossField
 {
     public class StartDateClosingDateTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TestApprenticeshipProgramme.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TestApprenticeshipProgramme.cs
@@ -1,7 +1,7 @@
 using System;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.CrossField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.CrossField
 {
     public class TestApprenticeshipProgramme : IApprenticeshipProgramme
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TrainingExpiryDateValidation.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TrainingExpiryDateValidation.cs
@@ -6,7 +6,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.CrossField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.CrossField
 {
     public class TrainingExpiryDateValidation : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ClosingDateValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ClosingDateValidationTests.cs
@@ -5,7 +5,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ClosingDateValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/DescriptionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/DescriptionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class DescriptionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/DurationValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/DurationValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class DurationValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactEmailValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactEmailValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public partial class EmployerContactDetailValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactNameValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactNameValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public partial class EmployerContactDetailValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactPhoneNumberValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerContactDetailContactPhoneNumberValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public partial class EmployerContactDetailValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerDescriptionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerDescriptionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class EmployerDescriptionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class EmployerValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerWebsiteUrlValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerWebsiteUrlValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class EmployerWebsiteUrlValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ExternalApplicationInstructionsValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ExternalApplicationInstructionsValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ExternalApplicationInstructionsValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ExternalApplicationUrlValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ExternalApplicationUrlValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ExternalApplicationUrlValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/OutcomeDescriptionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/OutcomeDescriptionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class OutcomeDescriptionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/PositionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/PositionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class PositionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/QualificationsTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/QualificationsTests.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class QualificationsTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/SkillsTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/SkillsTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class SkillsTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/StartDateValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/StartDateValidationTests.cs
@@ -5,7 +5,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class StartDateValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ThingsToConsiderValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ThingsToConsiderValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ThingsToConsiderValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ThroughFaaApplicationMethodValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/ThroughFaaApplicationMethodValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ThroughFaaApplicationMethodValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TitleValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TitleValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class ValidateVacancyTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingDescriptionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingDescriptionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class TrainingDescriptionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingProviderUkprnValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingProviderUkprnValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class TrainingProviderUkprnValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/TrainingValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class TrainingValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WageValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WageValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class WageValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WeeklyHoursValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WeeklyHoursValidationTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class WeeklyHoursValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WorkingWeekDescriptionValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/WorkingWeekDescriptionValidationTests.cs
@@ -4,7 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation.SingleField
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField
 {
     public class WorkingWeekDescriptionValidationTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyReviewTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyReviewTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.VacancyValidation
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
 {
     public class VacancyReviewTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
@@ -7,7 +7,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
 {
     public abstract class VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/ValidateAllTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/ValidateAllTests.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using FluentAssertions;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Application.VacancyValidation
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
 {
     public class ValidateAllTests : VacancyValidationTestsBase
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/EventHandlers/UpdateFAAOnApplicationReviewedTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/EventHandlers/UpdateFAAOnApplicationReviewedTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructure.EventHandlers
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.EventHandlers
 {
     public class UpdateFaaOnApplicationReviewedTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Providers/NationalMinimumWageProviderTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Providers/NationalMinimumWageProviderTests.cs
@@ -1,12 +1,12 @@
 using System;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
-using Esfa.Recruit.Vacancies.Client.UnitTests.TestHelpers;
+using Esfa.Recruit.UnitTests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructure.Services
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.Services
 {
     public class NationalMinimumWageProviderTests
     {

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdaterServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdaterServiceTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Services.ReferenceData;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes;
+using Esfa.Recruit.UnitTests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SFA.DAS.Apprenticeships.Api.Client;
+using SFA.DAS.Apprenticeships.Api.Types;
+using Xunit;
+using ApprenticeshipProgrammesReferenceData = Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes.ApprenticeshipProgrammes;
+
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes
+{
+    [Trait("Category", "Unit")]
+    public class ApprenticeshipProgrammesUpdaterServiceTests
+    {
+        private readonly IApprenticeshipProgrammesUpdateService _sut;
+        private readonly Mock<IStandardApiClient> _mockStandardsClient;
+        private readonly Mock<IFrameworkApiClient> _mockFrameworksClient;
+        private readonly Mock<IReferenceDataWriter> _mockReferenceDataWriter;
+
+        private readonly StandardSummary _standardOne = new StandardSummary
+        {
+            Id = "1",
+            Title = "Network engineer",
+            Uri = "https =//findapprenticeshiptraining-api.sfa.bis.gov.uk/standards/1",
+            Duration = 24,
+            Level = 4,
+            IsPublished = true,
+            Ssa1 = 6,
+            Ssa2 = 6.1,
+            EffectiveFrom = new DateTime(2014, 8, 1),
+            IsActiveStandard = true,
+            StandardSectorCode = 7
+        };
+        private readonly StandardSummary _standardTwo = new StandardSummary
+        {
+            Id = "10",
+            Title = "Electrical / electronic technical support engineer",
+            Uri = "https =//findapprenticeshiptraining-api.sfa.bis.gov.uk/standards/10",
+            Duration = 60,
+            Level = 6,
+            IsPublished = true,
+            Ssa1 = 4,
+            Ssa2 = 4.2,
+            EffectiveFrom = new DateTime(2014, 8, 1),
+            IsActiveStandard = true,
+            StandardSectorCode = 7
+        };
+        private readonly FrameworkSummary _frameworkOne = new FrameworkSummary
+        {
+            Id = "401-3-1",
+            Uri = "https =//findapprenticeshiptraining-api.sfa.bis.gov.uk/frameworks/401-3-1",
+            Title = "Drinks Dispense Systems = Drinks Dispense Systems",
+            FrameworkName = "Drinks Dispense Systems",
+            PathwayName = "Drinks Dispense Systems",
+            ProgType = 3,
+            FrameworkCode = 401,
+            PathwayCode = 1,
+            Level = 2,
+            Duration = 0,
+            CurrentFundingCap = 0,
+            Ssa1 = 7,
+            Ssa2 = 7.4,
+            EffectiveFrom = new DateTime(2013, 2, 1),
+            EffectiveTo = new DateTime(2013, 7, 31),
+            IsActiveFramework = false
+        };
+        private readonly FrameworkSummary _frameworkTwo = new FrameworkSummary
+        {
+            Id = "403-2-1",
+            Uri = "https =//findapprenticeshiptraining-api.sfa.bis.gov.uk/frameworks/403-2-1",
+            Title = "Food and Drink = Meat and Poultry Industry Skills",
+            FrameworkName = "Food and Drink",
+            PathwayName = "Meat and Poultry Industry Skills",
+            ProgType = 2,
+            FrameworkCode = 403,
+            PathwayCode = 1,
+            Level = 3,
+            Duration = 12,
+            CurrentFundingCap = 0,
+            Ssa1 = 4,
+            Ssa2 = 4.2,
+            EffectiveFrom = new DateTime(2013, 2, 1),
+            EffectiveTo = new DateTime(2018, 4, 30),
+            IsActiveFramework = false,
+        };
+
+        public ApprenticeshipProgrammesUpdaterServiceTests()
+        {
+            _mockStandardsClient = new Mock<IStandardApiClient>();
+            _mockFrameworksClient = new Mock<IFrameworkApiClient>();
+            _mockReferenceDataWriter = new Mock<IReferenceDataWriter>();
+
+            _sut = new ApprenticeshipProgrammesUpdateService(Mock.Of<ILogger<ApprenticeshipProgrammesUpdateService>>(),
+                                                            _mockStandardsClient.Object,
+                                                            _mockFrameworksClient.Object,
+                                                            _mockReferenceDataWriter.Object);
+        }
+
+        [Fact]
+        public async Task WhenApprenticeshipsApiReturnsDuplicateStandards_ThenOnlyDistinctStandardsAreUpsertedIntoReferenceData()
+        {
+            // Arrange
+            _mockStandardsClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(
+                Enumerable
+                .Repeat(_standardOne, 2)
+                .Append(_standardTwo)
+            );
+
+            _mockFrameworksClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(Enumerable.Empty<FrameworkSummary>());
+
+            ApprenticeshipProgrammesReferenceData apprenticeshipProgrammesReferenceData = null;
+
+            _mockReferenceDataWriter.Setup(x => x.UpsertReferenceData(It.IsAny<ApprenticeshipProgrammesReferenceData>()))
+            .Callback<ApprenticeshipProgrammesReferenceData>(arg => apprenticeshipProgrammesReferenceData = arg)
+            .Returns(Task.CompletedTask);
+
+            // Act
+            await _sut.UpdateApprenticeshipProgrammesAsync();
+
+            // Assert
+            var firstItem = apprenticeshipProgrammesReferenceData.Data.First();
+            var secondItem = apprenticeshipProgrammesReferenceData.Data.Skip(1).First();
+
+            _mockReferenceDataWriter.Verify(x => x.UpsertReferenceData(apprenticeshipProgrammesReferenceData), Times.Once);
+            apprenticeshipProgrammesReferenceData.Data.Count().Should().Be(2);
+            apprenticeshipProgrammesReferenceData.Data.All(ap => ap.ApprenticeshipType == TrainingType.Standard).Should().BeTrue();
+            firstItem.Id.Equals(secondItem.Id).Should().BeFalse();
+            firstItem.Level.Equals(secondItem.Level).Should().BeFalse();
+            firstItem.Title.Equals(secondItem.Title).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task WhenApprenticeshipsApiReturnsDuplicateFrameworks_ThenOnlyDistinctFrameworksAreUpsertedIntoReferenceData()
+        {
+            // Arrange
+            _mockStandardsClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(Enumerable.Empty<StandardSummary>());
+
+            _mockFrameworksClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(
+                Enumerable
+                .Repeat(_frameworkOne, 2)
+                .Append(_frameworkTwo)
+            );
+
+            ApprenticeshipProgrammesReferenceData apprenticeshipProgrammesReferenceData = null;
+
+            _mockReferenceDataWriter.Setup(x => x.UpsertReferenceData(It.IsAny<ApprenticeshipProgrammesReferenceData>()))
+            .Callback<ApprenticeshipProgrammesReferenceData>(arg => apprenticeshipProgrammesReferenceData = arg)
+            .Returns(Task.CompletedTask);
+
+            // Act
+            await _sut.UpdateApprenticeshipProgrammesAsync();
+
+            // Assert
+            var firstItem = apprenticeshipProgrammesReferenceData.Data.First();
+            var secondItem = apprenticeshipProgrammesReferenceData.Data.Skip(1).First();
+
+            _mockReferenceDataWriter.Verify(x => x.UpsertReferenceData(apprenticeshipProgrammesReferenceData), Times.Once);
+            apprenticeshipProgrammesReferenceData.Data.Count().Should().Be(2);
+            apprenticeshipProgrammesReferenceData.Data.All(ap => ap.ApprenticeshipType == TrainingType.Framework).Should().BeTrue();
+            firstItem.Id.Equals(secondItem.Id).Should().BeFalse();
+            firstItem.Level.Equals(secondItem.Level).Should().BeFalse();
+            firstItem.Title.Equals(secondItem.Title).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task WhenApprenticeshipsApiReturnsDuplicateFrameworksAndStandards_ThenOnlyDistinctFrameworksAndStandardsAreUpsertedIntoReferenceData()
+        {
+            // Arrange
+            _mockStandardsClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(
+                Enumerable
+                .Repeat(_standardOne, 2)
+                .Union(Enumerable.Repeat(_standardTwo, 5))
+            );
+
+            _mockFrameworksClient
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(
+                Enumerable
+                .Repeat(_frameworkOne, 2)
+                .Union(Enumerable.Repeat(_frameworkTwo, 11))
+            );
+
+            ApprenticeshipProgrammesReferenceData apprenticeshipProgrammesReferenceData = null;
+
+            _mockReferenceDataWriter.Setup(x => x.UpsertReferenceData(It.IsAny<ApprenticeshipProgrammesReferenceData>()))
+            .Callback<ApprenticeshipProgrammesReferenceData>(arg => apprenticeshipProgrammesReferenceData = arg)
+            .Returns(Task.CompletedTask);
+
+            // Act
+            await _sut.UpdateApprenticeshipProgrammesAsync();
+
+            // Assert
+            var firstItem = apprenticeshipProgrammesReferenceData.Data.First();
+            var secondItem = apprenticeshipProgrammesReferenceData.Data.Skip(1).First();
+
+            _mockReferenceDataWriter.Verify(x => x.UpsertReferenceData(apprenticeshipProgrammesReferenceData), Times.Once);
+            apprenticeshipProgrammesReferenceData.Data.Count().Should().Be(4);
+            apprenticeshipProgrammesReferenceData.Data.Count(ap => ap.ApprenticeshipType == TrainingType.Framework).Should().Be(2);
+            apprenticeshipProgrammesReferenceData.Data.Count(ap => ap.ApprenticeshipType == TrainingType.Standard).Should().Be(2);
+        }
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Slack/SlackNotifyVacancyReviewUpdatesTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Slack/SlackNotifyVacancyReviewUpdatesTests.cs
@@ -6,7 +6,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.Slack;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.Vacancies.Client.UnitTests.Infrastructure.Slack
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.Slack
 {
     public class SlackNotifyVacancyReviewUpdatesTests
     {


### PR DESCRIPTION
I have consolidated some of the name-spacing for unit test around vacancy client to avoid having `Vacancy.Client` appearing two times in the namespace declaration.