### PR TITLE
ER-887 - Only show Provider review checkbox for employer vacancies

### DIFF
--- a/src/QA/QA.Web/Views/Review/Review.cshtml
+++ b/src/QA/QA.Web/Views/Review/Review.cshtml
@@ -334,7 +334,7 @@
                 <div class="@Model.ProviderClass" id="@FieldIdentifiers.Provider">
                     <h3 class="govuk-heading-s">Training provider</h3>
                     <p class="govuk-body">@Model.ProviderName</p>
-                    <esfa-review-checkbox asp-for="SelectedFieldIdentifiers"
+                    <esfa-review-checkbox asp-show="@Model.IsEmployerVacancy" asp-for="SelectedFieldIdentifiers"
                                           asp-value="@FieldIdentifiers.Provider"
                                           asp-items="@Model.FieldIdentifiers"></esfa-review-checkbox>
                 </div>


### PR DESCRIPTION
It makes sense to only mark the Provider for reviewing if the vacancy is an Employer vacancy.