### PR TITLE
ER-1110 - renamed provider cookies

### DIFF
--- a/src/Provider/Provider.Web/Configuration/CookieNames.cs
+++ b/src/Provider/Provider.Web/Configuration/CookieNames.cs
@@ -7,8 +7,8 @@ namespace Esfa.Recruit.Provider.Web.Configuration
         public const string AntiForgeryCookie = "prov-recruit-x-csrf";
         public const string SeenOutageMessage = "prov-recruit-seen-outage-message";
         public const string SetupProvider = "prov-recruit-setup-provider-{0}";
-        public const string VacancyProposedClosingDate = "vacancy-closingDate-{0}";
-        public const string VacancyProposedStartDate = "vacancy-startDate-{0}";
+        public const string VacancyProposedClosingDate = "prov-vacancy-closingDate-{0}";
+        public const string VacancyProposedStartDate = "prov-vacancy-startDate-{0}";
         public const string DashboardFilter = "prov-dashboard-filter";
     }
 }


### PR DESCRIPTION
Renamed a couple of provider cookies so all provider cookies now start with `prov-`. Documentation has also been adjusted