### PR TITLE
ER-972 provider navigation menu

### DIFF
--- a/src/Employer/Employer.Web/Configuration/Routing/ManageApprenticeshipsRoutes.cs
+++ b/src/Employer/Employer.Web/Configuration/Routing/ManageApprenticeshipsRoutes.cs
@@ -14,6 +14,6 @@ namespace Esfa.Recruit.Employer.Web.Configuration.Routing
         public string ManageApprenticeshipSiteAccountsTeamsViewRoute { get; set; }
         public string ManageApprenticeshipSiteAccountsAgreementsRoute { get; set; }
         public string ManageApprenticeshipSiteAccountsSchemesRoute { get; set; }
-        public object ManageApprenticeshipSitePrivacyRoute { get; set; }
+        public string ManageApprenticeshipSitePrivacyRoute { get; set; }
     }
 }

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -70,7 +70,8 @@
         "EmployerIdamsSiteUrl": "",
         "StaffIdamsUrl": "",
         "ProviderApprenticeshipSiteUrl": "",
-        "CommitmentsSiteUrl": ""
+        "CommitmentsSiteUrl": "",
+        "ProviderCommitmentsSiteUrl": ""
       }
     },
     "Features": {
@@ -596,6 +597,10 @@
               {
                 "name": "ExternalLinks:ProviderApprenticeshipSiteUrl",
                 "value": "[parameters('ExternalLinks').ProviderApprenticeshipSiteUrl]"
+              },
+              {
+                "name": "ExternalLinks:CommitmentsSiteUrl",
+                "value": "[parameters('ExternalLinks').ProviderCommitmentsSiteUrl]"
               },
               {
                 "name": "ASPNETCORE_ENVIRONMENT",

--- a/src/Provider/Provider.Web/Configuration/ExternalLinksConfiguration.cs
+++ b/src/Provider/Provider.Web/Configuration/ExternalLinksConfiguration.cs
@@ -4,5 +4,6 @@ namespace Esfa.Recruit.Provider.Web.Configuration
     {
         public string ProviderApprenticeshipSiteUrl { get; set; }
         public string FindAnApprenticeshipUrl { get; set; }
+        public string CommitmentsSiteUrl { get; set; }
     }
 }

--- a/src/Provider/Provider.Web/Configuration/IoC.cs
+++ b/src/Provider/Provider.Web/Configuration/IoC.cs
@@ -28,6 +28,7 @@ namespace Esfa.Recruit.Provider.Web.Configuration
             services.Configure<GoogleAnalyticsConfiguration>(configuration.GetSection("GoogleAnalytics"));
             services.Configure<PostcodeAnywhereConfiguration>(configuration.GetSection("PostcodeAnywhere"));
             services.Configure<FaaConfiguration>(configuration.GetSection("FaaConfiguration"));
+            services.AddSingleton<ProviderApprenticeshipsLinkHelper>();
 
             services.AddFeatureToggle();
 

--- a/src/Provider/Provider.Web/Configuration/ProviderApprenticeshipsLinkHelper.cs
+++ b/src/Provider/Provider.Web/Configuration/ProviderApprenticeshipsLinkHelper.cs
@@ -1,0 +1,27 @@
+using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Microsoft.Extensions.Options;
+
+namespace Esfa.Recruit.Provider.Web.Configuration
+{
+    public class ProviderApprenticeshipsLinkHelper
+    {
+        private readonly ExternalLinksConfiguration _externalLinks;
+        private readonly ProviderApprenticeshipsRoutes _pasRoutes;
+
+        public ProviderApprenticeshipsLinkHelper(IOptions<ExternalLinksConfiguration> externalLinks, IOptions<ProviderApprenticeshipsRoutes> pasRoutes)
+        {
+            _externalLinks = externalLinks.Value;
+            _pasRoutes = pasRoutes.Value;
+        }
+
+        public string AccountHome => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteAccountsHomeRoute}";
+        public string Notifications => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteNotificationSettingsRoute}";
+        public string Apprentices => $"{_externalLinks.CommitmentsSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteManageApprenticesRoute}";
+        public string YourCohorts => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteYourCohortsRoute}";
+        public string Agreements => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteOrganisationAgreementsRoute}";
+        public string Help => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteHelp}";
+        public string Feedback => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteFeedback}";
+        public string Privacy => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSitePrivacy}";
+        public string TermsAndConditions => $"{_externalLinks.ProviderApprenticeshipSiteUrl}{_pasRoutes.ProviderApprenticeshipSiteTermsAndConditions}";
+    }
+}

--- a/src/Provider/Provider.Web/Configuration/Routing/ProviderApprenticeshipsRoutes.cs
+++ b/src/Provider/Provider.Web/Configuration/Routing/ProviderApprenticeshipsRoutes.cs
@@ -1,0 +1,15 @@
+namespace Esfa.Recruit.Provider.Web.Configuration.Routing
+{
+    public sealed class ProviderApprenticeshipsRoutes
+    {
+        public string ProviderApprenticeshipSiteAccountsHomeRoute { get; set; }
+        public string ProviderApprenticeshipSiteManageApprenticesRoute { get; set; }
+        public string ProviderApprenticeshipSiteYourCohortsRoute { get; set; }
+        public string ProviderApprenticeshipSiteOrganisationAgreementsRoute { get; set; }
+        public string ProviderApprenticeshipSiteNotificationSettingsRoute { get; set; }
+        public string ProviderApprenticeshipSiteHelp { get; set; }
+        public string ProviderApprenticeshipSiteFeedback { get; set; }
+        public string ProviderApprenticeshipSitePrivacy { get; set; }
+        public string ProviderApprenticeshipSiteTermsAndConditions { get; set; }
+    }
+}

--- a/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
@@ -14,8 +14,15 @@
         public const string CreateVacancy_Get = "CreateVacancy_Get";
         public const string CreateVacancy_Post = "CreateVacancy_Post";
         public const string Dashboard_Index_Get = "Dashboard_Index_Get";
-        public const string Dashboard_ChangePassword = "Dashboard_ChangePassword";
-        public const string Dashboard_ChangeEmail = "Dashboard_ChangeEmail";
+        public const string Dashboard_AccountsNotifications = "Dashboard_AccountsNotifications";
+        public const string Dashboard_ManageApprentices = "Dashboard_ManageApprentices";
+        public const string Dashboard_YourCohorts = "Dashboard_YourCohorts";
+        public const string Dashboard_AccountsAgreements = "Dashboard_AccountsAgreements";
+        public const string Dashboard_Account_Home = "Dashboard_Account_Home";
+        public const string Dashboard_Help = "Dashboard_Help";
+        public const string Dashboard_Feedback = "Dashboard_Feedback";
+        public const string Dashboard_Privacy = "Dashboard_Privacy";
+        public const string Dashboard_TermsAndConditions = "Dashboard_TermsAndConditions";
         public const string DeleteVacancy_Delete_Get = "DeleteVacancy_Delete_Get";
         public const string DeleteVacancy_Delete_Post = "DeleteVacancy_Delete_Post";
         public const string DisplayFullVacancy_Get = "DisplayFullVacancy_Get";

--- a/src/Provider/Provider.Web/Configuration/Routing/RoutePaths.cs
+++ b/src/Provider/Provider.Web/Configuration/Routing/RoutePaths.cs
@@ -8,7 +8,6 @@
 
         public const string ApplicationReviewPath = "applications/{applicationReviewId:guid}";
         public const string AccountApplicationReviewRoutePath = AccountVacancyRoutePath + "/" + ApplicationReviewPath;
-        public const string Services = "services";
         public const string AccessDeniedPath = "/error/403";
         public const string ExceptionHandlingPath = "/error/handle";
     }

--- a/src/Provider/Provider.Web/Controllers/ExternalLinksController.cs
+++ b/src/Provider/Provider.Web/Controllers/ExternalLinksController.cs
@@ -1,0 +1,75 @@
+﻿using Esfa.Recruit.Provider.Web.Configuration;
+using Esfa.Recruit.Provider.Web.Configuration.Routing;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Esfa.Recruit.Provider.Web.Controllers
+{
+    [Route(RoutePaths.AccountRoutePath)]
+	public class ExternalLinksController : Controller
+    {
+        private readonly ProviderApprenticeshipsLinkHelper _linkHelper;
+
+        public ExternalLinksController(ProviderApprenticeshipsLinkHelper linkHelper)
+        {
+            _linkHelper = linkHelper;
+        }
+
+        [HttpGet("account-home", Name = RouteNames.Dashboard_Account_Home)]
+        public IActionResult AccountHome()
+        {
+            return Redirect(_linkHelper.AccountHome);
+        }
+
+        [HttpGet("notification-settings", Name = RouteNames.Dashboard_AccountsNotifications)]
+        public IActionResult AccountsNotifications()
+        {
+            var url = _linkHelper.Notifications;
+            return Redirect(url);
+        }
+
+        [HttpGet("manage-apprentices", Name = RouteNames.Dashboard_ManageApprentices)]
+        public IActionResult AccountsApprentices(long ukprn)
+        {
+            var url = string.Format(_linkHelper.Apprentices, ukprn);
+            return Redirect(url);
+        }
+
+        [HttpGet("your-cohorts", Name = RouteNames.Dashboard_YourCohorts)]
+        public IActionResult AccountsCohorts(long ukprn)
+        {
+            var url = string.Format(_linkHelper.YourCohorts, ukprn);
+            return Redirect(url);
+        }
+
+        [HttpGet("agreements", Name = RouteNames.Dashboard_AccountsAgreements)]
+        public IActionResult AccountsAgreements(long ukprn)
+        {
+            var url = string.Format(_linkHelper.Agreements, ukprn);
+            return Redirect(url);
+        }
+
+        [HttpGet("help", Name = RouteNames.Dashboard_Help)]
+        public IActionResult Help()
+        {
+            return Redirect(_linkHelper.Help);
+        }
+
+        [HttpGet("feedback", Name = RouteNames.Dashboard_Feedback)]
+        public IActionResult Feedback()
+        {
+            return Redirect(_linkHelper.Feedback);
+        }
+
+        [HttpGet("privacy", Name = RouteNames.Dashboard_Privacy)]
+        public IActionResult PrivacyAndCookies()
+        {
+            return Redirect(_linkHelper.Privacy);
+        }
+
+        [HttpGet("terms", Name = RouteNames.Dashboard_TermsAndConditions)]
+        public IActionResult TermsAndConditions()
+        {
+            return Redirect(_linkHelper.TermsAndConditions);
+        }
+    }
+}

--- a/src/Provider/Provider.Web/Controllers/LogoutController.cs
+++ b/src/Provider/Provider.Web/Controllers/LogoutController.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Options;
 
 namespace Esfa.Recruit.Provider.Web.Controllers
 {
-    [Route(RoutePaths.Services)]
     public class LogoutController : Controller
     {
         private readonly IHostingEnvironment _hostingEnvironment;
@@ -31,6 +30,5 @@ namespace Esfa.Recruit.Provider.Web.Controllers
                 RedirectUri = _externalLinks.ProviderApprenticeshipSiteUrl // TODO: LWA - Need to test if this works!!??
             });
         }
-            
     }
 }

--- a/src/Provider/Provider.Web/Startup.Configure.cs
+++ b/src/Provider/Provider.Web/Startup.Configure.cs
@@ -45,7 +45,7 @@ namespace Esfa.Recruit.Provider.Web
                 .StyleSources(s => 
                     s.Self()
                     //TinyMCE uses inline styles
-                    .UnsafeInline() 
+                    .UnsafeInline()
                 )
                 .ScriptSources(s => 
                     s.Self()
@@ -107,6 +107,9 @@ namespace Esfa.Recruit.Provider.Web
 
             if (!string.IsNullOrWhiteSpace(linksConfig?.ProviderApprenticeshipSiteUrl))
                 destinations.Add(linksConfig?.ProviderApprenticeshipSiteUrl);
+
+            if (!string.IsNullOrWhiteSpace(linksConfig?.CommitmentsSiteUrl))
+                destinations.Add(linksConfig?.CommitmentsSiteUrl);
 
             return destinations.ToArray();
         }

--- a/src/Provider/Provider.Web/Views/Shared/_Layout.cshtml
+++ b/src/Provider/Provider.Web/Views/Shared/_Layout.cshtml
@@ -63,6 +63,7 @@
     <![endif]-->
 
     <meta property="og:image" content="/lib/govuk-frontend/dist/assets/images/govuk-opengraph-image.png">
+    <link asp-append-version="true" rel="stylesheet" media="screen" href="/lib/esfa-provider-menu/style.css" />
     <link asp-append-version="true" rel="stylesheet" media="screen" href="/lib/select2/style.css" />
     <link asp-append-version="true" rel="stylesheet" media="screen" href="/css/application.css" />
     <partial name="@PartialNames.ApplicationInsights" />
@@ -98,28 +99,61 @@
 
     <header class="govuk-header " role="banner" data-module="header">
         <div class="govuk-header__container govuk-width-container">
-
-            <div class="govuk-header__logo">
-                <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" class="govuk-header__link govuk-header__link--homepage">
-                    <span class="govuk-header__logotype">
-
-                        <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
-                            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                            <image src="/lib/govuk-frontend/dist/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
-                        </svg>
-                        <span class="govuk-header__logotype-text">
-                        GOV.UK
-                        </span>
-                    </span>
-                </a>
-            </div>
             <div class="govuk-header__content">
-                <a href="#" class="govuk-header__link govuk-header__link--service-name">
-                Provider
-                </a>
+                <div class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-4">
+                    <a href="#" class="govuk-header__link">
+                    Apprenticeships
+                    </a>
+                </div>
             </div>
         </div>
     </header>
+
+    <div id="global-header-bar"></div>
+
+    @if (Context.User.Identity.IsAuthenticated)
+    {
+        <div class="das-account-header das-account-header--provider">
+            <div class="govuk-width-container">
+                <p class="das-account-header__title">Your training provider account</p>
+                <nav class="das-user-navigation" id="user-nav">
+                    <ul class="das-user-navigation__list" role="menu">
+                        <li role="menuitem" class="das-user-navigation__list-item">
+                            <a href="#" class="das-user-navigation__link">Provider account</a>
+                        </li>
+                        <li role="menuitem" class="das-user-navigation__list-item">
+                            <a href="#" class="das-user-navigation__link">Notification settings</a>
+                        </li>
+                        <li role="menuitem" class="das-user-navigation__list-item">
+                            <a href="#" class="das-user-navigation__link">Sign out</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+
+        <nav class="das-navigation">
+            <div class="govuk-width-container">
+                <ul class="das-navigation__list">
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link das-navigation__link--current" href="#">Home</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href="#">Your cohorts</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href="#">Manage your apprentices</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href="#">Recruitment</a>
+                    </li>  
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href="#">Organisations and agreements</a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+    }
 
     <div class="govuk-width-container">
         <div class="govuk-phase-banner">

--- a/src/Provider/Provider.Web/Views/Shared/_Layout.cshtml
+++ b/src/Provider/Provider.Web/Views/Shared/_Layout.cshtml
@@ -2,6 +2,7 @@
 @using Esfa.Recruit.Provider.Web.Configuration.Routing
 @using Esfa.Recruit.Provider.Web.Views
 @using Esfa.Recruit.Shared.Web.Configuration
+@inject ProviderApprenticeshipsLinkHelper ExternalLinks
 @functions
 {
     public bool ParseHideNavFromViewBag()
@@ -119,13 +120,13 @@
                 <nav class="das-user-navigation" id="user-nav">
                     <ul class="das-user-navigation__list" role="menu">
                         <li role="menuitem" class="das-user-navigation__list-item">
-                            <a href="#" class="das-user-navigation__link">Provider account</a>
+                            <a asp-route="@RouteNames.Dashboard_Account_Home" class="das-user-navigation__link">Provider account</a>
                         </li>
                         <li role="menuitem" class="das-user-navigation__list-item">
-                            <a href="#" class="das-user-navigation__link">Notification settings</a>
+                            <a asp-route="@RouteNames.Dashboard_AccountsNotifications" class="das-user-navigation__link">Notification settings</a>
                         </li>
                         <li role="menuitem" class="das-user-navigation__list-item">
-                            <a href="#" class="das-user-navigation__link">Sign out</a>
+                            <a asp-route="@RouteNames.Logout_Get" class="das-user-navigation__link">Sign out</a>
                         </li>
                     </ul>
                 </nav>
@@ -136,19 +137,19 @@
             <div class="govuk-width-container">
                 <ul class="das-navigation__list">
                     <li class="das-navigation__list-item">
-                        <a class="das-navigation__link das-navigation__link--current" href="#">Home</a>
+                        <a asp-route="@RouteNames.Dashboard_Account_Home" class="das-navigation__link das-navigation__link--current">Home</a>
                     </li>
                     <li class="das-navigation__list-item">
-                        <a class="das-navigation__link" href="#">Your cohorts</a>
+                        <a asp-route="@RouteNames.Dashboard_ManageApprentices" class="das-navigation__link">Manage your apprentices</a>
                     </li>
                     <li class="das-navigation__list-item">
-                        <a class="das-navigation__link" href="#">Manage your apprentices</a>
+                        <a asp-route="@RouteNames.Dashboard_YourCohorts" class="das-navigation__link">Your cohorts</a>
                     </li>
                     <li class="das-navigation__list-item">
-                        <a class="das-navigation__link" href="#">Recruitment</a>
-                    </li>  
+                        <a asp-route="@RouteNames.Dashboard_AccountsAgreements" class="das-navigation__link">Organisations and agreements</a>
+                    </li>
                     <li class="das-navigation__list-item">
-                        <a class="das-navigation__link" href="#">Organisations and agreements</a>
+                        <a asp-route="@RouteNames.Dashboard_Index_Get" class="das-navigation__link">Recruitment</a>
                     </li>
                 </ul>
             </div>
@@ -177,13 +178,16 @@
                     <h2 class="govuk-visually-hidden">Support links</h2>
                     <ul class="govuk-footer__inline-list">
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="Help">Help</a>
+                            <a asp-route="@RouteNames.Dashboard_Help" class="govuk-footer__link">Help</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="https://www.surveymonkey.co.uk/r/2JPLQ9T" target="_blank">Feedback</a>
+                            <a asp-route="@RouteNames.Dashboard_Feedback" class="govuk-footer__link" target="_blank">Feedback</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="Privacy">Privacy and cookies</a>
+                            <a asp-route="@RouteNames.Dashboard_Privacy" class="govuk-footer__link">Privacy and cookies</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a asp-route="@RouteNames.Dashboard_TermsAndConditions" class="govuk-footer__link">Terms and conditions</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
                             Built by the <a href="http://gov.uk/sfa" target="_blank" class="govuk-footer__link">Education and Skills Funding Agency</a>

--- a/src/Provider/Provider.Web/appsettings.json
+++ b/src/Provider/Provider.Web/appsettings.json
@@ -25,10 +25,22 @@
     "InstrumentationKey": ""
   },
   "ExternalLinks": {
-    "ProviderApprenticeshipSiteUrl": "https://providers.apprenticeships.sfa.bis.gov.uk/",
-    "FindAnApprenticeshipUrl": "https://www.gov.uk/apply-apprenticeship"
+    "ProviderApprenticeshipSiteUrl": "https://providers.apprenticeships.sfa.bis.gov.uk",
+    "FindAnApprenticeshipUrl": "https://www.gov.uk/apply-apprenticeship",
+    "CommitmentsSiteUrl": "https://providers.apprenticeships.sfa.bis.gov.uk"
   },
   "Features": {
+  },
+  "ProviderApprenticeshipsRoutes": {
+    "ProviderApprenticeshipSiteAccountsHomeRoute": "/account",
+    "ProviderApprenticeshipSiteManageApprenticesRoute": "/{0}/apprentices/manage/all",
+    "ProviderApprenticeshipSiteYourCohortsRoute": "/{0}/apprentices/cohorts",
+    "ProviderApprenticeshipSiteOrganisationAgreementsRoute": "/{0}/agreements",
+    "ProviderApprenticeshipSiteNotificationSettingsRoute": "/notification-settings",
+    "ProviderApprenticeshipSiteHelp": "/help",
+    "ProviderApprenticeshipSiteFeedback": "/r/accessmylevysurvey",
+    "ProviderApprenticeshipSitePrivacy": "/privacy",
+    "ProviderApprenticeshipSiteTermsAndConditions": "/terms"
   },
   "ProviderApiUrl": "https://findapprenticeshiptraining-api.sfa.bis.gov.uk",
   "PostcodeAnywhere": {

--- a/src/Provider/Provider.Web/wwwroot/css/application.css
+++ b/src/Provider/Provider.Web/wwwroot/css/application.css
@@ -1,116 +1,148 @@
 /*** Cookie banner ***/
 .app-cookie-banner {
-    font-family: "nta", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 14px;
-    font-size: .875rem;
-    line-height: 1.14286;
-    color: #0b0c0c;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-    width: 100%;
-    padding-top: 15px;
-    padding-right: 15px;
-    padding-bottom: 15px;
-    padding-left: 15px;
-    background-color: #d5e8f3
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  font-size: .875rem;
+  line-height: 1.14286;
+  color: #0b0c0c;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding-top: 15px;
+  padding-right: 15px;
+  padding-bottom: 15px;
+  padding-left: 15px;
+  background-color: #d5e8f3
 }
 
 @media print {
-    .app-cookie-banner {
-        font-family: sans-serif
-    }
+  .app-cookie-banner {
+      font-family: sans-serif
+  }
 }
 
 @media (min-width: 40.0625em) {
-    .app-cookie-banner {
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.25
-    }
+  .app-cookie-banner {
+      font-size: 16px;
+      font-size: 1rem;
+      line-height: 1.25
+  }
 }
 
 @media print {
-    .app-cookie-banner {
-        font-size: 14pt;
-        line-height: 1.2
-    }
+  .app-cookie-banner {
+      font-size: 14pt;
+      line-height: 1.2
+  }
 }
 
 @media print {
-    .app-cookie-banner {
-        color: #000
-    }
+  .app-cookie-banner {
+      color: #000
+  }
 }
 
 .app-cookie-banner {
-    display: none
+  display: none
 }
 
 .app-cookie-banner__message {
-    margin: 0
+  margin: 0
 }
 
 @media print {
-    .app-cookie-banner {
-        display: none !important
-    }
+  .app-cookie-banner {
+      display: none !important
+  }
+}
+
+/*** Overide GDS Styles to match DAS ***/
+body {
+font-family: nta, Arial, sans-serif;
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+}
+
+.govuk-header {
+border-bottom: 0;
+}
+
+.govuk-header__container {
+position: relative;
+margin-bottom: 0;
+padding-top: 10px;
+border-bottom: 0;
+}
+
+.govuk-header__link--service-name {
+margin-left: 10px;
+}
+
+.govuk-header__logo {
+margin-bottom: 8px;
+}
+
+#global-header-bar {
+height:10px;
+max-width:100%;
+background: #6f777b
 }
 
 /*** Added as new GDS doesn't have js-hidden class **/
 .js-hidden {
-    display: none;
-    visibility: hidden;
+  display: none;
+  visibility: hidden;
 }
 
 /*** Validation Styles ***/
 .validation-summary-valid {
-    display:none;
+  display:none;
 }
 
 /*** Buttons / links ***/
 .das-button-link {
-    font-family: nta,Arial,sans-serif;
-    display:inline-block;
-    padding:10px 15px 5px 10px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 19px;
-    line-height: 1.25;
-    margin-top: 0;
-    margin-bottom: 15px
+  font-family: nta,Arial,sans-serif;
+  display:inline-block;
+  padding:10px 15px 5px 10px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 19px;
+  line-height: 1.25;
+  margin-top: 0;
+  margin-bottom: 15px
 }
 
 .button-fake-link {
-    background:none;
-    border:none;
-    color: #005ea5;
-    cursor: pointer;
-    display:inline-block;
-    font-size:1em;
-    padding:0;    
-    text-decoration: underline;
+  background:none;
+  border:none;
+  color: #005ea5;
+  cursor: pointer;
+  display:inline-block;
+  font-size:1em;
+  padding:0;    
+  text-decoration: underline;
 }
 
 .button-secondary {
-  background-color:#BFC1C3;
-  box-shadow:none;
-  color:#0B0C0C !important;
-  display:inline-block;
-  padding:7px 15px;
-  text-decoration:none;
+background-color:#BFC1C3;
+box-shadow:none;
+color:#0B0C0C !important;
+display:inline-block;
+padding:7px 15px;
+text-decoration:none;
 }
 
 .button-secondary:hover {
-  background-color:#BFC1C3;
+background-color:#BFC1C3;
 }
 
 .button-secondary:active {
-  top: 2px;
-  box-shadow: none;
+top: 2px;
+box-shadow: none;
 }
 
 .button-secondary:focus {
@@ -119,638 +151,638 @@ outline-offset: 0
 }
 
 .delete-button, .delete-button:visited, .delete-button:hover {
-  background-color: #b10e1e;
-  box-shadow: 0 2px 0 #000000;
+background-color: #b10e1e;
+box-shadow: 0 2px 0 #000000;
 }
 
 /** Utility classes ***/
 .float-right {
-    float:right;
+  float:right;
 }
 
 .float-left {
-    float:left;
+  float:left;
 }
 
 .clear{
-    clear:both;
+  clear:both;
 }
 
 .hide {
-  display: none;
+display: none;
 }
 
 .grey-border {
-    border: 1px solid #bfc1c3;
-    padding: 15px;
-    margin-bottom: 15px;
-    overflow: auto;
+  border: 1px solid #bfc1c3;
+  padding: 15px;
+  margin-bottom: 15px;
+  overflow: auto;
 }
 
 .character-count {
-  margin-bottom: 5px;
+margin-bottom: 5px;
 }
 
 /*** Disability confident styles ***/
 .disability-confident-logo {
-    width: 150px;
-    margin-top: 10px;
+  width: 150px;
+  margin-top: 10px;
 }
 
 .disability-confident-logo-big {
-    width: 200px; 
-    margin-top: 10px;
+  width: 200px; 
+  margin-top: 10px;
 }
 
 /*** Info / Warning summary styles ***/
 .info-summary, .warning-summary{
-    margin-top: 15px;
-    margin-bottom: 15px;
-    padding: 15px 10px;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding: 15px 10px;
+}
+
+.info-summary {
+  border: 4px solid #2e358b;
+}
+
+.warning-summary {
+  border: 4px solid #f47738;
+}
+
+.highlight-summary {
+ border: 4px solid #28a197;
+}
+
+@media (min-width: 641px) {
+  .info-summary, .warning-summary, .highlight-summary {
+      margin-top: 30px;
+      margin-bottom: 30px;
+      padding: 20px 15px 15px;
   }
 
   .info-summary {
-    border: 4px solid #2e358b;
+      border: 5px solid #2e358b;
   }
 
   .warning-summary {
-    border: 4px solid #f47738;
+      border: 5px solid #f47738;
   }
 
- .highlight-summary {
-   border: 4px solid #28a197;
- }
-
-  @media (min-width: 641px) {
-    .info-summary, .warning-summary, .highlight-summary {
-        margin-top: 30px;
-        margin-bottom: 30px;
-        padding: 20px 15px 15px;
-    }
-
-    .info-summary {
-        border: 5px solid #2e358b;
-    }
-
-    .warning-summary {
-        border: 5px solid #f47738;
-    }
-
-    .highlight-summary {
-        border: 4px solid #28a197;
-    }
+  .highlight-summary {
+      border: 4px solid #28a197;
   }
+}
+
+.info-summaryfocus {
+  outline: 3px solid #2e358b;
+}
+
+.warning-summaryfocus {
+  outline: 3px solid #f47738;
+}
+
+.info-summary .info-summary-heading, .warning-summary .warning-summary-heading {
+  margin-top: 0;
+}
+
+.info-summary p, .warning-summary p {
+  margin-bottom: 10px;
+}
+
+.info-summary .info-summary-list, .warning-summary .warning-summary-list {
+  padding-left: 0;
+}
+
+@media (min-width: 641px) {
+  .info-summary .info-summary-list li, .warning-summary .warning-summary-list li {
+    margin-bottom: 5px;
+  }
+}
+
+.info-summary .info-summary-list a, .warning-summary .warning-summary-list a {
   
-  .info-summaryfocus {
-    outline: 3px solid #2e358b;
-  }
+  font-weight: bold;
+  text-decoration: underline;
+}
 
-  .warning-summaryfocus {
-    outline: 3px solid #f47738;
-  }
+.info-summary .info-summary-list a{
+  color: #2e358b;
+}
 
-  .info-summary .info-summary-heading, .warning-summary .warning-summary-heading {
-    margin-top: 0;
-  }
-  
-  .info-summary p, .warning-summary p {
-    margin-bottom: 10px;
-  }
-  
-  .info-summary .info-summary-list, .warning-summary .warning-summary-list {
-    padding-left: 0;
-  }
-  
-  @media (min-width: 641px) {
-    .info-summary .info-summary-list li, .warning-summary .warning-summary-list li {
-      margin-bottom: 5px;
-    }
-  }
-  
-  .info-summary .info-summary-list a, .warning-summary .warning-summary-list a {
-    
-    font-weight: bold;
-    text-decoration: underline;
-  }
+.warning-summary .warning-summary-list a{
+  color: #f47738;
+}
 
-  .info-summary .info-summary-list a{
-    color: #2e358b;
-  }
-
-  .warning-summary .warning-summary-list a{
-    color: #f47738;
-  }
-
-  .info-summary-heading, .warning-summary-heading {
-    margin-top: 0;
-  }
+.info-summary-heading, .warning-summary-heading {
+  margin-top: 0;
+}
 
 /*** Additional error style ***/
 .error-summary .error-summary-list span {
-    color: #b10e1e;
-    font-weight: bold;
+  color: #b10e1e;
+  font-weight: bold;
 }
 
 /***  Inline form ***/
 .form-inline{
-    display: inline;
+  display: inline;
 }
 
 /*** Verification summary ***/
 .verification-summary {
-    border: 4px solid #00823B;
-    margin-top: 15px;
-    margin-bottom: 15px;
-    padding: 15px 10px
+  border: 4px solid #00823B;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding: 15px 10px
 }
 
 @media (min-width: 641px) {
-    .verification-summary {
-        border: 5px solid #00823B;
-        margin-top: 30px;
-        margin-bottom: 30px;
-        padding: 20px 15px 15px
-    }
+  .verification-summary {
+      border: 5px solid #00823B;
+      margin-top: 30px;
+      margin-bottom: 30px;
+      padding: 20px 15px 15px
+  }
 }
 
 .verification-summary .error-summary-heading {
-    margin-top: 0
+  margin-top: 0
 }
 
 .verification-summary p {
-    margin-bottom: 10px
+  margin-bottom: 10px
 }
 
 .verification-summary .verification-summary-list {
-    padding-left: 0
+  padding-left: 0
 }
 
 @media (min-width: 641px) {
-    .verification-summary .verification-summary-list li {
-        margin-bottom: 5px
-    }
+  .verification-summary .verification-summary-list li {
+      margin-bottom: 5px
+  }
 }
 
 .verification-summary .verification-summary-list a {
-    color: #b10e1e;
-    font-weight: 700;
-    text-decoration: underline
+  color: #b10e1e;
+  font-weight: 700;
+  text-decoration: underline
 }
 
 .verification-summary .govuk-heading-s {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    color: #6F777B;
-    font-weight: 400;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  color: #6F777B;
+  font-weight: 400;
 }
 
 /*** Review summary ***/
 .review-summary {
-    border: 5px solid #f47738;
+  border: 5px solid #f47738;
 }
 
 .preview-empty {
-    border-left: 5px solid #2e358b;
-    min-height: 80px;
-    padding-left: 15px;
+  border-left: 5px solid #2e358b;
+  min-height: 80px;
+  padding-left: 15px;
 }
 
 .preview-error {
-    border-left: 5px solid #b10e1e;
-    min-height: 80px;
-    padding-left: 15px;
+  border-left: 5px solid #b10e1e;
+  min-height: 80px;
+  padding-left: 15px;
 }
 
 .preview-review {
-    border-left: 5px solid #f47738;
-    min-height: 80px;
-    padding-left: 15px;
+  border-left: 5px solid #f47738;
+  min-height: 80px;
+  padding-left: 15px;
 }
 
 .vacancy-descriptions ul {
-    margin-top: .3125em;
-    margin-bottom: 1.25em;
-    padding-left: 40px;
-    list-style-type: disc;
+  margin-top: .3125em;
+  margin-bottom: 1.25em;
+  padding-left: 40px;
+  list-style-type: disc;
 }
 
 @media (min-width: 641px) {
-    .vacancy-descriptions ul {
-        margin-top: .26316em;
-        margin-bottom: 1.05263em;
-    }
+  .vacancy-descriptions ul {
+      margin-top: .26316em;
+      margin-bottom: 1.05263em;
+  }
 }
 
 /*** Skills ***/
 @media(min-width: 769px) {
-    .two-column-checkbox-container{
-        overflow:hidden;
-    }
+  .two-column-checkbox-container{
+      overflow:hidden;
+  }
 
-    .two-column-checkbox {
-        display:block;
-        width:50%;
-        float:left;
-    }
+  .two-column-checkbox {
+      display:block;
+      width:50%;
+      float:left;
+  }
 
-    .two-column-checkbox:after{
-        content: "";
-        clear:both;
-        display:block;
-    }
+  .two-column-checkbox:after{
+      content: "";
+      clear:both;
+      display:block;
+  }
 }
 textarea.form-control {
-    opacity: 1;
-    background-image: none;
+  opacity: 1;
+  background-image: none;
 }
 
 input.form-control, textarea.form-control {
-    appearance:none;
-    -webkit-appearance: none;
-    border-radius: 0;
+  appearance:none;
+  -webkit-appearance: none;
+  border-radius: 0;
 }
 
 .red-cross-logo {
-    margin-right: 5px;
-  }
+  margin-right: 5px;
+}
 
 /*** Embeded map ***/
 #static-map {
-    max-width:100%;
+  max-width:100%;
 }
 
 /*** Tiny MCE Styles ***/
 .mce-tinymce {
-    border: 2px solid #0b0c0c !important;
+  border: 2px solid #0b0c0c !important;
 }
 
 .ui-autocomplete {
-    position: absolute;
-    cursor: default
-  }
-  
-  * html .ui-autocomplete {
-    width: 1px
-  }
-  
-  .ui-menu {
-    list-style: none;
-    padding: 2px;
-    margin: 0;
-    display: block;
-    float: left
-  }
-  
-  .ui-menu .ui-menu {
-    margin-top: -3px
-  }
-  
-  .ui-menu .ui-menu-item {
-    margin: 0;
-    padding: 0;
-    zoom:1;float: left;
-    clear: left;
-    width: 100%
-  }
-  
-  .ui-menu .ui-menu-item a {
-    text-decoration: none;
-    display: block;
-    padding: 0.2em 0.4em;
-    line-height: 1.5;
-    zoom:1}
-  
-  .ui-menu .ui-menu-item a.ui-state-hover,.ui-menu .ui-menu-item a.ui-state-active {
-    font-weight: normal;
-    margin: -1px
-  }
-  
-  .ui-helper-hidden-accessible {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px
-  }
-  
-  .ui-autocomplete {
-    background: #fff;
-    border: 1px solid #bfc1c3;
-    list-style-type: none;
-    max-height: 370px;
-    max-width: 100%;
-    overflow-y: auto
-  }
-  
+  position: absolute;
+  cursor: default
+}
+
+* html .ui-autocomplete {
+  width: 1px
+}
+
+.ui-menu {
+  list-style: none;
+  padding: 2px;
+  margin: 0;
+  display: block;
+  float: left
+}
+
+.ui-menu .ui-menu {
+  margin-top: -3px
+}
+
+.ui-menu .ui-menu-item {
+  margin: 0;
+  padding: 0;
+  zoom:1;float: left;
+  clear: left;
+  width: 100%
+}
+
+.ui-menu .ui-menu-item a {
+  text-decoration: none;
+  display: block;
+  padding: 0.2em 0.4em;
+  line-height: 1.5;
+  zoom:1}
+
+.ui-menu .ui-menu-item a.ui-state-hover,.ui-menu .ui-menu-item a.ui-state-active {
+  font-weight: normal;
+  margin: -1px
+}
+
+.ui-helper-hidden-accessible {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px
+}
+
+.ui-autocomplete {
+  background: #fff;
+  border: 1px solid #bfc1c3;
+  list-style-type: none;
+  max-height: 370px;
+  max-width: 100%;
+  overflow-y: auto
+}
+
+.ui-autocomplete .ui-menu-item {
+  cursor: pointer;
+  font-family: "nta",Arial,sans-serif;
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 300;
+  text-transform: none;
+  padding-top: 8px;
+  padding-bottom: 7px
+}
+
+@media (max-width: 640px) {
   .ui-autocomplete .ui-menu-item {
-    cursor: pointer;
-    font-family: "nta",Arial,sans-serif;
-    font-size: 16px;
-    line-height: 1.25;
-    font-weight: 300;
-    text-transform: none;
-    padding-top: 8px;
-    padding-bottom: 7px
+      font-size:14px
   }
-  
-  @media (max-width: 640px) {
-    .ui-autocomplete .ui-menu-item {
-        font-size:14px
-    }
+}
+
+@media (min-width: 641px) {
+  .ui-autocomplete .ui-menu-item {
+      padding-top:5px;
+      padding-bottom: 5px
   }
-  
-  @media (min-width: 641px) {
-    .ui-autocomplete .ui-menu-item {
-        padding-top:5px;
-        padding-bottom: 5px
-    }
-  }
-  
-  .ui-autocomplete .ui-menu-item a:hover,.ui-autocomplete .ui-menu-item .ui-state-focus {
-    background: #dee0e2
-  }
-  
-  .disabled,.disabled>* {
-    opacity: .5;
-    pointer-events: none
-  }
+}
 
- /*** Dashboard ***/
- #dashboard-table td {
-    min-height: 3em;
- }
+.ui-autocomplete .ui-menu-item a:hover,.ui-autocomplete .ui-menu-item .ui-state-focus {
+  background: #dee0e2
+}
 
- #dashboard-table .dashboard-status {
-    min-width: 8em;
- }
+.disabled,.disabled>* {
+  opacity: .5;
+  pointer-events: none
+}
 
- #dashboard-table .dashboard-closingdate {
-    min-width: 8em;
- }
+/*** Dashboard ***/
+#dashboard-table td {
+  min-height: 3em;
+}
 
- #dashboard-table .dashboard-action {
-    min-width: 8em;
- }
+#dashboard-table .dashboard-status {
+  min-width: 8em;
+}
 
- .action-links li {
-    float: left;
-    margin-right: 40px;
- }
+#dashboard-table .dashboard-closingdate {
+  min-width: 8em;
+}
+
+#dashboard-table .dashboard-action {
+  min-width: 8em;
+}
+
+.action-links li {
+  float: left;
+  margin-right: 40px;
+}
 
 
- .close-vacancy-info {
-    border-color: #005ea5;
-    background-color:#eaebf4;
-  }
+.close-vacancy-info {
+  border-color: #005ea5;
+  background-color:#eaebf4;
+}
 
- .tag {
-    display: inline-block;
-    text-align: center;
-    background-color: #808080;
-    color: white;
-    padding: 0.3em 0.4em 0.2em 0.4em;
-    font-weight: bold;
-    font-size: 16px;
-    border-radius: 4px;
-    white-space: nowrap;
-  }
+.tag {
+  display: inline-block;
+  text-align: center;
+  background-color: #808080;
+  color: white;
+  padding: 0.3em 0.4em 0.2em 0.4em;
+  font-weight: bold;
+  font-size: 16px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
 
-  .tag-draft {
-    background-color: #6F777B;
-  }
-  
-  .tag-submitted {
-    background-color: #F47738;
-  }
+.tag-draft {
+  background-color: #6F777B;
+}
 
-  .tag-referred {
-    background-color: #B10E1E;
-  }
+.tag-submitted {
+  background-color: #F47738;
+}
 
-  .tag-approved {
-    background-color: #006435;
-  }
+.tag-referred {
+  background-color: #B10E1E;
+}
 
-  .tag-live {
-    background-color: #006435;
-  }
-  
-  .tag-closed {
-    background-color: #0B0C0C;
-  }
+.tag-approved {
+  background-color: #006435;
+}
+
+.tag-live {
+  background-color: #006435;
+}
+
+.tag-closed {
+  background-color: #0B0C0C;
+}
 
 
 /*** Responsive tables ***/
 table.responsive thead {
+  display: none;
+}
+
+table.responsive tr {
+  margin-bottom: 10px;
+  display: block;
+  float: left;
+  width: 100%;
+  box-sizing: border-box;
+  border: 2px solid #bfc1c3;
+}
+
+table.responsive tr td {
+  display: block;
+  text-align: right;
+  clear: left;
+  float: left;
+  width: 100%;
+  padding: 10px 10px 8px;
+  box-sizing: border-box;
+  border-bottom: 1px dotted #bfc1c3;
+}
+
+table.responsive tr td:before {
+  content: attr(data-label);
+  float: left;
+  font-weight: bold;
+  padding-right: 10px;
+}
+
+table.responsive tr td:last-child {
+  border-bottom: none;
+}
+
+table.responsive tr td:empty {
+  display: none;
+}
+
+table.responsive tr.total {
+  border: 2px solid #000;
+}
+
+@media (min-width: 641px) {
+  table.responsive thead {
+    display: table-header-group;
+  }
+  table.responsive tr {
+    display: table-row;
+    border: none;
+    float: none;
+    margin: 0;
+  }
+  table.responsive tr th, table.responsive tr td {
+    display: table-cell;
+    text-align: left;
+    float: none;
+    clear: none;
+    padding: 0.6em 1em 0.5em;
+    border-bottom-style: solid;
+    width: auto;
+  }
+  table.responsive tr th:first-child, table.responsive tr td:first-child {
+    padding-left: 0;
+  }
+  table.responsive tr th:last-child, table.responsive tr td:last-child {
+    padding-right: 0;
+  }
+  table.responsive tr th:before, table.responsive tr td:before {
     display: none;
   }
-  
-  table.responsive tr {
-    margin-bottom: 10px;
-    display: block;
-    float: left;
-    width: 100%;
-    box-sizing: border-box;
-    border: 2px solid #bfc1c3;
-  }
-  
-  table.responsive tr td {
-    display: block;
+  table.responsive tr th.numeric, table.responsive tr td.numeric {
     text-align: right;
-    clear: left;
-    float: left;
-    width: 100%;
-    padding: 10px 10px 8px;
-    box-sizing: border-box;
-    border-bottom: 1px dotted #bfc1c3;
   }
-  
-  table.responsive tr td:before {
-    content: attr(data-label);
-    float: left;
-    font-weight: bold;
-    padding-right: 10px;
+  table.responsive tr th.colgroup, table.responsive tr td.colgroup {
+    text-align: center;
   }
-  
-  table.responsive tr td:last-child {
+  table.responsive tr th:last-child, table.responsive tr td:last-child {
+    border-bottom: 1px solid #bfc1c3;
+  }
+  table.responsive tr.total {
+    border: none;
+  }
+  table.responsive tr.total td {
     border-bottom: none;
   }
-  
-  table.responsive tr td:empty {
-    display: none;
+  table.responsive tr.total td.total {
+    border-bottom: 2px solid #000;
   }
-  
-  table.responsive tr.total {
-    border: 2px solid #000;
+  table.responsive tr.total td:last-child {
+    padding-left: 0;
   }
-  
-  @media (min-width: 641px) {
-    table.responsive thead {
-      display: table-header-group;
-    }
-    table.responsive tr {
-      display: table-row;
-      border: none;
-      float: none;
-      margin: 0;
-    }
-    table.responsive tr th, table.responsive tr td {
-      display: table-cell;
-      text-align: left;
-      float: none;
-      clear: none;
-      padding: 0.6em 1em 0.5em;
-      border-bottom-style: solid;
-      width: auto;
-    }
-    table.responsive tr th:first-child, table.responsive tr td:first-child {
-      padding-left: 0;
-    }
-    table.responsive tr th:last-child, table.responsive tr td:last-child {
-      padding-right: 0;
-    }
-    table.responsive tr th:before, table.responsive tr td:before {
-      display: none;
-    }
-    table.responsive tr th.numeric, table.responsive tr td.numeric {
-      text-align: right;
-    }
-    table.responsive tr th.colgroup, table.responsive tr td.colgroup {
-      text-align: center;
-    }
-    table.responsive tr th:last-child, table.responsive tr td:last-child {
-      border-bottom: 1px solid #bfc1c3;
-    }
-    table.responsive tr.total {
-      border: none;
-    }
-    table.responsive tr.total td {
-      border-bottom: none;
-    }
-    table.responsive tr.total td.total {
-      border-bottom: 2px solid #000;
-    }
-    table.responsive tr.total td:last-child {
-      padding-left: 0;
-    }
-    table.responsive tr th.tw-5 {
-      width: 5%;
-    }
-    table.responsive tr th.tw-10 {
-      width: 10%;
-    }
-    table.responsive tr th.tw-15 {
-      width: 15%;
-    }
-    table.responsive tr th.tw-20 {
-      width: 20%;
-    }
-    table.responsive tr th.tw-25 {
-      width: 25%;
-    }
-    table.responsive tr th.tw-30 {
-      width: 30%;
-    }
-    table.responsive tr th.tw-35 {
-      width: 35%;
-    }
-    table.responsive tr th.tw-40 {
-      width: 40%;
-    }
-    table.responsive tr th.tw-45 {
-      width: 45%;
-    }
-    table.responsive tr th.tw-50 {
-      width: 50%;
-    }
-    table.responsive tr th.tw-55 {
-      width: 55%;
-    }
-    table.responsive tr th.tw-60 {
-      width: 60%;
-    }
-    table.responsive tr th.tw-65 {
-      width: 65%;
-    }
-    table.responsive tr th.tw-70 {
-      width: 70%;
-    }
+  table.responsive tr th.tw-5 {
+    width: 5%;
   }
-  /*** End responsive tables ***/
+  table.responsive tr th.tw-10 {
+    width: 10%;
+  }
+  table.responsive tr th.tw-15 {
+    width: 15%;
+  }
+  table.responsive tr th.tw-20 {
+    width: 20%;
+  }
+  table.responsive tr th.tw-25 {
+    width: 25%;
+  }
+  table.responsive tr th.tw-30 {
+    width: 30%;
+  }
+  table.responsive tr th.tw-35 {
+    width: 35%;
+  }
+  table.responsive tr th.tw-40 {
+    width: 40%;
+  }
+  table.responsive tr th.tw-45 {
+    width: 45%;
+  }
+  table.responsive tr th.tw-50 {
+    width: 50%;
+  }
+  table.responsive tr th.tw-55 {
+    width: 55%;
+  }
+  table.responsive tr th.tw-60 {
+    width: 60%;
+  }
+  table.responsive tr th.tw-65 {
+    width: 65%;
+  }
+  table.responsive tr th.tw-70 {
+    width: 70%;
+  }
+}
+/*** End responsive tables ***/
 
-  .employer-agreement-container .notice .icon {
-    top:20px;
-  }
+.employer-agreement-container .notice .icon {
+  top:20px;
+}
 
 a[rel="external"]:after {
-    background-image: url(../img/external-link.png);
-    background-repeat: no-repeat;
+  background-image: url(../img/external-link.png);
+  background-repeat: no-repeat;
 }
-    
+  
 @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20 / 10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-      a[rel="external"]:after {
-        background-image: url(../img/external-link-24x24.png);
-        background-size: 12px 400px; }
+    a[rel="external"]:after {
+      background-image: url(../img/external-link-24x24.png);
+      background-size: 12px 400px; }
 }
-  
+
 a[rel="external"]:after {
-    content: "\A0\A0\A0\A0\A0";
-    background-position: right 3px; 
+  content: "\A0\A0\A0\A0\A0";
+  background-position: right 3px; 
 }
 
 a[rel="external"]:hover:after {
-    background-position: right -385px; 
+  background-position: right -385px; 
 }
-  
+
 @media (min-width: 641px) {
-    a[rel="external"]:after {
-      content: "\A0\A0\A0\A0";
-      background-position: right 6px; }
-    a[rel="external"]:hover:after {
-      background-position: right -382px; } 
+  a[rel="external"]:after {
+    content: "\A0\A0\A0\A0";
+    background-position: right 6px; }
+  a[rel="external"]:hover:after {
+    background-position: right -382px; } 
 }
 
 .duration-unit-select {
-    width: auto;
+  width: auto;
 }
 
-  #global-outage-message p {
-    max-width: 960px;
-    margin: 0 15px; }
-    @media (min-width: 641px) {
-      #global-outage-message p {
-        margin: 0 30px; } }
-    @media (min-width: 1020px) {
-      #global-outage-message p {
-        margin: 0 auto; } }
-
-  #global-outage-message form {
-    max-width: 960px;
-    margin: 0 15px; }
-    @media (min-width: 641px) {
-      #global-outage-message form {
-        margin: 0 30px; } }
-    @media (min-width: 1020px) {
-      #global-outage-message form {
-        margin: 0 auto; } }
-
-  #global-outage-message {
-    width: 100%;
-    background-color: #fdf0c9;
-    padding-top: 10px;
-    padding-bottom: 10px; }
+#global-outage-message p {
+  max-width: 960px;
+  margin: 0 15px; }
+  @media (min-width: 641px) {
     #global-outage-message p {
-      font-family: "nta", Arial, sans-serif;
-      font-weight: 400;
-      text-transform: none;
-      font-size: 14px;
-      line-height: 1.14286;
-      margin-top: 0;
-      margin-bottom: 0; }
-      @media (min-width: 641px) {
-        #global-outage-message p {
-          font-size: 16px;
-          line-height: 1.25; } }
+      margin: 0 30px; } }
+  @media (min-width: 1020px) {
+    #global-outage-message p {
+      margin: 0 auto; } }
+
+#global-outage-message form {
+  max-width: 960px;
+  margin: 0 15px; }
+  @media (min-width: 641px) {
+    #global-outage-message form {
+      margin: 0 30px; } }
+  @media (min-width: 1020px) {
+    #global-outage-message form {
+      margin: 0 auto; } }
+
+#global-outage-message {
+  width: 100%;
+  background-color: #fdf0c9;
+  padding-top: 10px;
+  padding-bottom: 10px; }
+  #global-outage-message p {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    font-size: 14px;
+    line-height: 1.14286;
+    margin-top: 0;
+    margin-bottom: 0; }
+    @media (min-width: 641px) {
+      #global-outage-message p {
+        font-size: 16px;
+        line-height: 1.25; } }

--- a/src/Provider/Provider.Web/wwwroot/lib/esfa-provider-menu/style.css
+++ b/src/Provider/Provider.Web/wwwroot/lib/esfa-provider-menu/style.css
@@ -1,0 +1,189 @@
+/*** DAS Account Header ***/
+
+.das-account-header {
+    font-family: "nta",Arial,sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.25;
+    color: #fff;
+    padding: 5px 0
+}
+
+@media print {
+    .das-account-header {
+        font-family: sans-serif
+    }
+}
+
+@media (min-width: 40.0625em) {
+    .das-account-header {
+        font-size:19px;
+        font-size: 1.1875rem;
+        line-height: 1.31579
+    }
+}
+
+@media print {
+    .das-account-header {
+        font-size: 14pt;
+        line-height: 1.15
+    }
+}
+
+@media (min-width: 40.0625em) {
+    .das-account-header {
+        padding:0
+    }
+}
+
+.das-account-header>.govuk-width-container:after {
+    content: "";
+    display: block;
+    clear: both
+}
+
+.das-account-header--provider {
+    background: #f47738
+}
+
+.das-account-header--employer {
+    background: #6f72af
+}
+
+.das-account-header__title {
+    margin: 0 -15px;
+    padding: 10px 15px;
+    font-weight: 700
+}
+
+@media (min-width: 40.0625em) {
+    .das-account-header__title {
+        float:left;
+        padding: 8px 15px
+    }
+}
+
+/*** DAS Navigation ***/
+
+.das-navigation {
+    border-bottom: 1px solid #6f777b;
+    color: #0b0c0c;
+    font-family: "nta",Arial,sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.25
+}
+
+@media print {
+    .das-navigation {
+        color: #000
+    }
+}
+
+@media print {
+    .das-navigation {
+        font-family: sans-serif
+    }
+}
+
+@media (min-width: 40.0625em) {
+    .das-navigation {
+        font-size:19px;
+        font-size: 1.1875rem;
+        line-height: 1.31579
+    }
+}
+
+@media print {
+    .das-navigation {
+        font-size: 14pt;
+        line-height: 1.15
+    }
+}
+
+.das-navigation__list {
+    list-style: none;
+    padding: 0;
+    margin: 0 -15px
+}
+
+.das-navigation__list:after {
+    content: "";
+    display: block;
+    clear: both
+}
+
+@media (min-width: 40.0625em) {
+    .das-navigation__list-item {
+        float:left
+    }
+}
+
+.das-navigation__link {
+    display: block;
+    padding: 10px 15px;
+    border-bottom: 1px solid #dee0e2;
+    color: #005ea5
+}
+
+.das-navigation__link:focus {
+    outline: 3px solid #ffbf47;
+    outline-offset: 0
+}
+
+@media (min-width: 40.0625em) {
+    .das-navigation__link {
+        border:none
+    }
+}
+
+.das-navigation__link--last {
+    border-bottom: none
+}
+
+/*** DAS User Navigation ***/
+
+.das-user-navigation {
+    margin: 0 -15px
+}
+
+@media (min-width: 40.0625em) {
+    .das-user-navigation {
+        float:right
+    }
+}
+
+.das-user-navigation__list {
+    list-style: none;
+    padding: 0;
+    margin: 0
+}
+
+@media (min-width: 40.0625em) {
+    .das-user-navigation__list-item {
+        float:left
+    }
+}
+
+.das-user-navigation__link {
+    color: #fff;
+    text-decoration: none;
+    display: block;
+    padding: 10px 15px;
+    font-size: 16px
+}
+
+.das-user-navigation__link:focus {
+    outline: 3px solid #ffbf47;
+    outline-offset: 0
+}
+
+.das-user-navigation__link:hover {
+    text-decoration: underline
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbCollectionBase.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Mongo/MongoDbCollectionBase.cs
@@ -40,7 +40,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo
             var settings = MongoClientSettings.FromUrl(new MongoUrl(_config.ConnectionString));
             settings.SslSettings = new SslSettings { EnabledSslProtocols = SslProtocols.Tls12 };
 
-            if(RecruitEnvironment.IsDevelopment)
+            if (RecruitEnvironment.IsDevelopment)
                 LogMongoCommands(settings);
             
             var client = new MongoClient(settings);


### PR DESCRIPTION
This is basic.

Going forward we will be using a shared partial across DAS for the employer and Provider menu's these should also take not of the whitelisting and env differences for showing particular menu items.

I have copied in the way that the footer is on the PAS website on test, including a survey link to AccessMyLevy, we can change this as we get a survey for provider recruit or drop it all together.

I have left out the reservations link which might appear on the other env's because it is not showing up on TEST yet. We will have to revisit this when going through the env's to make sure the menu items are the same across other das services.