### PR TITLE
ER-1178 - Toggle levy functionality

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Console.RecruitSeedDataWriter.csproj
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Console.RecruitSeedDataWriter.csproj
@@ -14,6 +14,9 @@
     <Folder Include="Sequence\" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Data\BlockedEmployers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Data\CandidateSkills.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BlockedEmployers.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/BlockedEmployers.json
@@ -1,0 +1,5 @@
+﻿{
+  "_id" : "BlockedEmployers",
+  "lastUpdatedDate" : ISODate("2019-05-14T00:00:00.000Z"),
+  "employerAccountIds" : []
+}

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
@@ -9,6 +9,7 @@ try {
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/QualificationTypes.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BannedPhrases.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
+    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BlockedEmployers.json" -o false
 
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRules.json"
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRecruitSystem.json"

--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/SeedScript.ps1
@@ -9,7 +9,7 @@ try {
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/QualificationTypes.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BannedPhrases.json" -o true
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/Profanities.json" # Due to the sensitive content within this document, the actual profanity content will be loaded manually.
-    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BlockedEmployers.json" -o false
+    & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -f "$PSScriptRoot/Data/BlockedEmployers.json"
 
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRules.json"
     & dotnet "$PSScriptRoot/Esfa.Recruit.Console.RecruitSeedDataWriter.dll" $($dbConnectionString) -c configuration -f "$PSScriptRoot/Data/QaRecruitSystem.json"

--- a/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
+++ b/src/Employer/Employer.Web/Configuration/ConfigurationExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Esfa.Recruit.Shared.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Filters;
 using Esfa.Recruit.Shared.Web.Extensions;
+using Esfa.Recruit.Shared.Web.FeatureToggle;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.Configuration
@@ -43,7 +44,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
             services.AddTransient<IAuthorizationHandler, EmployerAccountHandler>();
         }
 
-        public static void AddMvcService(this IServiceCollection services, IHostingEnvironment hostingEnvironment, bool isAuthEnabled, ILoggerFactory loggerFactory)
+        public static void AddMvcService(this IServiceCollection services, IHostingEnvironment hostingEnvironment, bool isAuthEnabled, ILoggerFactory loggerFactory, IFeature featureToggle)
         {
             services.AddAntiforgery(options =>
             {
@@ -78,8 +79,11 @@ namespace Esfa.Recruit.Employer.Web.Configuration
 
                 opts.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
 
-                opts.Filters.Add(typeof(LevyDeclarationCheckFilter), 50);
-
+                if (featureToggle.IsFeatureEnabled(FeatureNames.AllowLevyPayingEmployersOnly))
+                {
+                    opts.Filters.Add(typeof(LevyDeclarationCheckFilter), 50);
+                }
+                
                 if (EnvironmentNames.IsProductionEnvironment(hostingEnvironment))
                 {
                     opts.Filters.AddService<CheckEmployerBlockedFilter>();

--- a/src/Employer/Employer.Web/Configuration/FeatureNames.cs
+++ b/src/Employer/Employer.Web/Configuration/FeatureNames.cs
@@ -2,7 +2,6 @@
 {
     public static class FeatureNames
     {
-        // Do not remove the class as it ties with FeatureToggle framework
-        // Feature toggle name constants will go here.
+        public const string AllowLevyPayingEmployersOnly = "AllowLevyPayingEmployersOnly";
     }
 }

--- a/src/Employer/Employer.Web/Startup.ConfigureServices.cs
+++ b/src/Employer/Employer.Web/Startup.ConfigureServices.cs
@@ -1,4 +1,5 @@
 using Esfa.Recruit.Employer.Web.Configuration;
+using Esfa.Recruit.Shared.Web.FeatureToggle;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -30,6 +31,9 @@ namespace Esfa.Recruit.Employer.Web
         {
             services.AddIoC(_configuration);
 
+            var serviceProvider = services.BuildServiceProvider();
+            var featureToggle = serviceProvider.GetService<IFeature>();
+
             // Routing has to come before adding Mvc
             services.AddRouting(opt =>
             {
@@ -42,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web
                 o.ViewLocationFormats.Add("/Views/Part2/{1}/{0}" + RazorViewEngine.ViewExtension);
             });
 
-            services.AddMvcService(_hostingEnvironment, _isAuthEnabled, _loggerFactory);
+            services.AddMvcService(_hostingEnvironment, _isAuthEnabled, _loggerFactory, featureToggle);
 
             services.AddApplicationInsightsTelemetry(_configuration);
 

--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -28,17 +28,35 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <div asp-hide="Model.HasVacancies">
-            <p class="govuk-body">
-                You must be a levy-paying employer to post a vacancy.
-            </p>
-            <p class="govuk-body">
-                You can clone vacancies once they've been submitted.
-            </p>
-            <p class="govuk-body">
-                Vacancies will be approved or rejected within 24 hours.
-            </p>
-        </div>
+
+        <esfaFeatureEnabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
+            <div asp-hide="Model.HasVacancies">
+                <p class="govuk-body">
+                    You must be a levy-paying employer to post a vacancy.
+                </p>
+                <p class="govuk-body">
+                    You can clone vacancies once they've been submitted.
+                </p>
+                <p class="govuk-body">
+                    Vacancies will be approved or rejected within 24 hours.
+                </p>
+            </div>
+        </esfaFeatureEnabled>
+
+        <esfaFeatureDisabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
+            <div asp-hide="@Model.HasVacancies">
+                <p class="govuk-body">
+                    Your dashboard is empty, start by creating your first vacancy.
+                </p>
+                <p class="govuk-body">
+                    You can clone vacancies once they've been submitted.
+                </p>
+                <p class="govuk-body">
+                    Vacancies will be approved or rejected within 24 hours.
+                </p>
+            </div>
+        </esfaFeatureDisabled>
+
         <a asp-route="@RouteNames.CreateVacancyOptions_Get" class="govuk-button govuk-!-margin-bottom-6" esfa-automation="create-vacancy">Create vacancy</a>
     </div>
 </div>

--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -29,8 +29,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-        <esfaFeatureEnabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
-            <div asp-hide="Model.HasVacancies">
+        <div asp-hide="Model.HasVacancies">
+            <esfaFeatureEnabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
                 <p class="govuk-body">
                     You must be a levy-paying employer to post a vacancy.
                 </p>
@@ -40,11 +40,9 @@
                 <p class="govuk-body">
                     Vacancies will be approved or rejected within 24 hours.
                 </p>
-            </div>
-        </esfaFeatureEnabled>
+            </esfaFeatureEnabled>
 
-        <esfaFeatureDisabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
-            <div asp-hide="@Model.HasVacancies">
+            <esfaFeatureDisabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
                 <p class="govuk-body">
                     Your dashboard is empty, start by creating your first vacancy.
                 </p>
@@ -56,7 +54,7 @@
                 </p>
             </esfaFeatureDisabled>
         </div>
-        
+
         <a asp-route="@RouteNames.CreateVacancyOptions_Get" class="govuk-button govuk-!-margin-bottom-6" esfa-automation="create-vacancy">Create vacancy</a>
     </div>
 </div>

--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -54,9 +54,9 @@
                 <p class="govuk-body">
                     Vacancies will be approved or rejected within 24 hours.
                 </p>
-            </div>
-        </esfaFeatureDisabled>
-
+            </esfaFeatureDisabled>
+        </div>
+        
         <a asp-route="@RouteNames.CreateVacancyOptions_Get" class="govuk-button govuk-!-margin-bottom-6" esfa-automation="create-vacancy">Create vacancy</a>
     </div>
 </div>

--- a/src/Employer/Employer.Web/appsettings.json
+++ b/src/Employer/Employer.Web/appsettings.json
@@ -38,7 +38,7 @@
     "CommitmentsSiteUrl": "https://manage-apprenticeships.service.gov.uk/"
   },
   "Features": {
-    "AllowThroughFaaApplicationMethod": false
+    "AllowLevyPayingEmployersOnly": true
   },
   "ManageApprenticeshipsRoutes": {
     "ManageApprenticeshipSiteAccountsHomeRoute": "/accounts/{0}/teams",

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -87,7 +87,7 @@
     "Features": {
       "type": "object",
       "defaultValue": {
-        "AllowThroughFaaApplicationMethod": false
+        "AllowLevyPayingEmployersOnly": true
       }
     },
     "LoggingRedisConnectionString": {
@@ -398,8 +398,8 @@
                 "value": "[parameters('ExternalLinks').CommitmentsSiteUrl]"
               },
               {
-                "name": "Features:AllowThroughFaaApplicationMethod",
-                "value": "[parameters('Features').AllowThroughFaaApplicationMethod]"
+                "name": "Features:AllowLevyPayingEmployersOnly",
+                "value": "[parameters('Features').AllowLevyPayingEmployersOnly]"
               },
               {
                 "name": "ASPNETCORE_ENVIRONMENT",

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
@@ -63,7 +63,7 @@
     },
     "Features": {
       "value": {
-        "AllowThroughFaaApplicationMethod": false
+        "AllowLevyPayingEmployersOnly" : true
       }
     },
     "LoggingRedisConnectionString": {

--- a/src/Shared/Recruit.Shared.Web/TagHelpers/EsfaFeatureTagHelper.cs
+++ b/src/Shared/Recruit.Shared.Web/TagHelpers/EsfaFeatureTagHelper.cs
@@ -4,23 +4,48 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace Esfa.Recruit.Shared.Web.TagHelpers
 {
     [HtmlTargetElement(TagName)]
-    public class EsfaFeatureTagHelper : TagHelper
+    public class EsfaFeatureEnabledTagHelper : TagHelper
     {
-        private const string TagName = "esfaFeature";
+        private const string TagName = "esfaFeatureEnabled";
         private readonly IFeature _feature;
 
         [HtmlAttributeName("name")]
         public string Name { get; set; }
 
-        public EsfaFeatureTagHelper(IFeature feature)
+        public EsfaFeatureEnabledTagHelper(IFeature feature)
         {
             _feature = feature;
         }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (!_feature.IsFeatureEnabled(Name))
-                output.SuppressOutput();
+            if (_feature.IsFeatureEnabled(Name))
+                return;
+
+            output.SuppressOutput();
+        }
+    }
+
+    [HtmlTargetElement(TagName)]
+    public class EsfaFeatureDisabledTagHelper : TagHelper
+    {
+        private const string TagName = "esfaFeatureDisabled";
+        private readonly IFeature _feature;
+
+        [HtmlAttributeName("name")]
+        public string Name { get; set; }
+
+        public EsfaFeatureDisabledTagHelper(IFeature feature)
+        {
+            _feature = feature;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (_feature.IsFeatureEnabled(Name) == false)
+                return;
+
+            output.SuppressOutput();
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdateService.cs
@@ -18,19 +18,20 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Apprentices
         private readonly IStandardApiClient _standardsClient;
         private readonly IFrameworkApiClient _frameworksClient;
         private readonly IReferenceDataWriter _referenceDataWriter;
-        private readonly IApprenticeshipProgrammeProvider _programmeProvider;
+        private readonly IReferenceDataReader _referenceDataReader;
 
         public ApprenticeshipProgrammesUpdateService(
             ILogger<ApprenticeshipProgrammesUpdateService> logger, 
             IStandardApiClient standardsClient,
             IFrameworkApiClient frameworksClient,
-            IReferenceDataWriter referenceDataWriter, IApprenticeshipProgrammeProvider programmeProvider)
+            IReferenceDataWriter referenceDataWriter,
+            IReferenceDataReader referenceDataReader)
         {
             _logger = logger;
             _standardsClient = standardsClient;
             _frameworksClient = frameworksClient;
             _referenceDataWriter = referenceDataWriter;
-            _programmeProvider = programmeProvider;
+            _referenceDataReader = referenceDataReader;
         }
 
         public async Task UpdateApprenticeshipProgrammesAsync()
@@ -79,9 +80,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.Apprentices
 
         private async Task ValidateList(List<ApprenticeshipProgramme> apprenticeshipProgrammesFromApi)
         {
-            var apprenticeshipProgrammesFromDb = await _programmeProvider.GetApprenticeshipProgrammesAsync(true);
+            var apprenticeshipProgrammesFromDb = await _referenceDataReader.GetReferenceData<ApprenticeshipProgrammes>();
+
+            if (apprenticeshipProgrammesFromDb == null)
+                return;
+
             var apiCount = apprenticeshipProgrammesFromApi.Count;
-            var dbCount = apprenticeshipProgrammesFromDb.Count();
+            var dbCount = apprenticeshipProgrammesFromDb.Data.Count();
             var difference = Math.Abs(apiCount - dbCount);
             double percent = (double)(difference * 100) / apiCount; 
             if (percent > AcceptablePercentage)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/BankHolidays/BankHolidayUpdateService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/ReferenceData/BankHolidays/BankHolidayUpdateService.cs
@@ -55,6 +55,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.BankHoliday
         private async Task<bool> HasBankHolidayDataChanged(BankHolidays bankHolidaysFromApi)
         {
             var bankHolidaysFromDb = await _referenceDataReader.GetReferenceData<BankHolidays>();
+
+            if (bankHolidaysFromDb == null)
+                return true;
+
             var bankHolidaysFromApiJson = JsonConvert.SerializeObject(bankHolidaysFromApi.Data);
             var bankHolidaysFromDbJson = JsonConvert.SerializeObject(bankHolidaysFromDb.Data);
             var areEqual = JToken.DeepEquals(bankHolidaysFromApiJson, bankHolidaysFromDbJson);

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdaterServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/ReferenceData/ApprenticeshipProgrammes/ApprenticeshipProgrammesUpdaterServiceTests.cs
@@ -94,7 +94,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.ReferenceData.A
 
         public ApprenticeshipProgrammesUpdaterServiceTests()
         {
-            var mockApprenticeshipProgrammeProvider = new Mock<IApprenticeshipProgrammeProvider>();
+            var mockReferenceDataReader = new Mock<IReferenceDataReader>();
             _mockStandardsClient = new Mock<IStandardApiClient>();
             _mockFrameworksClient = new Mock<IFrameworkApiClient>();
             _mockReferenceDataWriter = new Mock<IReferenceDataWriter>();
@@ -103,7 +103,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Infrastructure.ReferenceData.A
                                                             _mockStandardsClient.Object,
                                                             _mockFrameworksClient.Object,
                                                             _mockReferenceDataWriter.Object,
-                                                            mockApprenticeshipProgrammeProvider.Object);
+                                                            mockReferenceDataReader.Object);
         }
 
         [Fact]


### PR DESCRIPTION
Moved feature toggle functionality from Shared.Web to Client so we can use the toggle from the jobs

- Added `EnableLevy` feature toggle
- Toggle turns off the adding of the `LevyDeclarationCheckFilter` in Employer.Web
- Toggle is used in the `NonLevyAccountBlockerJob`. When `EnableLevy` is false the BlockedEmployers list is set to be empty.