### PR TITLE
ER-890 - Provider vacancy submit

### DIFF
--- a/src/Provider/Provider.Web/Configuration/IoC.cs
+++ b/src/Provider/Provider.Web/Configuration/IoC.cs
@@ -66,6 +66,7 @@ namespace Esfa.Recruit.Provider.Web.Configuration
             services.AddTransient<SkillsOrchestrator>();
             services.AddTransient<VacancyDescriptionOrchestrator>();
             services.AddTransient<VacancyPreviewOrchestrator>();
+            services.AddTransient<SubmittedOrchestrator>();
         }
 
         private static void RegisterMapperDeps(IServiceCollection services)

--- a/src/Provider/Provider.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Provider/Provider.Web/Controllers/VacancyPreviewController.cs
@@ -46,8 +46,8 @@ namespace Esfa.Recruit.Provider.Web.Controllers
                 response.AddErrorsToModelState(ModelState);
             }
 
-            //if (ModelState.IsValid)
-            //    return RedirectToRoute(RouteNames.Submitted_Index_Get);
+            if (ModelState.IsValid)
+                return RedirectToRoute(RouteNames.Submitted_Index_Get);
 
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);
 

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -73,13 +73,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
                     SyncErrorsAndModel(result.Errors);
                     return result;
                 },
-                v => SubmitActionAsync(v, user)
+                v => _client.SubmitVacancyAsync(vacancy.Id, user)
                 );
-        }
-
-        private Task SubmitActionAsync(Vacancy vacancy, VacancyUser user)
-        {
-            return Task.CompletedTask;
         }
 
         private void SyncErrorsAndModel(IList<EntityValidationError> errors)

--- a/src/Provider/Provider.Web/Views/Submitted/Confirmation.cshtml
+++ b/src/Provider/Provider.Web/Views/Submitted/Confirmation.cshtml
@@ -1,0 +1,34 @@
+﻿@model Esfa.Recruit.Provider.Web.ViewModels.Submitted.VacancySubmittedConfirmationViewModel
+
+<h1 class="govuk-heading-l">@Model.Title</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div asp-show="@Model.IsNotResubmit" class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">
+                Vacancy submitted for approval
+            </h1>
+            <div class="govuk-panel__body">
+                <p asp-show="@Model.HasVacancyReference">
+                    The vacancy reference number is <br>
+                    <strong class="govuk-!-font-weight-bold">VAC@(Model.VacancyReference)</strong>
+                </p>
+            </div>
+        </div>
+        <div asp-show="@Model.IsResubmit" class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">
+                Vacancy resubmitted for approval
+            </h1>
+        </div>
+        <h2 class="govuk-heading-m">Next steps</h2>
+        <p class="govuk-body">Your vacancy will now be reviewed by an Education and Skills Funding Agency adviser.</p>
+        <p class="govuk-body">You’ll be notified within 24 hours, through your recruitment page, if you need to make any edits to your vacancy.</p>
+        <p class="govuk-body">We’ll also confirm on your recruitment page, when your vacancy is live.</p>
+        <div class="govuk-form-group inline">
+            <div class="govuk-form-group">
+                <a asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-button">Return to dashboard</a>
+                <a asp-route="@RouteNames.Employer_Get" class="govuk-link das-button-link">Create another vacancy</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
@@ -42,18 +42,20 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
                 _logger.LogWarning($"Unable to submit vacancy {{vacancyId}} due to vacancy having a status of {vacancy?.Status}.", message.VacancyId);
                 return;
             }
-            
+
+            if (vacancy.VacancyReference.HasValue == false)
+                throw new Exception("Cannot submit vacancy without a vacancy reference");
+
             var now = _timeProvider.Now;
 
-            vacancy.EmployerDescription = message.EmployerDescription;
+            if(!string.IsNullOrEmpty(message.EmployerDescription))
+                vacancy.EmployerDescription = message.EmployerDescription;
+
             vacancy.Status = VacancyStatus.Submitted;
             vacancy.SubmittedDate = now;
             vacancy.SubmittedByUser = message.User;
             vacancy.LastUpdatedDate = now;
             vacancy.LastUpdatedByUser = message.User;
-
-            if (vacancy.VacancyReference.HasValue == false)
-                throw new Exception("Cannot submit vacancy without a vacancy reference");
 
             await _vacancyRepository.UpdateAsync(vacancy);
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
@@ -7,8 +7,21 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class SubmitVacancyCommand : ICommand, IRequest
     {
-        public Guid VacancyId { get;set; }
-        public VacancyUser User { get; set; }
-        public string EmployerDescription { get; set; }
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user)
+        {
+            VacancyId = vacancyId;
+            User = user;
+        }
+
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, string employerDescription)
+        {
+            VacancyId = vacancyId;
+            User = user;
+            EmployerDescription = employerDescription;
+        }
+
+        public Guid VacancyId { get;}
+        public VacancyUser User { get; }
+        public string EmployerDescription { get; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
@@ -16,6 +16,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task<ProviderEditVacancyInfo> GetProviderEditVacancyInfoAsync(long ukprn);
         Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId);
+        Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<IEnumerable<IApprenticeshipProgramme>> GetActiveApprenticeshipProgrammesAsync();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
@@ -59,5 +59,12 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 
             return _messaging.SendCommandAsync(command);
         }
+
+        public Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user)
+        {
+            var command = new SubmitVacancyCommand(vacancyId, user);
+
+            return _messaging.SendCommandAsync(command);
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -145,12 +145,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 
         public Task SubmitVacancyAsync(Guid vacancyId, string employerDescription, VacancyUser user)
         {
-            var command = new SubmitVacancyCommand
-            {
-                VacancyId = vacancyId,
-                EmployerDescription = employerDescription,
-                User = user
-            };
+            var command = new SubmitVacancyCommand(vacancyId, user, employerDescription);
 
             return _messaging.SendCommandAsync(command);
         }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.CommandHandlers;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
+{
+    public class SubmitVacancyCommandHandlerTests
+    {
+        [Fact]
+        public async Task Handle_ShouldChangeEmployerDescriptionIfSpecifiedInCommand()
+        {
+            var vacancy = new Vacancy
+            {
+                Id = Guid.NewGuid(),
+                EmployerDescription = "initial description",
+                IsDeleted = false,
+                Status = VacancyStatus.Draft,
+                VacancyReference = 1234567890
+            };
+
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+
+            var handler = GetSubmitVacancyCommandHandler(vacancy, now);
+
+            var message = new SubmitVacancyCommand(vacancy.Id, user, "updated description");
+
+            var cancel = new CancellationToken();
+            await handler.Handle(message, cancel);
+
+            vacancy.Status.Should().Be(VacancyStatus.Submitted);
+            vacancy.SubmittedDate.Should().Be(now);
+            vacancy.SubmittedByUser.Should().Be(user);
+            vacancy.LastUpdatedDate.Should().Be(now);
+            vacancy.LastUpdatedByUser.Should().Be(user);
+
+            vacancy.EmployerDescription.Should().Be("updated description");
+        }
+
+        [Fact]
+        public async Task Handle_ShouldNotChangeEmployerDescriptionIfNotSpecifiedInCommand()
+        {
+            var vacancy = new Vacancy
+            {
+                Id = Guid.NewGuid(),
+                EmployerDescription = "initial description",
+                IsDeleted = false,
+                Status = VacancyStatus.Draft,
+                VacancyReference = 1234567890
+            };
+
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+
+            var handler = GetSubmitVacancyCommandHandler(vacancy, now);
+
+            var message = new SubmitVacancyCommand(vacancy.Id, user);
+
+            var cancel = new CancellationToken();
+            await handler.Handle(message, cancel);
+
+            vacancy.Status.Should().Be(VacancyStatus.Submitted);
+            vacancy.SubmittedDate.Should().Be(now);
+            vacancy.SubmittedByUser.Should().Be(user);
+            vacancy.LastUpdatedDate.Should().Be(now);
+            vacancy.LastUpdatedByUser.Should().Be(user);
+
+            vacancy.EmployerDescription.Should().Be("initial description");
+        }
+
+        public SubmitVacancyCommandHandler GetSubmitVacancyCommandHandler(Vacancy vacancy, DateTime now)
+        {
+            var mockLogger = new Mock<ILogger<SubmitVacancyCommandHandler>>();
+
+            var mockRepository = new Mock<IVacancyRepository>();
+            mockRepository.Setup(r => r.GetVacancyAsync(vacancy.Id)).ReturnsAsync(vacancy);
+
+            var mockMessaging = new Mock<IMessaging>();
+
+            var mockTimeProvider = new Mock<ITimeProvider>();
+            mockTimeProvider.Setup(t => t.Now).Returns(now);
+
+            var handler = new SubmitVacancyCommandHandler(mockLogger.Object, mockRepository.Object, mockMessaging.Object, mockTimeProvider.Object);
+
+            return handler;
+        }
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Domain/Entities/VacancyTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Domain/Entities/VacancyTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Domain.Entities
+{
+    public class VacancyTests
+    {
+        [Fact]
+        public void CanSubmit_ShouldNotSubmitDeletedVacancy()
+        {
+            var vacancy = new Vacancy
+            {
+                Status = VacancyStatus.Draft,
+                IsDeleted = true
+            };
+
+            vacancy.CanSubmit.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CanSubmit_ShouldNotSubmitVacancyInUnexpectedStatus()
+        {
+            foreach (var status in Enum.GetValues(typeof(VacancyStatus)).Cast<VacancyStatus>()
+                .Except(new[] {VacancyStatus.Draft, VacancyStatus.Referred}))
+            {
+                var vacancy = new Vacancy
+                {
+                    Status = status,
+                    IsDeleted = false
+                };
+
+                vacancy.CanSubmit.Should().BeFalse();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've modified the `SubmitVacancyCommand` so the specifying of EmployerDescription is optional.  So when submitting from Employer the employer description needs to be specified.  When submitting from Provider it is not.

Adding a unit test to ensure the EmployerDescription is set/not set correctly.