### PR TITLE
Fix apprentices link

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ExternalLinksConfiguration.cs
+++ b/src/Employer/Employer.Web/Configuration/ExternalLinksConfiguration.cs
@@ -5,5 +5,6 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         public string ManageApprenticeshipSiteUrl { get; set; }
         public string EmployerIdamsSiteUrl { get; set; }
         public string FindAnApprenticeshipUrl { get; set; }
+        public string CommitmentsSiteUrl { get; set; }
     }
 }

--- a/src/Employer/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
+++ b/src/Employer/Employer.Web/Configuration/ManageApprenticeshipsLinkHelper.cs
@@ -24,7 +24,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         public string ChangeEmail => $"{_externalLinks.EmployerIdamsSiteUrl}{_maRoutes.ManageApprenticeshipSiteChangeEmailAddressRoute}";
         public string Notifications => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteNotificationsRoute}";
         public string Finance => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsFinanceRoute}";
-        public string Apprentices => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsApprenticesRoute}";
+        public string Apprentices => $"{_externalLinks.CommitmentsSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsApprenticesRoute}";
         public string Teams => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsTeamsViewRoute}";
         public string Agreements => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsAgreementsRoute}";
         public string Schemes => $"{_externalLinks.ManageApprenticeshipSiteUrl}{_maRoutes.ManageApprenticeshipSiteAccountsSchemesRoute}";

--- a/src/Employer/Employer.Web/Startup.Configure.cs
+++ b/src/Employer/Employer.Web/Startup.Configure.cs
@@ -134,6 +134,9 @@ namespace Esfa.Recruit.Employer.Web
             
             if (!string.IsNullOrWhiteSpace(linksConfig?.ManageApprenticeshipSiteUrl))
                 destinations.Add(linksConfig?.ManageApprenticeshipSiteUrl);
+            
+            if (!string.IsNullOrWhiteSpace(linksConfig?.CommitmentsSiteUrl))
+                destinations.Add(linksConfig?.CommitmentsSiteUrl);
 
             return destinations.ToArray();
         }

--- a/src/Employer/Employer.Web/appsettings.json
+++ b/src/Employer/Employer.Web/appsettings.json
@@ -30,7 +30,8 @@
   "ExternalLinks": {
     "ManageApprenticeshipSiteUrl": "https://manage-apprenticeships.service.gov.uk/",
     "EmployerIdamsSiteUrl": "https://beta-login.apprenticeships.sfa.bis.gov.uk",
-    "FindAnApprenticeshipUrl": "https://www.gov.uk/apply-apprenticeship"
+    "FindAnApprenticeshipUrl": "https://www.gov.uk/apply-apprenticeship",
+    "CommitmentsSiteUrl": "https://manage-apprenticeships.service.gov.uk/"
   },
   "Features": {
     "AllowThroughFaaApplicationMethod": false

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -69,7 +69,8 @@
         "ManageApprenticeshipSiteUrl": "",
         "EmployerIdamsSiteUrl": "",
         "StaffIdamsUrl": "",
-        "ProviderApprenticeshipSiteUrl": ""
+        "ProviderApprenticeshipSiteUrl": "",
+        "CommitmentsSiteUrl": ""
       }
     },
     "Features": {
@@ -360,6 +361,10 @@
               {
                 "name": "ExternalLinks:EmployerIdamsSiteUrl",
                 "value": "[parameters('ExternalLinks').EmployerIdamsSiteUrl]"
+              },
+              {
+                "name": "ExternalLinks:CommitmentsSiteUrl",
+                "value": "[parameters('ExternalLinks').CommitmentsSiteUrl]"
               },
               {
                 "name": "Features:AllowThroughFaaApplicationMethod",

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
@@ -48,7 +48,8 @@
         "ManageApprenticeshipSiteUrl": "",
         "EmployerIdamsSiteUrl": "",
         "StaffIdamsUrl": "",
-        "ProviderApprenticeshipSiteUrl": ""
+        "ProviderApprenticeshipSiteUrl": "",
+        "CommitmentsSiteUrl": ""
       }
     },
     "Features": {


### PR DESCRIPTION
https://skillsfundingagency.atlassian.net/browse/ER-987

Added new config value specifically for the commitments site to resolve the problem with the 'Apprentices' links only working in PRE/PROD