### PR TITLE
Changes log level for invalid state exception

### DIFF
--- a/src/Employer/Employer.Web/nlog.config
+++ b/src/Employer/Employer.Web/nlog.config
@@ -15,6 +15,7 @@
 
     <target xsi:type="Redis" name="redis" connectionStringName="Redis" environmentKeyName="ASPNETCORE_ENVIRONMENT" appName="das-employer-recruit-web" includeAllProperties="true" layout="${message}">
       <field name="requestId" layout="${aspnet-traceidentifier}"/>
+      <field name="user" layout="${aspnet-user-identity}"/>
       <field name="loggerName" layout="${logger}"/>
     </target>
   </targets>

--- a/src/Provider/Provider.Web/Controllers/ErrorController.cs
+++ b/src/Provider/Provider.Web/Controllers/ErrorController.cs
@@ -75,7 +75,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers
 
                 if (exception is InvalidStateException)
                 {
-                    _logger.LogError(exception, "Exception on path: {route}", routeWhereExceptionOccurred);
+                    _logger.LogWarning(exception, "Exception on path: {route}", routeWhereExceptionOccurred);
                     AddDashboardMessage(exception.Message);
                     return RedirectToRoute(RouteNames.Vacancies_Get, new { Ukprn = ukprn });
                 }

--- a/src/Provider/Provider.Web/nlog.config
+++ b/src/Provider/Provider.Web/nlog.config
@@ -15,6 +15,7 @@
 
     <target xsi:type="Redis" name="redis" connectionStringName="Redis" environmentKeyName="ASPNETCORE_ENVIRONMENT" appName="das-provider-recruit-web" includeAllProperties="true" layout="${message}">
       <field name="requestId" layout="${aspnet-traceidentifier}"/>
+      <field name="user" layout="${aspnet-user-identity}"/>
       <field name="loggerName" layout="${logger}"/>
     </target>
   </targets>


### PR DESCRIPTION
Invalid state exception is raised when an disallowed action is requested. Since this is handled, it shouldn't be logged as error as there is not much we can do about it. Instead, we need to raise this as a warning and keep an eye on the number of occurrences. If too many instance of these warnings are logged we may have to investigate the user actions. 
Also I have added missing user info to provider's and employer's log. 