### PR TITLE
ER-842 - Removing MinimumWageRanges.json from SeedScript

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
@@ -7,7 +7,6 @@ try {
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c sequences -f "$PSScriptRoot/Sequence/Sequence_Vacancy.json"
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/CandidateSkills.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/QualificationTypes.json" -o true
-    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/MinimumWageRanges.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BannedPhrases.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
 


### PR DESCRIPTION
This is a clean-up ticket.  Even though I've deleted the MinimumWageRanges.json file I neglected to remove the reference from here.

The deployment script handles this missing file nicely so I don't think its worth redeploying the release for.