### PR TITLE
ER-886 provider resubmit

### DIFF
--- a/src/Provider/Provider.Web/Controllers/Part1/EmployerController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/EmployerController.cs
@@ -4,8 +4,6 @@ using Esfa.Recruit.Provider.Web.RouteModel;
 using Microsoft.AspNetCore.Mvc;
 using Esfa.Recruit.Provider.Web.Orchestrators.Part1;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Employer;
-using Esfa.Recruit.Provider.Web.Extensions;
-using Esfa.Recruit.Shared.Web.Extensions;
 using Provider.Web.ViewModels;
 
 namespace Esfa.Recruit.Provider.Web.Controllers.Part1
@@ -21,16 +19,15 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
         }
 
         [HttpGet("employer", Name = RouteNames.Employer_Get)]
-        public async Task<IActionResult> Employer(VacancyRouteModel vacancyRouteModel, [FromQuery] string wizard = "true")
+        public async Task<IActionResult> Employer(VacancyRouteModel vacancyRouteModel)
         {
             var vm = await _orchestrator.GetEmployersViewModelAsync(vacancyRouteModel);
-            vm.PageInfo.SetWizard(wizard);
             return View(vm);
         }
 
         [HttpPost("employer", Name = RouteNames.Employer_Post)]
         public async Task<IActionResult> Employer(VacancyRouteModel vacancyRouteModel, 
-            EmployersEditModel model, [FromQuery] bool wizard)
+            EmployersEditModel model)
         {            
             if (string.IsNullOrWhiteSpace(model.SelectedEmployerId))
             {
@@ -40,14 +37,10 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
             if(!ModelState.IsValid)
             {
                 var vm = await _orchestrator.GetEmployersViewModelAsync(model);
-                vm.PageInfo.SetWizard(wizard);
                 return View(vm);
             }
-            
-            return
-                wizard 
-                    ? RedirectToRoute(RouteNames.CreateVacancy_Get, new {employerAccountId = model.SelectedEmployerId}) 
-                    : RedirectToRoute(RouteNames.Vacancy_Preview_Get);
+
+            return RedirectToRoute(RouteNames.CreateVacancy_Get, new {employerAccountId = model.SelectedEmployerId});
         }
     }
 }

--- a/src/Provider/Provider.Web/Controllers/Part1/TitleController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/TitleController.cs
@@ -1,13 +1,12 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
 using Esfa.Recruit.Provider.Web.Extensions;
-using Esfa.Recruit.Provider.Web.Orchestrators;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Title;
 using Microsoft.AspNetCore.Mvc;
 using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using System;
+using Esfa.Recruit.Provider.Web.Orchestrators.Part1;
 
 namespace Esfa.Recruit.Provider.Web.Controllers.Part1
 {

--- a/src/Provider/Provider.Web/Controllers/Part1/TitleController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/TitleController.cs
@@ -26,9 +26,9 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
         }
 
         [HttpGet(NewVacancyTitleRoute, Name = RouteNames.CreateVacancy_Get)]
-        public IActionResult Title([FromQuery] string employerAccountId)
+        public async Task<IActionResult> Title([FromQuery] string employerAccountId)
         {
-            var vm = _orchestrator.GetTitleViewModelForNewVacancy(employerAccountId, User.GetUkprn());
+            var vm = await _orchestrator.GetTitleViewModelForNewVacancyAsync(employerAccountId, User.GetUkprn());
             vm.PageInfo.SetWizard();
             return View(vm);
         }

--- a/src/Provider/Provider.Web/Mappings/ReviewFieldMappingLookups.cs
+++ b/src/Provider/Provider.Web/Mappings/ReviewFieldMappingLookups.cs
@@ -84,9 +84,9 @@ namespace Esfa.Recruit.Provider.Web.Mappings
                 { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine3), new []{ FieldIdentifiers.EmployerAddress }},
                 { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine4), new []{ FieldIdentifiers.EmployerAddress }},
                 { FieldIdResolver.ToFieldId(v => v.EmployerLocation.Postcode), new[] { FieldIdentifiers.EmployerAddress}},
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Email), new []{ FieldIdentifiers.EmployerContact} },
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Name), new [] { FieldIdentifiers.EmployerContact }},
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Phone), new []{ FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Email), new []{ FieldIdentifiers.ProviderContact } },
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Name), new [] { FieldIdentifiers.ProviderContact }},
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Phone), new []{ FieldIdentifiers.ProviderContact }},
                 { FieldIdResolver.ToFieldId(v => v.ApplicationInstructions), new [] { FieldIdentifiers.ApplicationInstructions }},
                 { FieldIdResolver.ToFieldId(v => v.ApplicationMethod), new [] { FieldIdentifiers.ApplicationMethod} },
                 { FieldIdResolver.ToFieldId(v => v.ApplicationUrl), new []{ FieldIdentifiers.ApplicationUrl} }
@@ -287,9 +287,9 @@ namespace Esfa.Recruit.Provider.Web.Mappings
 
             var mappings =  new Dictionary<string, IEnumerable<string>>
             {
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Email), new []{ FieldIdentifiers.ProviderContact }},
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Name), new []{ FieldIdentifiers.ProviderContact }},
-                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Phone), new []{ FieldIdentifiers.ProviderContact }}
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Email), new []{ FieldIdentifiers.ProviderContact }},
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Name), new []{ FieldIdentifiers.ProviderContact }},
+                { FieldIdResolver.ToFieldId(v => v.ProviderContact.Phone), new []{ FieldIdentifiers.ProviderContact }}
             };
 
             return new ReviewFieldMappingLookupsForPage(vms, mappings);

--- a/src/Provider/Provider.Web/Mappings/ReviewFieldMappingLookups.cs
+++ b/src/Provider/Provider.Web/Mappings/ReviewFieldMappingLookups.cs
@@ -1,0 +1,317 @@
+using System.Collections.Generic;
+using Esfa.Recruit.Provider.Web.ViewModels;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Employer;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Location;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.ShortDescription;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Title;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Training;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Wage;
+using Esfa.Recruit.Provider.Web.ViewModels.Part2.AboutEmployer;
+using Esfa.Recruit.Provider.Web.ViewModels.Part2.ApplicationProcess;
+using Esfa.Recruit.Provider.Web.ViewModels.Part2.Considerations;
+using Esfa.Recruit.Provider.Web.ViewModels.Part2.ProviderContactDetails;
+using Esfa.Recruit.Provider.Web.ViewModels.Part2.VacancyDescription;
+using Esfa.Recruit.Provider.Web.Views;
+using Esfa.Recruit.Shared.Web.Mappers;
+using Esfa.Recruit.Shared.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Application.Services;
+using static Esfa.Recruit.Vacancies.Client.Domain.Entities.VacancyReview;
+
+namespace Esfa.Recruit.Provider.Web.Mappings
+{
+    public static class ReviewFieldMappingLookups
+    {
+        public static ReviewFieldMappingLookupsForPage GetPreviewReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, Anchors.Title),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, Anchors.ShortDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, Anchors.ClosingDate),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, Anchors.WorkingWeek),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.YearlyWage),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, Anchors.ExpectedDuration),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, Anchors.PossibleStartDate),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, Anchors.TrainingLevel),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, Anchors.NumberOfPositions),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, Anchors.VacancyDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, Anchors.TrainingDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, Anchors.OutcomeDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.Skills),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.Qualifications),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, Anchors.ThingsToConsider),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, Anchors.EmployerDescription),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, Anchors.DisabilityConfident),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, Anchors.EmployerWebsiteUrl),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, Anchors.EmployerAddress),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Provider, Anchors.Provider),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ProviderContact, Anchors.ProviderContact),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, Anchors.Training),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethod),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, Anchors.ApplicationUrl),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, Anchors.ApplicationInstructions)
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerAccountId), new string[0]},
+                { FieldIdResolver.ToFieldId(v => v.Title), new[]{ FieldIdentifiers.Title} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerName), new string[0] },
+                { FieldIdResolver.ToFieldId(v => v.ShortDescription), new []{ FieldIdentifiers.ShortDescription} },
+                { FieldIdResolver.ToFieldId(v => v.ClosingDate), new []{ FieldIdentifiers.ClosingDate} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WeeklyHours), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WorkingWeekDescription), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageAdditionalInformation), new []{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageType),  new[]{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.FixedWageYearlyAmount), new []{ FieldIdentifiers.Wage }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.Duration), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.DurationUnit), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.StartDate), new []{ FieldIdentifiers.PossibleStartDate} },
+                { FieldIdResolver.ToFieldId(v => v.ProgrammeId), new []{ FieldIdentifiers.TrainingLevel, FieldIdentifiers.Training} },
+                { FieldIdResolver.ToFieldId(v => v.VacancyReference), new string[0] },
+                { FieldIdResolver.ToFieldId(v => v.NumberOfPositions), new []{ FieldIdentifiers.NumberOfPositions} },
+                { FieldIdResolver.ToFieldId(v => v.Description), new []{ FieldIdentifiers.VacancyDescription} },
+                { FieldIdResolver.ToFieldId(v => v.TrainingDescription), new []{ FieldIdentifiers.TrainingDescription} },
+                { FieldIdResolver.ToFieldId(v => v.OutcomeDescription), new []{ FieldIdentifiers.OutcomeDescription} },
+                { FieldIdResolver.ToFieldId(v => v.Skills), new []{ FieldIdentifiers.Skills} },
+                { FieldIdResolver.ToFieldId(v => v.Qualifications), new []{ FieldIdentifiers.Qualifications} },
+                { FieldIdResolver.ToFieldId(v => v.ThingsToConsider), new []{ FieldIdentifiers.ThingsToConsider} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerDescription), new [] { FieldIdentifiers.EmployerDescription }},
+                { FieldIdResolver.ToFieldId(v => v.DisabilityConfident), new []{ FieldIdentifiers.DisabilityConfident} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerWebsiteUrl), new []{ FieldIdentifiers.EmployerWebsiteUrl} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine1), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine2), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine3), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine4), new []{ FieldIdentifiers.EmployerAddress }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.Postcode), new[] { FieldIdentifiers.EmployerAddress}},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Email), new []{ FieldIdentifiers.EmployerContact} },
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Name), new [] { FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Phone), new []{ FieldIdentifiers.EmployerContact }},
+                { FieldIdResolver.ToFieldId(v => v.ApplicationInstructions), new [] { FieldIdentifiers.ApplicationInstructions }},
+                { FieldIdResolver.ToFieldId(v => v.ApplicationMethod), new [] { FieldIdentifiers.ApplicationMethod} },
+                { FieldIdResolver.ToFieldId(v => v.ApplicationUrl), new []{ FieldIdentifiers.ApplicationUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetShortDescriptionReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ShortDescription, nameof(ShortDescriptionEditModel.ShortDescription))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ShortDescription), new []{ FieldIdentifiers.ShortDescription} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetTrainingReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ClosingDate, nameof(TrainingEditModel.ClosingDay)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.PossibleStartDate, nameof(TrainingEditModel.StartDay)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Training, nameof(TrainingEditModel.SelectedProgrammeId)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingLevel, nameof(TrainingEditModel.SelectedProgrammeId)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.DisabilityConfident, nameof(TrainingEditModel.IsDisabilityConfident))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ClosingDate), new []{ FieldIdentifiers.ClosingDate} },
+                { FieldIdResolver.ToFieldId(v => v.StartDate), new []{ FieldIdentifiers.PossibleStartDate} },
+                { FieldIdResolver.ToFieldId(v => v.ProgrammeId), new []{ FieldIdentifiers.TrainingLevel, FieldIdentifiers.Training} },
+                { FieldIdResolver.ToFieldId(v => v.DisabilityConfident), new []{ FieldIdentifiers.DisabilityConfident} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetWageReviewFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ExpectedDuration, nameof(WageEditModel.Duration)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WorkingWeek, nameof(WageEditModel.WorkingWeekDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Wage, Anchors.WageTypeHeading),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.WageAdditionalInfo, nameof(WageEditModel.WageAdditionalInformation))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Wage.WeeklyHours), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WorkingWeekDescription), new []{ FieldIdentifiers.WorkingWeek} },
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageAdditionalInformation), new []{ FieldIdentifiers.WageAdditionalInfo }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.WageType),  new[]{ FieldIdentifiers.Wage}},
+                { FieldIdResolver.ToFieldId(v => v.Wage.FixedWageYearlyAmount), new []{ FieldIdentifiers.Wage }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.Duration), new []{ FieldIdentifiers.ExpectedDuration }},
+                { FieldIdResolver.ToFieldId(v => v.Wage.DurationUnit), new []{ FieldIdentifiers.ExpectedDuration }},
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetTitleFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Title, nameof(TitleEditModel.Title)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.NumberOfPositions, nameof(TitleEditModel.NumberOfPositions))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Title), new[]{ FieldIdentifiers.Title} },
+                { FieldIdResolver.ToFieldId(v => v.NumberOfPositions), new []{ FieldIdentifiers.NumberOfPositions} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetLocationFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress, nameof(LocationEditModel.AddressLine1)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress1, nameof(LocationEditModel.AddressLine1)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress2, nameof(LocationEditModel.AddressLine2)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress3, nameof(LocationEditModel.AddressLine3)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerAddress4, nameof(LocationEditModel.AddressLine4))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine1), new []{ FieldIdentifiers.EmployerAddress1 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine2), new []{ FieldIdentifiers.EmployerAddress2 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine3), new []{ FieldIdentifiers.EmployerAddress3 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.AddressLine4), new []{ FieldIdentifiers.EmployerAddress4 }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerLocation.Postcode), new[]{ FieldIdentifiers.EmployerAddress}}
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetVacancyDescriptionFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.VacancyDescription, nameof(VacancyDescriptionEditModel.VacancyDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.TrainingDescription, nameof(VacancyDescriptionEditModel.TrainingDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.OutcomeDescription, nameof(VacancyDescriptionEditModel.OutcomeDescription)),
+
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Description), new []{ FieldIdentifiers.VacancyDescription} },
+                { FieldIdResolver.ToFieldId(v => v.TrainingDescription), new []{ FieldIdentifiers.TrainingDescription} },
+                { FieldIdResolver.ToFieldId(v => v.OutcomeDescription), new []{ FieldIdentifiers.OutcomeDescription} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetSkillsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Skills, Anchors.SkillsHeading),
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Skills), new []{ FieldIdentifiers.Skills} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetQualificationsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.Qualifications, Anchors.QualificationsHeading)
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.Qualifications), new []{ FieldIdentifiers.Qualifications} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetConsiderationsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ThingsToConsider, nameof(ConsiderationsEditModel.ThingsToConsider))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ThingsToConsider), new []{ FieldIdentifiers.ThingsToConsider} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetAboutEmployerFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerDescription, nameof(AboutEmployerEditModel.EmployerDescription)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.EmployerWebsiteUrl, nameof(AboutEmployerEditModel.EmployerWebsiteUrl))
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerDescription), new [] { FieldIdentifiers.EmployerDescription }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerWebsiteUrl), new []{ FieldIdentifiers.EmployerWebsiteUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetProviderContactDetailsFieldIndicators()
+        {
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ProviderContact, nameof(ProviderContactDetailsEditModel.ProviderContactName)),
+            };
+
+            var mappings =  new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Email), new []{ FieldIdentifiers.ProviderContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Name), new []{ FieldIdentifiers.ProviderContact }},
+                { FieldIdResolver.ToFieldId(v => v.EmployerContact.Phone), new []{ FieldIdentifiers.ProviderContact }}
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+
+        public static ReviewFieldMappingLookupsForPage GetApplicationProcessFieldIndicators()
+        { 
+            var vms = new List<ReviewFieldIndicatorViewModel>
+            {
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationMethod, Anchors.ApplicationMethodHeading),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationUrl, nameof(ApplicationProcessEditModel.ApplicationUrl)),
+                new ReviewFieldIndicatorViewModel(FieldIdentifiers.ApplicationInstructions, nameof(ApplicationProcessEditModel.ApplicationInstructions))
+            };
+
+            var mappings = new Dictionary<string, IEnumerable<string>>
+            {
+                { FieldIdResolver.ToFieldId(v => v.ApplicationInstructions), new [] { FieldIdentifiers.ApplicationInstructions }},
+                { FieldIdResolver.ToFieldId(v => v.ApplicationMethod), new [] { FieldIdentifiers.ApplicationMethod} },
+                { FieldIdResolver.ToFieldId(v => v.ApplicationUrl), new []{ FieldIdentifiers.ApplicationUrl} }
+            };
+
+            return new ReviewFieldMappingLookupsForPage(vms, mappings);
+        }
+    }
+}

--- a/src/Provider/Provider.Web/Orchestrators/Part1/EmployerOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/EmployerOrchestrator.cs
@@ -1,32 +1,18 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Employer;
-using Esfa.Recruit.Shared.Web.Orchestrators;
-using Esfa.Recruit.Shared.Web.ViewModels;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Application.Validation;
-using Microsoft.Extensions.Logging;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using Esfa.Recruit.Provider.Web.Configuration.Routing;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
 
 namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 {
     public class EmployerOrchestrator 
     {
-        private const VacancyRuleSet ValidationRules = VacancyRuleSet.EmployerAccountId;
         private readonly IProviderVacancyClient _providerVacancyClient;
-        private readonly IRecruitVacancyClient _recruitVacancyClient;
 
-        public EmployerOrchestrator(ILogger<EmployerOrchestrator> logger, 
-            IProviderVacancyClient providerVacancyClient, IRecruitVacancyClient recruitVacancyClient)
-            
+        public EmployerOrchestrator(IProviderVacancyClient providerVacancyClient)
         {
             _providerVacancyClient = providerVacancyClient;
-            _recruitVacancyClient = recruitVacancyClient;
         }
 
         public async Task<EmployersViewModel> GetEmployersViewModelAsync(VacancyRouteModel vacancyRouteModel)
@@ -35,7 +21,6 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 
             var vm = new EmployersViewModel
             {
-                PageInfo = new PartOnePageInfoViewModel(),
                 Employers = editVacancyInfo.Employers.Select(e => new EmployerViewModel {Id = e.Id, Name = e.Name})
             };
 

--- a/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
@@ -2,10 +2,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Location;
 using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.Extensions;
+using Esfa.Recruit.Shared.Web.Services;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
@@ -19,12 +21,15 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
         private const VacancyRuleSet ValidationRules = VacancyRuleSet.EmployerName | VacancyRuleSet.EmployerAddress;
         private readonly IProviderVacancyClient _providerVacancyClient;
         private readonly IRecruitVacancyClient _recruitVacancyClient;
+        private readonly IReviewSummaryService _reviewSummaryService;
+
         public LocationOrchestrator(IProviderVacancyClient providerVacancyClient, 
-            IRecruitVacancyClient recruitVacancyClient, ILogger<LocationOrchestrator> logger)
+            IRecruitVacancyClient recruitVacancyClient, ILogger<LocationOrchestrator> logger, IReviewSummaryService reviewSummaryService)
             : base(logger)
         {
             _providerVacancyClient = providerVacancyClient;
             _recruitVacancyClient = recruitVacancyClient;
+            _reviewSummaryService = reviewSummaryService;
         }
         public async Task<LocationViewModel> GetLocationViewModelAsync(VacancyRouteModel vrm, long ukprn)
         {
@@ -56,11 +61,11 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
                 vm.Postcode = defaultLegalEntity.Address.Postcode;
             }
 
-            // if (vacancy.Status == VacancyStatus.Referred)
-            // {
-            //     vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-            //         ReviewFieldMappingLookups.GetEmployerFieldIndicators());
-            // }
+            if (vacancy.Status == VacancyStatus.Referred)
+            {
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetLocationFieldIndicators());
+            }
 
             return vm;
         }

--- a/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/LocationOrchestrator.cs
@@ -88,8 +88,9 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 
             var selectedLegalEntity = employerVacancyInfo.LegalEntities.SingleOrDefault(x => x.LegalEntityId == m.SelectedLegalEntityId);
 
+            vacancy.EmployerName = selectedLegalEntity?.Name;
             vacancy.LegalEntityId = m.SelectedLegalEntityId;
-
+            
             vacancy.EmployerLocation = new Vacancies.Client.Domain.Entities.Address
             {
                 AddressLine1 = m.AddressLine1,

--- a/src/Provider/Provider.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/ShortDescriptionOrchestrator.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.ShortDescription;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -39,11 +40,11 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
                 PageInfo = Utility.GetPartOnePageInfo(vacancy)
             };
 
-            // if (vacancy.Status == VacancyStatus.Referred)
-            // {
-            //     vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value, 
-            //         ReviewFieldMappingLookups.GetShortDescriptionReviewFieldIndicators());
-            // }
+            if (vacancy.Status == VacancyStatus.Referred)
+            {
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetShortDescriptionReviewFieldIndicators());
+            }
 
             return vm;
         }

--- a/src/Provider/Provider.Web/Orchestrators/Part1/TitleOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/TitleOrchestrator.cs
@@ -1,23 +1,21 @@
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
 using Esfa.Recruit.Provider.Web.Mappings;
-using Esfa.Recruit.Provider.Web.ViewModels.Part1.Title;
-using Esfa.Recruit.Vacancies.Client.Application.Validation;
-using Microsoft.Extensions.Logging;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Provider.Web.RouteModel;
+using Esfa.Recruit.Provider.Web.ViewModels.Part1.Title;
+using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.Services;
 using Esfa.Recruit.Shared.Web.ViewModels;
-using Esfa.Recruit.Provider.Web.ViewModels.Part1;
-using Esfa.Recruit.Shared.Web.Orchestrators;
-using Esfa.Recruit.Provider.Web.Extensions;
-using System.Linq;
 using Esfa.Recruit.Vacancies.Client.Application.Exceptions;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Microsoft.Extensions.Logging;
 
-namespace Esfa.Recruit.Provider.Web.Orchestrators
+namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 {
     public class TitleOrchestrator : EntityValidatingOrchestrator<Vacancy, TitleEditModel>
     {
@@ -32,7 +30,6 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             _providerVacancyClient = providerVacancyClient;
             _recruitVacancyClient = recruitVacancyClient;
             _reviewSummaryService = reviewSummaryService;
-
         }
 
         public async Task<TitleViewModel> GetTitleViewModelForNewVacancyAsync(string employerAccountId, long ukprn)
@@ -64,8 +61,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                // vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //     ReviewFieldMappingLookups.GetTitleFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetTitleFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part1/TrainingOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/TrainingOrchestrator.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Training;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -71,11 +72,11 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
                 vm.StartYear = $"{vacancy.StartDate.Value.Year}";
             }
 
-            // if (vacancy.Status == VacancyStatus.Referred)
-            // {
-            //     vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-            //         ReviewFieldMappingLookups.GetTrainingReviewFieldIndicators());
-            // }
+            if (vacancy.Status == VacancyStatus.Referred)
+            {
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetTrainingReviewFieldIndicators());
+            }
 
             return vm;
         }

--- a/src/Provider/Provider.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Wage;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -48,8 +49,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                // vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //     ReviewFieldMappingLookups.GetWageReviewFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetWageReviewFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.AboutEmployer;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -38,8 +39,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetAboutEmployerFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetAboutEmployerFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/ApplicationProcessOrchestrator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.ApplicationProcess;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -47,8 +48,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetApplicationProcessFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetApplicationProcessFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/ConsiderationsOrchestrator.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.Considerations;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -37,8 +38,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetConsiderationsFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetConsiderationsFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/ProviderContactDetailsOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/ProviderContactDetailsOrchestrator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.ProviderContactDetails;
 using Esfa.Recruit.Shared.Web.Orchestrators;
@@ -39,8 +40,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                // vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetProviderContactDetailsFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                   ReviewFieldMappingLookups.GetProviderContactDetailsFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/QualificationsOrchestrator.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.Qualifications;
 using Esfa.Recruit.Shared.Web.Extensions;
@@ -45,8 +46,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetQualificationsFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                   ReviewFieldMappingLookups.GetQualificationsFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/SkillsOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/SkillsOrchestrator.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.Skills;
 using Esfa.Recruit.Shared.Web.Extensions;
@@ -51,8 +52,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetSkillsFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                    ReviewFieldMappingLookups.GetSkillsFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part2/VacancyDescriptionOrchestrator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Esfa.Recruit.Provider.Web.Mappings;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels;
 using Esfa.Recruit.Provider.Web.ViewModels.Part2.VacancyDescription;
@@ -44,8 +45,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part2
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                // vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
-                //    ReviewFieldMappingLookups.GetVacancyDescriptionFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value,
+                   ReviewFieldMappingLookups.GetVacancyDescriptionFieldIndicators());
             }
 
             return vm;

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -51,8 +51,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
             if (vacancy.Status == VacancyStatus.Referred)
             {
-                //vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value, 
-                //    ReviewFieldMappingLookups.GetPreviewReviewFieldIndicators());
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value, 
+                    ReviewFieldMappingLookups.GetPreviewReviewFieldIndicators());
             }
             
             return vm;

--- a/src/Provider/Provider.Web/ViewModels/Part1/Employer/EmployersViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Employer/EmployersViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Esfa.Recruit.Shared.Web.ViewModels;
 
 namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Employer
 {
@@ -7,6 +6,5 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Employer
     {
         public string SelectedEmployerId { get; set; }
         public IEnumerable<EmployerViewModel> Employers { get; set; }
-        public PartOnePageInfoViewModel PageInfo { get; set; }
     }
 }

--- a/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Location/LocationViewModel.cs
@@ -11,7 +11,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Location
         public bool HasOnlyOneOrganisation => LegalEntities.Count() == 1;
 		public bool HasMoreThanOneOrganisation => LegalEntities.Count() > 1;
 
-        //public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
+        public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Provider/Provider.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/ShortDescription/ShortDescriptionViewModel.cs
@@ -6,7 +6,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.ShortDescription
 {
     public class ShortDescriptionViewModel 
     {
-        //public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
+        public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
 
         public Guid VacancyId { get; set; }
         public string ShortDescription { get; set; }

--- a/src/Provider/Provider.Web/ViewModels/Part1/Title/TitleViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Title/TitleViewModel.cs
@@ -27,7 +27,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Title
         public PartOnePageInfoViewModel PageInfo { get; set; }
         public string FormPostRouteName => VacancyId.HasValue ? RouteNames.Title_Post : RouteNames.CreateVacancy_Post;
         
-        //public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
+        public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
 
     }
 }

--- a/src/Provider/Provider.Web/ViewModels/Part1/Training/TrainingViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Training/TrainingViewModel.cs
@@ -49,7 +49,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Training
         public bool IsDisabilityConfident { get; set; }
         public IEnumerable<ApprenticeshipProgrammeViewModel> Programmes { get; set; }
 
-        //public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
+        public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
 
         public IList<string> OrderedFieldNames => new List<string>
         {

--- a/src/Provider/Provider.Web/Views/Part1/Employer/Employer.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Employer/Employer.cshtml
@@ -11,7 +11,7 @@
 
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Which of your employers do you want create a vacancy for?</h1>
 
-        <form asp-route="@RouteNames.Employer_Post" asp-route-wizard="@Model.PageInfo.IsWizard">
+        <form asp-route="@RouteNames.Employer_Post">
             <div esfa-validation-marker-for="SelectedEmployerId" class="govuk-form-group">
                 <h2 class="govuk-heading-s">Select employer</h2>
                 <fieldset class="govuk-fieldset">
@@ -28,9 +28,9 @@
                 </fieldset>
             </div>
 
-            <button type="submit" class="govuk-button save-button">@Model.PageInfo.SubmitButtonText</button>
+            <button type="submit" class="govuk-button save-button">@PartOnePageInfoViewModel.SubmitButtonCaptionForWizard</button>
 
-            <a asp-show="@Model.PageInfo.IsWizard" asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-link das-button-link">Cancel</a>
+            <a asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-link das-button-link">Cancel</a>
         </form>
     </div>
 </div>

--- a/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Location/Location.cshtml
@@ -12,7 +12,7 @@
 
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Location</h1>
 
-        <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
+        <partial name="@PartialNames.ReviewSummary" for="Review"/>
 
         <div asp-show="@Model.HasOnlyOneOrganisation">
             <p class="govuk-body">@Model.LegalEntities.First().Name</p>

--- a/src/Provider/Provider.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/ShortDescription/ShortDescription.cshtml
@@ -10,7 +10,7 @@
 
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Brief overview</h1>
 
-        <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
+        <partial name="@PartialNames.ReviewSummary" for="Review"/>
     </div>
 </div>
 

--- a/src/Provider/Provider.Web/Views/Part1/Title/Title.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Title/Title.cshtml
@@ -15,7 +15,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
+        <partial name="@PartialNames.ReviewSummary" for="Review"/>
 
         <form asp-route="@Model.FormPostRouteName" asp-route-wizard="@Model.PageInfo.IsWizard" novalidate>
             <input type="hidden" name="EmployerAccountId" value="@Model.EmployerAccountId" />

--- a/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
@@ -13,7 +13,7 @@
 
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Important dates</h1>
 
-        <!-- <partial name="@PartialNames.ReviewSummary" for="Review"/> -->
+        <partial name="@PartialNames.ReviewSummary" for="Review"/>
 
         <form asp-route="@RouteNames.Training_Post" asp-route-wizard="@Model.PageInfo.IsWizard" novalidate>
 

--- a/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -284,6 +284,7 @@ public IHtmlContent EditLink(string routeName, VacancyPreviewSectionState state,
             <h3 class="govuk-heading-s govuk-!-margin-top-4">Employer</h3>
             <span esfa-validation-message-for="EmployerName" class="govuk-error-message"></span>
             <p asp-show="@Model.HasEmployerName" class="govuk-body">@Model.EmployerName</p>
+            @EditLink(RouteNames.Location_Get, Model.EmployerAddressSectionState, "link-location", new { wizard = false })
         </div>
         <div class="@GetSectionClass(Model.DisabilityConfidentSectionState)">
             <h3 class="govuk-heading-s govuk-!-margin-top-4" id="@Anchors.DisabilityConfident">

--- a/src/Shared/Recruit.Shared.Web/Mappers/ReviewFieldIndicatorMapper.cs
+++ b/src/Shared/Recruit.Shared.Web/Mappers/ReviewFieldIndicatorMapper.cs
@@ -39,6 +39,7 @@ namespace Esfa.Recruit.Shared.Web.Mappers
             { FieldIdentifiers.EmployerContact, "Contact details requires edit" },
             { FieldIdentifiers.EmployerAddress, "Employer address requires edit" },
             { FieldIdentifiers.Provider, "Training provider requires edit" },
+            { FieldIdentifiers.ProviderContact, "Contact details requires edit" },
             { FieldIdentifiers.Training, "Training requires edit" },
             { FieldIdentifiers.ApplicationMethod, "Application method requires edit" },
             { FieldIdentifiers.ApplicationUrl, "Apply now web address requires edit" },

--- a/src/Shared/Recruit.Shared.Web/ViewModels/PartOnePageInfoViewModel.cs
+++ b/src/Shared/Recruit.Shared.Web/ViewModels/PartOnePageInfoViewModel.cs
@@ -2,11 +2,14 @@
 {
     public class PartOnePageInfoViewModel
     {
+        public const string SubmitButtonCaptionForWizard = "Save and Continue";
+        public const string SubmitButtonCaption = "Save and Preview";
+        
         public bool HasCompletedPartOne { get; set; }
         public bool HasStartedPartTwo { get; set; }
         public bool IsWizard { get; private set; }
         public bool IsNotWizard => !IsWizard;
-        public string SubmitButtonText => IsWizard ? "Save and Continue" : "Save and Preview";
+        public string SubmitButtonText => IsWizard ? SubmitButtonCaptionForWizard : SubmitButtonCaption;
 
         public void SetWizard(string requestedWizardParam = null)
         {

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateProviderOwnedVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateProviderOwnedVacancyCommandHandler.cs
@@ -43,7 +43,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
                 SourceOrigin = message.Origin,
                 SourceType = SourceType.New,
                 EmployerAccountId = message.EmployerAccountId,
-                EmployerName = message.EmployerName,
                 TrainingProvider = new TrainingProvider { Ukprn = message.Ukprn },
                 Status = VacancyStatus.Draft,
                 CreatedDate = now,

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/CreateProviderOwnedVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/CreateProviderOwnedVacancyCommand.cs
@@ -7,14 +7,26 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class CreateProviderOwnedVacancyCommand : ICommand, IRequest
     {
-        public Guid VacancyId { get; set; }
-        public SourceOrigin Origin { get; set; }
-        public long Ukprn { get; set; }
-        public string EmployerAccountId { get; set; }
-        public string EmployerName { get; set; }
-        public VacancyUser User { get; set; }
-        public UserType UserType { get; set; }
-        public string Title { get; set; }
-        public int NumberOfPositions { get; set; }
+        public CreateProviderOwnedVacancyCommand(Guid vacancyId, SourceOrigin origin, long ukprn,
+            string employerAccountId, VacancyUser user, UserType userType, string title, int numberOfPositions)
+        {
+            VacancyId = vacancyId;
+            Origin = origin;
+            Ukprn = ukprn;
+            EmployerAccountId = employerAccountId;
+            User = user;
+            UserType = userType;
+            Title = title;
+            NumberOfPositions = numberOfPositions;
+        }
+
+        public Guid VacancyId { get; }
+        public SourceOrigin Origin { get; }
+        public long Ukprn { get; }
+        public string EmployerAccountId { get; }
+        public VacancyUser User { get; }
+        public UserType UserType { get; }
+        public string Title { get; }
+        public int NumberOfPositions { get; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Exceptions/ExceptionMessages.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Exceptions/ExceptionMessages.cs
@@ -6,5 +6,6 @@
         public const string VacancyWithReferenceNotFound = "Unable to find vacancy with reference: {0}.";
         public const string VacancyWithIdNotFound = "Unable to find vacancy with id: {0}.";
         public const string ApplicationReviewUnauthorisedAccess = "The employer account '{0}' cannot access employer account '{1}' application '{2}' for vacancy '{3}'.";
+        public const string ProviderEmployerAccountIdNotFound = "The provider ukprn '{0}' cannot access employer account '{1}'";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -74,8 +74,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
             ValidateEmployerInformation();
 
             ValidateTrainingProvider();
-
-            ValidateEmployer();
         }
 
         private void CrossFieldValidations()
@@ -107,15 +105,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                 .WithRuleId(VacancyRuleSet.Title);
         }
 
-        private void ValidateEmployer()
-        {
-            RuleFor(x => x.EmployerAccountId)
-                .NotNull()
-                .WithMessage("You must select an employer")
-                .WithErrorCode("104")
-                .RunCondition(VacancyRuleSet.EmployerAccountId)
-                .WithRuleId(VacancyRuleSet.EmployerAccountId);
-        }
         private void ValidateOrganisation()
         {
             RuleFor(x => x.EmployerName)

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/VacancyRuleSet.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/VacancyRuleSet.cs
@@ -33,7 +33,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation
         EmployerDescription = 1 << 24,
         EmployerWebsiteUrl = 1 << 25,
         TrainingProvider = 1 << 26,
-        EmployerAccountId = 1 << 27,
         All = ~None,
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
@@ -9,7 +8,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
     public interface IProviderVacancyClient
     {
-        Task<Guid> CreateVacancyAsync(string employerAccountId, string employerName, long ukprn, string title, int numberOfPositions, VacancyUser user);
+        Task<Guid> CreateVacancyAsync(string employerAccountId, long ukprn, string title, int numberOfPositions, VacancyUser user);
         Task GenerateDashboard(long ukprn);
         Task<ProviderDashboard> GetDashboardAsync(long ukprn);
         Task SetupProviderAsync(long ukprn);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
@@ -10,23 +10,21 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 {
     public partial class VacancyClient : IProviderVacancyClient
     {              
-        public async Task<Guid> CreateVacancyAsync(string employerAccountId, string employerName,
+        public async Task<Guid> CreateVacancyAsync(string employerAccountId,
             long ukprn, string title, int numberOfPositions, VacancyUser user)
         {
             var vacancyId = GenerateVacancyId();
 
-            var command = new CreateProviderOwnedVacancyCommand
-            {
-                VacancyId = vacancyId,
-                User = user,
-                UserType = UserType.Provider,
-                EmployerAccountId = employerAccountId,
-                EmployerName = employerName,
-                Ukprn = ukprn,           
-                Origin = SourceOrigin.ProviderWeb,
-                Title = title,
-                NumberOfPositions = numberOfPositions
-            };
+            var command = new CreateProviderOwnedVacancyCommand(
+                vacancyId,
+                SourceOrigin.ProviderWeb,
+                ukprn,
+                employerAccountId,
+                user,
+                UserType.Provider,
+                title,
+                numberOfPositions
+            );
 
             await _messaging.SendCommandAsync(command);
 


### PR DESCRIPTION
- Added the Review Summary to each page
- Simplified the Employer screen as it will only ever be shown as part of the wizard so the redirect path was always the same route.
- Removed `EmployerAccountId` validation.  There is no UI for the user to correct if it was somehow wrong so its not an input validation.  I've added checks to ensure the provider has a valid relationship with `EmployerAccountId` before we allow the creation of the vacancy.
- Corrected the setting of `EmployerName` by the legal entity name and not the account name.