### PR TITLE
Defaults user type in employer create vacancy method

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -95,7 +95,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                 return await ValidateAndExecute(
                     newVacancy, 
                     v => _vacancyClient.Validate(v, ValidationRules),
-                    async v => await _client.CreateVacancyAsync(SourceOrigin.EmployerWeb, m.Title, numberOfPositions.Value, m.EmployerAccountId, user, UserType.Employer));
+                    async v => await _client.CreateVacancyAsync(SourceOrigin.EmployerWeb, m.Title, numberOfPositions.Value, m.EmployerAccountId, user));
             }
 
             var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, _vacancyClient, 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -11,7 +11,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
     public interface IEmployerVacancyClient
     {
-        Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, int numberOfPositions, string employerAccountId, VacancyUser user, UserType userType);
+        Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, int numberOfPositions, string employerAccountId, VacancyUser user);
         Task GenerateDashboard(string employerAccountId);
         Task CloseVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<Guid> CloneVacancyAsync(Guid vacancyId, VacancyUser user, SourceOrigin sourceOrigin);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -107,7 +107,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _repository.GetVacancyAsync(vacancyId);
         }
 
-        public async Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, int numberOfPositions, string employerAccountId, VacancyUser user, UserType userType)
+        public async Task<Guid> CreateVacancyAsync(SourceOrigin origin, string title, int numberOfPositions, string employerAccountId, VacancyUser user)
         {
             var vacancyId = GenerateVacancyId();
 
@@ -115,7 +115,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             {
                 VacancyId = vacancyId,
                 User = user,
-                UserType = userType,
+                UserType = UserType.Employer,
                 Title = title,
                 NumberOfPositions = numberOfPositions,
                 EmployerAccountId = employerAccountId,


### PR DESCRIPTION
Now that Provider is using it's own CreateVacancy method, it is safe to assume the UserType here as Employer as this method is only invoked from Employer recruit.  

PS: I don't like my comment here but the 💩 VacancyClient implementation has forced me to do this. 