### PR TITLE
Turn off VacancyAnalyticsSummary gen job

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
@@ -1,4 +1,4 @@
 {
     "_id" : "RecruitWebJobsSystem",
-    "disabledJobs" : []
+    "disabledJobs" : ["VacancyAnalyticsSummaryGeneratorJob"]
 }


### PR DESCRIPTION
This is to turn off the job. We will enable it selectively when testing along with FAA/Vacancy API and keep it turned on when the full integration is in place.