### PR TITLE
ER-1259 - Patch ESFA training provider details instead of calling Providers API for ESFA owned Provider vacancies

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
@@ -17,10 +17,24 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
         private readonly ILogger<PatchVacancyTrainingProviderCommandHandler> _logger;
         private readonly ITrainingProviderService _trainingProviderService;
 
+        private readonly TrainingProvider _esfaTrainingProvider = new TrainingProvider
+        {
+            Ukprn = 10033670,
+            Name = "Education Skills Funding Agency",
+            Address = new Address
+            {
+                AddressLine1 = "Cheylesmore House",
+                AddressLine2 = "Quinton Road",
+                AddressLine3 = "Coventry",
+                AddressLine4 = "",
+                Postcode = "CV1 2WT"
+            }
+        };
+
         public PatchVacancyTrainingProviderCommandHandler(
+            ILogger<PatchVacancyTrainingProviderCommandHandler> logger,
             IVacancyRepository repository,
             IMessaging messaging,
-            ILogger<PatchVacancyTrainingProviderCommandHandler> logger,
             ITrainingProviderService trainingProviderService)
         {
             _repository = repository;
@@ -47,7 +61,16 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
             _logger.LogInformation("Patching training provider name and address for vacancy {vacancyId}.", message.VacancyId);
 
-            var tp = await _trainingProviderService.GetProviderAsync(vacancy.TrainingProvider.Ukprn.Value);
+            TrainingProvider tp;
+
+            if (vacancy.TrainingProvider.Ukprn.Value.Equals(_esfaTrainingProvider.Ukprn))
+            {
+                tp = _esfaTrainingProvider;
+            }
+            else
+            {
+                tp = await _trainingProviderService.GetProviderAsync(vacancy.TrainingProvider.Ukprn.Value);
+            }
 
             vacancy = await _repository.GetVacancyAsync(message.VacancyId);
             PatchVacancyTrainingProvider(vacancy, tp);

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloneVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloneVacancyCommandHandlerTests.cs
@@ -16,7 +16,8 @@ using AutoFixture;
 
 namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
 {
-    public class CloneVacancyCommandHandlerTests : VacancyValidationTestsBase
+    [Trait("Category", "Unit")]
+    public class CloneVacancyCommandHandlerTests
     {
         [Fact]
         public async Task CheckClonedVacancyHasCorrectFieldsSet()

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandlerTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Xunit;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Esfa.Recruit.Vacancies.Client.Application.CommandHandlers;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
+
+namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
+{
+    [Trait("Category", "Unit")]
+    public class PatchVacancyTrainingProviderCommandHandlerTests
+    {
+        private const long EsfaUkprn = 10033670;
+        private const long NonEsfaUkprn = 12345678;
+        private readonly Mock<IVacancyRepository> _mockRepository;
+        private readonly Mock<ITrainingProviderService> _mockTrainingProvider;
+        private readonly PatchVacancyTrainingProviderCommandHandler _handler;
+        private Vacancy _updatedVacancy = null;
+
+        public PatchVacancyTrainingProviderCommandHandlerTests()
+        {
+            _mockRepository = new Mock<IVacancyRepository>();
+            _mockTrainingProvider = new Mock<ITrainingProviderService>();
+            
+            _mockRepository.Setup(x => x.UpdateAsync(It.IsAny<Vacancy>()))
+                            .Callback<Vacancy>(arg => _updatedVacancy = arg)
+                            .Returns(Task.CompletedTask);
+            _mockTrainingProvider.Setup(x => x.GetProviderAsync(NonEsfaUkprn))
+                                .ReturnsAsync(new TrainingProvider() { Ukprn = NonEsfaUkprn, Name = "FakeProvider", Address = new Address() });
+
+            _handler = new PatchVacancyTrainingProviderCommandHandler(
+                Mock.Of<ILogger<PatchVacancyTrainingProviderCommandHandler>>(),
+                _mockRepository.Object,
+                Mock.Of<IMessaging>(),
+                _mockTrainingProvider.Object
+            );
+        }
+
+        [Fact]
+        public async Task GivenEmployerOwnedVacancy_ThenDoNotProcess()
+        {
+            var existingVacancy = GetTestEmployerOwnedVacancy();
+
+            _mockRepository.Setup(x => x.GetVacancyAsync(existingVacancy.Id))
+                            .ReturnsAsync(existingVacancy);
+
+            var command = new PatchVacancyTrainingProviderCommand(existingVacancy.Id);
+
+            await _handler.Handle(command, CancellationToken.None);
+
+            _mockTrainingProvider.Verify(x => x.GetProviderAsync(It.IsAny<long>()), Times.Never);
+            _mockRepository.Verify(x => x.UpdateAsync(It.IsAny<Vacancy>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GivenNonEsfaUkprnProviderOwnedVacancy_ThenCallsProvidersApi()
+        {
+            var existingVacancy = GetTestProviderOwnedVacancy(NonEsfaUkprn);
+
+            _mockRepository.Setup(x => x.GetVacancyAsync(existingVacancy.Id))
+                            .ReturnsAsync(existingVacancy);
+
+            var command = new PatchVacancyTrainingProviderCommand(existingVacancy.Id);
+
+            await _handler.Handle(command, CancellationToken.None);
+
+            _updatedVacancy.TrainingProvider.Name.Should().Be("FakeProvider");
+            _updatedVacancy.TrainingProvider.Address.Should().NotBeNull();
+            _mockTrainingProvider.Verify(x => x.GetProviderAsync(NonEsfaUkprn), Times.AtMostOnce);
+            _mockRepository.Verify(x => x.UpdateAsync(_updatedVacancy), Times.AtMostOnce);
+        }
+
+        [Fact]
+        public async Task GivenEsfaUkprnProviderOwnedVacancy_ThenDoNotCallProvidersApi()
+        {
+            var existingVacancy = GetTestProviderOwnedVacancy(EsfaUkprn);
+
+            _mockRepository.Setup(x => x.GetVacancyAsync(existingVacancy.Id))
+                            .ReturnsAsync(existingVacancy);
+
+            var command = new PatchVacancyTrainingProviderCommand(existingVacancy.Id);
+
+            await _handler.Handle(command, CancellationToken.None);
+
+            _updatedVacancy.TrainingProvider.Name.Should().Be("Education Skills Funding Agency");
+            _updatedVacancy.TrainingProvider.Address.Should().NotBeNull();
+            _mockTrainingProvider.Verify(x => x.GetProviderAsync(EsfaUkprn), Times.Never);
+            _mockRepository.Verify(x => x.UpdateAsync(_updatedVacancy), Times.AtMostOnce);
+        }
+
+        private Vacancy GetTestProviderOwnedVacancy(long ukprn)
+        {
+            var vacancy = new Vacancy();
+            vacancy.Id = Guid.NewGuid();
+            vacancy.OwnerType = OwnerType.Provider;
+            vacancy.TrainingProvider = new TrainingProvider { Ukprn = ukprn };
+            return vacancy;
+        }
+
+        private Vacancy GetTestEmployerOwnedVacancy()
+        {
+            var vacancy = new Vacancy();
+            vacancy.Id = Guid.NewGuid();
+            vacancy.OwnerType = OwnerType.Employer;
+            return vacancy;
+        }
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
 {
+    [Trait("Category", "Unit")]
     public class SubmitVacancyCommandHandlerTests
     {
         [Fact]

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Extensions/VacancyExtensionsTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Extensions/VacancyExtensionsTests.cs
@@ -93,7 +93,7 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructur
             p.EmployerWebsiteUrl.Should().BeNull();
         }
 
-        public void AssertCommonProperties(Vacancy v, VacancyProjectionBase p)
+        private  void AssertCommonProperties(Vacancy v, VacancyProjectionBase p)
         {
             p.Id.Should().Be(DocumentId);
             p.LastUpdated.Should().Be(_now);


### PR DESCRIPTION
Note this is a stop gap solution to support smoke testing without causing a flood of error logs.

The domain event handler picks up on DraftVacancyUpdatedEvent and kicks off the PatchTrainingProvider command handler and processes when the vacancy is Provider Owned and the name and address hasn't been populated.