### PR TITLE
ER-1192 - Provider require DAA service claim

### DIFF
--- a/src/Provider/Provider.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Provider/Provider.Web/Configuration/ConfigurationExtensions.cs
@@ -38,6 +38,7 @@ namespace Esfa.Recruit.Provider.Web.Configuration
                 {
                     policy.RequireAuthenticatedUser();
                     policy.RequireClaim(ProviderRecruitClaims.IdamsUserUkprnClaimsTypeIdentifier);
+                    policy.RequireClaim(ProviderRecruitClaims.IdamsUserServiceTypeClaimTypeIdentifier);
                     policy.Requirements.Add(new ProviderAccountRequirement());
                 });
             });

--- a/src/Provider/Provider.Web/Views/Error/AccessDenied.cshtml
+++ b/src/Provider/Provider.Web/Views/Error/AccessDenied.cshtml
@@ -7,5 +7,6 @@
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Access denied</h1>
         <p class="govuk-body">Your account does not have sufficient privileges</p>
         <p class="govuk-body">If you are experiencing difficulty accessing the area of the site you need, first contact an/the account owner to ensure you have the correct role assigned to your account.</p>
-        <a href="/" class="button">Go back to the service homepage</a></div>
+        <p><a href="/" class="button">Go back to the service homepage</a></p>
+    </div>
 </div>


### PR DESCRIPTION
Added an extra claim check to Provider.Web.  Every user must have the claim:

`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/service` with a value of `DAA`

