### PR TITLE
ER-875 Implements provider step 1 location

### DIFF
--- a/src/Provider/Provider.Web/Configuration/IoC.cs
+++ b/src/Provider/Provider.Web/Configuration/IoC.cs
@@ -57,6 +57,7 @@ namespace Esfa.Recruit.Provider.Web.Configuration
             services.AddTransient<EmployerOrchestrator>();
             services.AddTransient<TitleOrchestrator>();
             services.AddTransient<ShortDescriptionOrchestrator>();
+            services.AddTransient<LocationOrchestrator>();
             services.AddTransient<ProviderContactDetailsOrchestrator>();
             services.AddTransient<QualificationsOrchestrator>();
             services.AddTransient<SkillsOrchestrator>();

--- a/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
@@ -60,5 +60,8 @@
 
         public const string Wage_Get = "Wage_Get";
         public const string Wage_Post = "Wage_Post";
+
+        public const string Location_Get = "Location_Get";
+        public const string Location_Post = "Location_Post";
     }
 }

--- a/src/Provider/Provider.Web/Controllers/Part1/LocationController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/LocationController.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Extensions;
+using Esfa.Recruit.Provider.Web.Orchestrators.Part1;
+using Esfa.Recruit.Provider.Web.RouteModel;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Location;
+using Esfa.Recruit.Shared.Web.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Esfa.Recruit.Provider.Web.Controllers.Part1
+{
+    [Route(RoutePaths.AccountVacancyRoutePath)]
+    public class LocationController : Controller
+    {
+        private readonly LocationOrchestrator _orchestrator;
+
+        public LocationController(LocationOrchestrator orchestrator)
+        {
+            _orchestrator = orchestrator;
+        }
+
+        [HttpGet("location", Name = RouteNames.Location_Get)]
+        public async Task<IActionResult> Location(VacancyRouteModel vrm, [FromQuery] string wizard = "true")
+        {
+            var vm = await _orchestrator.GetLocationViewModelAsync(vrm, User.GetUkprn());
+            vm.PageInfo.SetWizard(wizard);
+            return View(vm);
+        }
+
+        [HttpPost("location", Name = RouteNames.Location_Post)]
+        public async Task<IActionResult> Location(LocationEditModel m, [FromQuery] bool wizard)
+        {
+            var response = await _orchestrator.PostLocationEditModelAsync(m, User.ToVacancyUser(), User.GetUkprn());
+
+            if (!response.Success)
+            {
+                response.AddErrorsToModelState(ModelState);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                var vm = await _orchestrator.GetLocationViewModelAsync(m, User.GetUkprn());
+                vm.PageInfo.SetWizard(wizard);
+                return View(vm);
+            }
+
+            return RedirectToRoute(RouteNames.Dashboard_Index_Get);
+            // return wizard
+            //     ? RedirectToRoute(RouteNames.Training_Get)
+            //     : RedirectToRoute(RouteNames.Vacancy_Preview_Get, null, Anchors.AboutEmployerSection);
+        }
+
+    }
+}

--- a/src/Provider/Provider.Web/Controllers/Part1/ShortDescriptionController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/ShortDescriptionController.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
                 vm.PageInfo.SetWizard(wizard);
                 return View(vm);
             }
-            return RedirectToRoute(RouteNames.Dashboard_Index_Get);
+            return RedirectToRoute(RouteNames.Location_Get);
             // return wizard 
             //     ? RedirectToRoute(RouteNames.Employer_Get)
             //     : RedirectToRoute(RouteNames.Vacancy_Preview_Get, null, Anchors.ShortDescriptionSection);

--- a/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.RouteModel;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Location;
+using Esfa.Recruit.Shared.Web.Orchestrators;
+using Esfa.Recruit.Shared.Web.Extensions;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Microsoft.Extensions.Logging;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
+
+namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
+{
+    public class LocationOrchestrator : EntityValidatingOrchestrator<Vacancy, LocationEditModel>
+    {
+        private const VacancyRuleSet ValidationRules = VacancyRuleSet.EmployerName | VacancyRuleSet.EmployerAddress;
+        private readonly IProviderVacancyClient _providerVacancyClient;
+        private readonly IRecruitVacancyClient _recruitVacancyClient;
+        public LocationOrchestrator(IProviderVacancyClient providerVacancyClient, 
+            IRecruitVacancyClient recruitVacancyClient, ILogger<LocationOrchestrator> logger)
+            : base(logger)
+        {
+            _providerVacancyClient = providerVacancyClient;
+            _recruitVacancyClient = recruitVacancyClient;
+        }
+        public async Task<LocationViewModel> GetLocationViewModelAsync(VacancyRouteModel vrm, long ukprn)
+        {
+            var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(
+                _providerVacancyClient, _recruitVacancyClient, vrm, RouteNames.Location_Get);
+
+            var vm = new LocationViewModel
+            {
+                LegalEntities = await GetLegalEntityViewModelsAsync(ukprn, vacancy.EmployerAccountId),
+                SelectedLegalEntityId = vacancy.LegalEntityId,
+                PageInfo = Utility.GetPartOnePageInfo(vacancy)
+            };
+
+            if (vacancy.EmployerLocation != null)
+            {
+                vm.AddressLine1 = vacancy.EmployerLocation.AddressLine1;
+                vm.AddressLine2 = vacancy.EmployerLocation.AddressLine2;
+                vm.AddressLine3 = vacancy.EmployerLocation.AddressLine3;
+                vm.AddressLine4 = vacancy.EmployerLocation.AddressLine4;
+                vm.Postcode = vacancy.EmployerLocation.Postcode;
+            }
+            else if (vm.LegalEntities.Count() == 1 && vacancy.EmployerLocation == null)
+            {
+                var defaultLegalEntity = vm.LegalEntities.First();
+                vm.AddressLine1 = defaultLegalEntity.Address.AddressLine1;
+                vm.AddressLine2 = defaultLegalEntity.Address.AddressLine2;
+                vm.AddressLine3 = defaultLegalEntity.Address.AddressLine3;
+                vm.AddressLine4 = defaultLegalEntity.Address.AddressLine4;
+                vm.Postcode = defaultLegalEntity.Address.Postcode;
+            }
+
+            // if (vacancy.Status == VacancyStatus.Referred)
+            // {
+            //     vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+            //         ReviewFieldMappingLookups.GetEmployerFieldIndicators());
+            // }
+
+            return vm;
+        }
+
+        public async Task<LocationViewModel> GetLocationViewModelAsync(LocationEditModel m, long ukprn)
+        {
+            var vm = await GetLocationViewModelAsync((VacancyRouteModel)m, ukprn);
+
+            vm.SelectedLegalEntityId = m.SelectedLegalEntityId;
+            vm.AddressLine1 = m.AddressLine1;
+            vm.AddressLine2 = m.AddressLine2;
+            vm.AddressLine3 = m.AddressLine3;
+            vm.AddressLine4 = m.AddressLine4;
+            vm.Postcode = m.Postcode;
+
+            return vm;
+        }
+
+        public async Task<OrchestratorResponse> PostLocationEditModelAsync(LocationEditModel m, VacancyUser user, long ukprn)
+        {
+            var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_providerVacancyClient, _recruitVacancyClient, m, RouteNames.Employer_Post);
+            
+            var employerVacancyInfo = await _providerVacancyClient.GetProviderEmployerVacancyDataAsync(ukprn, vacancy.EmployerAccountId);
+
+            var selectedLegalEntity = employerVacancyInfo.LegalEntities.SingleOrDefault(x => x.LegalEntityId == m.SelectedLegalEntityId);
+
+            vacancy.LegalEntityId = m.SelectedLegalEntityId;
+
+            vacancy.EmployerLocation = new Vacancies.Client.Domain.Entities.Address
+            {
+                AddressLine1 = m.AddressLine1,
+                AddressLine2 = m.AddressLine2,
+                AddressLine3 = m.AddressLine3,
+                AddressLine4 = m.AddressLine4,
+                Postcode = m.Postcode.AsPostcode(),
+                Latitude = null,
+                Longitude = null
+            };
+
+            return await ValidateAndExecute(
+                vacancy, 
+                v => _recruitVacancyClient.Validate(v, ValidationRules),
+                v => _recruitVacancyClient.UpdateDraftVacancyAsync(vacancy, user));
+        }
+
+        protected override EntityToViewModelPropertyMappings<Vacancy, LocationEditModel> DefineMappings()
+        {
+            var mappings = new EntityToViewModelPropertyMappings<Vacancy, LocationEditModel>();
+
+            mappings.Add(e => e.EmployerName, vm => vm.SelectedLegalEntityId);
+            mappings.Add(e => e.EmployerLocation.AddressLine1, vm => vm.AddressLine1);
+            mappings.Add(e => e.EmployerLocation.AddressLine2, vm => vm.AddressLine2);
+            mappings.Add(e => e.EmployerLocation.AddressLine3, vm => vm.AddressLine3);
+            mappings.Add(e => e.EmployerLocation.AddressLine4, vm => vm.AddressLine4);
+            mappings.Add(e => e.EmployerLocation.Postcode, vm => vm.Postcode);
+
+            return mappings;
+
+        }
+
+        private LegalEntityViewModel MapLegalEntitiesToOrgs(LegalEntity data)
+        {
+            return new LegalEntityViewModel { Id = data.LegalEntityId.ToString(), Name = data.Name, Address = data.Address };
+        }
+
+        private async Task<List<LegalEntityViewModel>> GetLegalEntityViewModelsAsync(long ukprn, string employerAccountId)
+        {
+            var result = new List<LegalEntityViewModel>();
+
+            var info = await _providerVacancyClient.GetProviderEmployerVacancyDataAsync(ukprn, employerAccountId);  
+
+            if (info == null || !info.LegalEntities.Any())
+            {
+                Logger.LogError("No legal entities found for {employerAccountId}", employerAccountId);
+                return null; // TODO: Can we carry on without a list of legal entities.
+            }
+
+            return info.LegalEntities.Select(MapLegalEntitiesToOrgs).ToList();
+        }
+    }
+}

--- a/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
@@ -134,8 +134,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 
             if (info == null || !info.LegalEntities.Any())
             {
-                Logger.LogError("No legal entities found for {employerAccountId}", employerAccountId);
-                return null; // TODO: Can we carry on without a list of legal entities.
+                Logger.LogWarning("No legal entities found for {employerAccountId}", employerAccountId);
+                return result; 
             }
 
             return info.LegalEntities.Select(MapLegalEntitiesToOrgs).ToList();

--- a/src/Provider/Provider.Web/Utility.cs
+++ b/src/Provider/Provider.Web/Utility.cs
@@ -73,21 +73,17 @@ namespace Esfa.Recruit.Provider.Web
             if (string.IsNullOrWhiteSpace(vacancy.Title))
                 return validRoutes;
 
-            // validRoutes.AddRange(new[] { RouteNames.ShortDescription_Post, RouteNames.ShortDescription_Get });
-            // if (string.IsNullOrWhiteSpace(vacancy.ShortDescription))
-            //     return validRoutes;
+            validRoutes.AddRange(new[] { RouteNames.ShortDescription_Post, RouteNames.ShortDescription_Get });
+            if (string.IsNullOrWhiteSpace(vacancy.ShortDescription))
+                return validRoutes;
 
-            // validRoutes.AddRange(new[] { RouteNames.Provider_Post, RouteNames.Provider_Get});
-            // if (string.IsNullOrWhiteSpace(vacancy.ProviderLocation?.Postcode))
-            //     return validRoutes;
+            validRoutes.AddRange(new[] { RouteNames.Location_Post, RouteNames.Location_Get});
+            if (string.IsNullOrWhiteSpace(vacancy.EmployerLocation?.Postcode))
+                return validRoutes;
             
-            // validRoutes.AddRange(new[] {RouteNames.LegalEntityAgreement_SoftStop_Get, RouteNames.Training_Post, RouteNames.Training_Get});
-            // if (string.IsNullOrWhiteSpace(vacancy.ProgrammeId))
-            //     return validRoutes;
-
-            // validRoutes.AddRange(new[] { RouteNames.Wage_Post, RouteNames.Wage_Get});
-            // if (vacancy.Wage?.WageType == null)
-            //     return validRoutes;
+            validRoutes.AddRange(new[] { RouteNames.Wage_Post, RouteNames.Wage_Get});
+            if (vacancy.Wage?.WageType == null)
+                return validRoutes;
 
             return null;
         }

--- a/src/Provider/Provider.Web/ViewModels/Part1/Location/LegalEntityViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Location/LegalEntityViewModel.cs
@@ -1,0 +1,11 @@
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+
+namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Location
+{
+    public class LegalEntityViewModel
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public Address Address { get; internal set; }
+    }
+}

--- a/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationEditModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationEditModel.cs
@@ -1,0 +1,19 @@
+using Esfa.Recruit.Provider.Web.RouteModel;
+
+namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Location
+{
+    public class LocationEditModel : VacancyRouteModel
+    {
+        public long SelectedLegalEntityId { get; set; }
+
+        public string AddressLine1 { get; set; }
+
+        public string AddressLine2 { get; set; }
+
+        public string AddressLine3 { get; set; }
+
+        public string AddressLine4 { get; set; }
+
+        public string Postcode { get; set; }
+    }
+}

--- a/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationViewModel.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using Esfa.Recruit.Shared.Web.ViewModels;
+
+namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Location
+{
+    public class LocationViewModel
+    {
+        public IEnumerable<LegalEntityViewModel> LegalEntities { get; set; }
+
+        public bool HasOnlyOneOrganisation => LegalEntities.Count() == 1;
+		public bool HasMoreThanOneOrganisation => LegalEntities.Count() > 1;
+
+        //public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
+
+        public IList<string> OrderedFieldNames => new List<string>
+        {
+            nameof(AddressLine1),
+            nameof(AddressLine2),
+            nameof(AddressLine3),
+            nameof(AddressLine4),
+            nameof(Postcode)
+        };
+
+        public PartOnePageInfoViewModel PageInfo { get; set; }
+        public long SelectedLegalEntityId { get; set; }
+
+        public string AddressLine1 { get; set; }
+
+        public string AddressLine2 { get; set; }
+
+        public string AddressLine3 { get; set; }
+
+        public string AddressLine4 { get; set; }
+
+        public string Postcode { get; set; }
+    }
+}

--- a/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
@@ -15,7 +15,7 @@
         <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
 
         <div asp-show="@Model.HasOnlyOneOrganisation">
-            <p>@Model.LegalEntities.First().Name</p>
+            <p class="govuk-body">@Model.LegalEntities.First().Name</p>
         </div>
         <form asp-route="@RouteNames.Location_Post" asp-route-wizard="@Model.PageInfo.IsWizard">
             <div esfa-validation-marker-for="SelectedLegalEntityId" class="govuk-form-group">

--- a/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
@@ -1,0 +1,117 @@
+@using Microsoft.Extensions.Options;
+@using Esfa.Recruit.Shared.Web.Configuration;
+@using Esfa.Recruit.Provider.Web.ViewModels.Part1.Location;
+@using Esfa.Recruit.Shared.Web.Mappers
+@model LocationViewModel
+@inject IOptions<PostcodeAnywhereConfiguration> PcaConfig
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <a asp-show="@Model.PageInfo.IsWizard" asp-route="@RouteNames.ShortDescription_Get" esfa-automation="link-back" class="govuk-back-link">Back</a>
+
+        <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
+
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Location</h1>
+
+        <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
+
+        <div asp-show="@Model.HasOnlyOneOrganisation">
+            <p>@Model.LegalEntities.First().Name</p>
+        </div>
+        <form asp-route="@RouteNames.Location_Post" asp-route-wizard="@Model.PageInfo.IsWizard">
+            <div esfa-validation-marker-for="SelectedLegalEntityId" class="govuk-form-group">
+
+                <input asp-show="@Model.HasOnlyOneOrganisation" asp-for="SelectedLegalEntityId" value="@Model.LegalEntities.First().Id" type="hidden"/>
+
+                <fieldset class="govuk-fieldset" asp-show="@Model.HasMoreThanOneOrganisation">
+                    <legend class="govuk-fieldset__legend">
+                        <span class="govuk-label govuk-!-font-weight-bold">Which organisation is the vacancy for?</span>
+                    </legend>
+                    <span esfa-validation-message-for="SelectedLegalEntityId" class="govuk-error-message"></span>
+                    <div class="govuk-radios">
+                    @foreach (var organisation in Model.LegalEntities)
+                    {
+                        <div class="govuk-radios__item">
+                            <input asp-for="SelectedLegalEntityId" type="radio" value="@organisation.Id" class="govuk-radios__input" id="org-@organisation.Id">
+                            <label for="org-@organisation.Id" class="govuk-label govuk-radios__label">@organisation.Name</label>
+                        </div>
+                    }
+                    </div>
+                </fieldset>
+            </div>
+
+            <div id="address-details" class="address-manual-input">
+                <label class="govuk-label govuk-!-font-weight-bold">Enter the address where the apprentice will work</label>
+                <div esfa-validation-marker-for="AddressLine1" class="govuk-form-group-compound address-item govuk-form-group">
+                    <label asp-for="AddressLine1" class="govuk-visually-hidden">Address line 1</label>
+                    <span esfa-validation-message-for="AddressLine1" class="govuk-error-message"></span>
+                    <input asp-for="AddressLine1" class="govuk-input postcode-lookup" maxlength="100"/>
+                </div>
+                <div esfa-validation-marker-for="AddressLine2" class="govuk-form-group-compound address-item govuk-form-group">
+                    <label asp-for="AddressLine2" class="govuk-visually-hidden">Address line 2</label>
+                    <span esfa-validation-message-for="AddressLine2" class="govuk-error-message"></span>
+                    <input asp-for="AddressLine2" class="govuk-input" maxlength="100"/>
+                </div>
+                <div esfa-validation-marker-for="AddressLine3" class="govuk-form-group-compound address-item govuk-form-group">
+                    <label asp-for="AddressLine3" class="govuk-visually-hidden">Address line 3</label>
+                    <span esfa-validation-message-for="AddressLine3" class="govuk-error-message"></span>
+                    <input asp-for="AddressLine3" class="govuk-input" maxlength="100"/>
+                </div>
+                <div esfa-validation-marker-for="AddressLine4" class="govuk-form-group-compound address-item govuk-form-group">
+                    <label asp-for="AddressLine4" class="govuk-visually-hidden">Address line 4</label>
+                    <span esfa-validation-message-for="AddressLine4" class="govuk-error-message"></span>
+                    <input asp-for="AddressLine4" class="govuk-input" maxlength="100"/>
+                </div>
+                <div esfa-validation-marker-for="Postcode" class="govuk-form-group address-item govuk-form-group">
+                    <label asp-for="Postcode" class="govuk-label govuk-!-font-weight-bold">Postcode</label>
+                    <span esfa-validation-message-for="Postcode" class="govuk-error-message"></span>
+                    <input asp-for="Postcode" class="govuk-input govuk-input--width-10 postcode-lookup" maxlength="8"/>
+                </div>
+            </div>
+
+            <button type="submit" class="govuk-button save-button">@Model.PageInfo.SubmitButtonText</button>
+
+            <a asp-show="@Model.PageInfo.IsWizard" asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-link das-button-link">Cancel</a>
+            <a asp-show="@Model.PageInfo.IsNotWizard" asp-route="@RouteNames.Vacancy_Preview_Get" asp-fragment="@Anchors.AboutEmployerSection" class="govuk-link das-button-link">Cancel</a>
+        </form>
+    </div>
+</div>
+@section HeadJS
+{
+<script nws-csp-add-nonce="true">
+window.EsfaRecruit.PcaConfig = {
+    key: '@PcaConfig.Value.Key',
+    findEndpoint: '@PcaConfig.Value.FindEndpoint',
+    retrieveEndpoint: '@PcaConfig.Value.RetrieveEndpoint'
+};
+</script>
+}
+@section FooterJS
+{
+<script nws-csp-add-nonce="true" asp-show="@Model.HasMoreThanOneOrganisation">
+$(document).ready(function() {
+    var orgInputName = "@nameof(LocationViewModel.SelectedLegalEntityId)";
+	var addresses = @Json.Serialize(Model.LegalEntities);
+
+	var setAddressById = function(id) {
+		for (var pos in addresses) {
+			if (addresses[pos].id === id) {
+				var matchedItem = addresses[pos];
+				$("#AddressLine1").val(matchedItem.address.addressLine1);
+				$("#AddressLine2").val(matchedItem.address.addressLine2);
+				$("#AddressLine3").val(matchedItem.address.addressLine3);
+				$("#AddressLine4").val(matchedItem.address.addressLine4);
+				$("#Postcode").val(matchedItem.address.postcode);
+			}
+		}
+	};
+
+    $("input[name='" + orgInputName + "']").click(function(e) {
+        var orgId = $(e.target).attr('id').slice(4);
+        setAddressById(orgId);
+    });
+});
+</script>
+
+<script src="/lib/jquery-ui/dist/jquery-ui.min.js"></script>
+<script asp-append-version="true" src="/lib/esfa-postcode/lookupService.js"></script>
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
@@ -14,5 +14,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task SetupProviderAsync(long ukprn);
         Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task<ProviderEditVacancyInfo> GetProviderEditVacancyInfoAsync(long ukprn);
+        Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
@@ -48,6 +48,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _reader.GetProviderVacancyDataAsync(ukprn);
         }
 
+        public Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId)
+        {
+            return _reader.GetProviderEmployerVacancyDataAsync(ukprn, employerAccountId);
+        }
+
         public Task SetupProviderAsync(long ukprn)
         {
             var command = new SetupProviderCommand(ukprn);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
@@ -14,6 +14,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         Task<EmployerDashboard> GetEmployerDashboardAsync(string employerAccountId);
         Task<EditVacancyInfo> GetEmployerVacancyDataAsync(string employerAccountId);
         Task<ProviderEditVacancyInfo> GetProviderVacancyDataAsync(long ukprn);
+        Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId);
         Task<IEnumerable<LiveVacancy>> GetLiveVacancies();
         Task<VacancyApplications> GetVacancyApplicationsAsync(string vacancyReference);
         Task<QaDashboard> GetQaDashboardAsync();

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/EditVacancyInfo/EmployerInfo.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/EditVacancyInfo/EmployerInfo.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo
 {
     public class EmployerInfo
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public IEnumerable<LegalEntity> LegalEntities { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -11,6 +11,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacanc
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyAnalytics;
 using System;
+using Address = Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo.Address;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 {
@@ -96,17 +97,66 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         public Task<ProviderEditVacancyInfo> GetProviderVacancyDataAsync(long ukprn)
         {
+            //TODO get data from QueryStore Collection
+            return Task.FromResult(FakeProviderVacancyData);
+
             // var key = QueryViewType.EditVacancyInfo.GetIdValue(ukprn);
 
             // return _queryStore.GetAsync<ProviderEditVacancyInfo>(QueryViewType.EditVacancyInfo.TypeName, key);
-
-            return Task.FromResult(new ProviderEditVacancyInfo{
-                Employers = new List<EmployerInfo>{                    
-                    {new EmployerInfo{ Id = "1234", Name = "Rogers and Federrers"  }}
-                }
-            });
-
         }
+
+        public Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId)
+        {
+            //TODO get data from QueryStore Collection
+            return Task.FromResult(FakeProviderVacancyData.Employers.FirstOrDefault(e => e.Id == employerAccountId));
+        }
+        private ProviderEditVacancyInfo FakeProviderVacancyData => 
+            new ProviderEditVacancyInfo {
+                Employers = new [] {
+                    new EmployerInfo { 
+                        Id = "RF1OEM", 
+                        Name = "Rogers and Federrers", 
+                        LegalEntities = new [] {
+                            new LegalEntity {
+                                Name = "Coventry building",
+                                LegalEntityId = 1122,
+                                Address = new Address {
+                                    AddressLine1 = "Chelyesmore House",
+                                    AddressLine2 = "5 Quinton Road",
+                                    AddressLine3 = "Coventry",
+                                    Postcode = "CV1 2WT"
+                                    }
+                                },
+                            new LegalEntity {
+                                Name = "Bedford building",
+                                LegalEntityId = 2233,
+                                Address = new Address {
+                                    AddressLine1 = "Unit No 4",
+                                    AddressLine2 = "Priory Business Park",
+                                    AddressLine3 = "Bedford",
+                                    Postcode = "MK44 3JZ"
+                                    }
+                                }
+                            }
+                        },
+                    new EmployerInfo { 
+                        Id = "WBT98F", 
+                        Name = "William Bothers", 
+                        LegalEntities = new [] {
+                            new LegalEntity {
+                                Name = "Coventry building",
+                                LegalEntityId = 1122,
+                                Address = new Address {
+                                    AddressLine1 = "Chelyesmore House",
+                                    AddressLine2 = "5 Quinton Road",
+                                    AddressLine3 = "Coventry",
+                                    Postcode = "CV1 2WT"
+                                    }
+                                }
+                            }
+                        }
+                }
+            };
 
         public Task<VacancyApplications> GetVacancyApplicationsAsync(string vacancyReference)
         {
@@ -190,6 +240,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         private string GetLiveVacancyId(long vacancyReference)
         {
             return QueryViewType.LiveVacancy.GetIdValue(vacancyReference.ToString());
-        }
+        }        
     }
 }


### PR DESCRIPTION
This one is identical to Employer's but not exact match. 
- The route used is `location` as `employer` is used for the first step. 
- No checks for soft/hard stop on legal entities selection as this is assumed. 
- Employer name will **not** be updated with legal entity name
- Some styling is missing, waiting on Richard to send me prototype