### PR TITLE
ER-1187 - UTC to GMT Standard conversion

### DIFF
--- a/src/Provider/Provider.Web/Orchestrators/Reports/ProviderApplicationsReportOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Reports/ProviderApplicationsReportOrchestrator.cs
@@ -44,8 +44,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Reports
 
         public Task<Guid> PostCreateViewModelAsync(ProviderApplicationsReportCreateEditModel model, VacancyUser user)
         {
-            DateTime toDateInclusive = _timeProvider.NextDay.AddTicks(-1);
             DateTime fromDate;
+            DateTime toDate = _timeProvider.Today;
 
             switch (model.DateRange)
             {
@@ -59,14 +59,16 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Reports
                     fromDate = _timeProvider.Today.AddDays(-30);
                     break;
                 case DateRangeType.Custom:
-                    fromDate = model.FromDate.AsDateTimeUk(DateTimeStyles.AssumeLocal).Value.ToUniversalTime();
-                    toDateInclusive = model.ToDate.AsDateTimeUk(DateTimeStyles.AssumeLocal).Value.ToUniversalTime().AddDays(1).AddTicks(-1);
+                    fromDate = model.FromDate.AsDateTimeUk().Value.ToUniversalTime();
+                    toDate = model.ToDate.AsDateTimeUk().Value.ToUniversalTime();
                     break;
                 default:
                     throw new Exception($"Cannot handle this date range type:{model.DateRange.ToString()}");
             }
 
-            var reportName = $"{fromDate.ToLocalTime().AsGdsDate()} to {toDateInclusive.ToLocalTime().AsGdsDate()}";
+            var reportName = $"{fromDate.ToUkTime().AsGdsDate()} to {toDate.ToUkTime().AsGdsDate()}";
+
+            DateTime toDateInclusive = toDate.AddDays(1).AddTicks(-1);
 
             return _client.CreateProviderApplicationsReportAsync(model.Ukprn, fromDate, toDateInclusive, user, reportName);
         }

--- a/src/Provider/Provider.Web/Orchestrators/Reports/ReportDashboardOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Reports/ReportDashboardOrchestrator.cs
@@ -33,7 +33,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Reports
                     ReportId = r.Id,
                     ReportName = r.ReportName,
                     DownloadCount = r.DownloadCount,
-                    CreatedDate = r.RequestedOn.ToLocalTime().AsGdsDateTime(),
+                    CreatedDate = r.RequestedOn.ToUkTime().AsGdsDateTime(),
                     CreatedBy = r.RequestedBy.Name,
                     Status = r.Status,
                     IsProcessing = r.IsProcessing

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/Reports/ProviderApplicationsReportOrchestratorTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/Reports/ProviderApplicationsReportOrchestratorTests.cs
@@ -14,19 +14,25 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.Orchestrators.Reports
 {
     public class ProviderApplicationsReportOrchestratorTests
     {
-        private readonly Mock<IProviderVacancyClient> _client = new Mock<IProviderVacancyClient>();
+        
 
         [Theory]
-        [InlineData(DateRangeType.Last7Days, "2019-02-26", "2019-03-05")]
-        [InlineData(DateRangeType.Last14Days, "2019-02-19", "2019-03-05")]
-        [InlineData(DateRangeType.Last30Days, "2019-02-03", "2019-03-05")]
+        [InlineData(DateRangeType.Last7Days, "2019-02-26Z", "2019-03-05Z")] //GMT
+        [InlineData(DateRangeType.Last14Days, "2019-02-19Z", "2019-03-05Z")] //GMT
+        [InlineData(DateRangeType.Last30Days, "2019-02-03Z", "2019-03-05Z")] //GMT
+        [InlineData(DateRangeType.Last7Days, "2019-04-01Z", "2019-04-08Z")] //BST
+        [InlineData(DateRangeType.Last14Days, "2019-04-01Z", "2019-04-15Z")] //BST
+        [InlineData(DateRangeType.Last30Days, "2019-04-01Z", "2019-05-01Z")] //BST
         public async Task PostCreateViewModelAsync_ShouldUseCorrectTimespan(DateRangeType dateRangeType, string fromDate, string toDate)
         {
-            var orchestrator = GetOrchestrator();
+            var mockClient = new Mock<IProviderVacancyClient>();
+            var orchestrator = GetOrchestrator(mockClient.Object, $"{toDate}");
+
+            var fromDateUtc = DateTimeOffset.Parse(fromDate).UtcDateTime;
+            var toDateUtc = DateTimeOffset.Parse(toDate).UtcDateTime;
 
             long ukprn = 12345678;
-            string reportName = $"{DateTime.Parse(fromDate).AsGdsDate()} to {DateTime.Parse(toDate).AsGdsDate()}";
-
+            
             var model = new ProviderApplicationsReportCreateEditModel {
                 Ukprn = ukprn,
                 DateRange = dateRangeType
@@ -36,55 +42,66 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.Orchestrators.Reports
 
             await orchestrator.PostCreateViewModelAsync(model, user);
 
-            _client.Verify(c => c.CreateProviderApplicationsReportAsync(
-                ukprn, 
-                DateTime.Parse(fromDate), 
-                DateTime.Parse(toDate).AddDays(1).AddTicks(-1), 
-                user, 
-                reportName), 
+            string expectedReportName = $"{fromDateUtc.AsGdsDate()} to {toDateUtc.AsGdsDate()}";
+
+            mockClient.Verify(c => c.CreateProviderApplicationsReportAsync(
+                ukprn,
+                fromDateUtc,
+                toDateUtc.AddDays(1).AddTicks(-1), 
+                user,
+                expectedReportName), 
                 Times.Once);
         }
 
-        [Fact]
-        public async Task PostCreateViewModelAsync_ShouldUseCustomTimespan()
+        [Theory]
+        [InlineData("1", "2", "2018", "20", "2", "2019")] //GMT
+        [InlineData("1", "4", "2018", "20", "4", "2019")] //BST
+        public async Task PostCreateViewModelAsync_ShouldUseCustomTimespan(string fromDay, string fromMonth, string fromYear, string toDay, string toMonth, string toYear)
         {
+            
             long ukprn = 12345678;
 
             var model = new ProviderApplicationsReportCreateEditModel {
                 Ukprn = ukprn,
                 DateRange = DateRangeType.Custom,
-                FromDay = "1",
-                FromMonth = "2",
-                FromYear = "2018",
-                ToDay = "3",
-                ToMonth = "4",
-                ToYear = "2019",
+                FromDay = fromDay,
+                FromMonth = fromMonth,
+                FromYear = fromYear,
+                ToDay = toDay,
+                ToMonth = toMonth,
+                ToYear = toYear,
             };
 
             var user = new VacancyUser();
 
-            var orchestrator = GetOrchestrator();
+            var mockClient = new Mock<IProviderVacancyClient>();
+            var orchestrator = GetOrchestrator(mockClient.Object, "2019-12-05Z");
+
+            var fromDateUtc = DateTimeOffset.Parse($"{fromYear}-{fromMonth}-{fromDay}Z").UtcDateTime;
+            var toDateUtc = DateTimeOffset.Parse($"{toYear}-{toMonth}-{toDay}Z").UtcDateTime;
 
             await orchestrator.PostCreateViewModelAsync(model, user);
 
-            _client.Verify(c => c.CreateProviderApplicationsReportAsync(
+            string expectedReportName = $"{fromDateUtc.AsGdsDate()} to {toDateUtc.AsGdsDate()}";
+
+            mockClient.Verify(c => c.CreateProviderApplicationsReportAsync(
                     ukprn,
-                    DateTime.Parse("2018-02-01").ToUniversalTime(),
-                    DateTime.Parse("2019-04-03").AddDays(1).AddTicks(-1).ToUniversalTime(), 
+                    fromDateUtc,
+                    toDateUtc.AddDays(1).AddTicks(-1),
                     user,
-                    "01 Feb 2018 to 03 Apr 2019"),
+                    expectedReportName),
                 Times.Once);
         }
 
-        private ProviderApplicationsReportOrchestrator GetOrchestrator()
+        private ProviderApplicationsReportOrchestrator GetOrchestrator(IProviderVacancyClient client, string todayDate)
         {
             var timeProvider = new Mock<ITimeProvider>();
 
-            var today = DateTime.Parse("2019-03-05").ToUniversalTime();
+            var today = DateTimeOffset.Parse(todayDate).UtcDateTime;
             timeProvider.Setup(t => t.Today).Returns(today);
             timeProvider.Setup(t => t.NextDay).Returns(today.AddDays(1));
 
-            return new ProviderApplicationsReportOrchestrator(_client.Object, timeProvider.Object);
+            return new ProviderApplicationsReportOrchestrator(client, timeProvider.Object);
         }
     }
 }

--- a/src/QA/QA.Web/ViewModels/ReviewHistoryViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ReviewHistoryViewModel.cs
@@ -19,7 +19,7 @@ namespace Esfa.Recruit.Qa.Web.ViewModels
         public string Outcome { get; set; }
         public DateTime ReviewDate { get; set; }
 
-        public string ReviewDateDay => ReviewDate.ToLocalTime().AsGdsDate();
-        public string ReviewDateTime => ReviewDate.ToLocalTime().AsGdsTime();
+        public string ReviewDateDay => ReviewDate.ToUkTime().AsGdsDate();
+        public string ReviewDateTime => ReviewDate.ToUkTime().AsGdsTime();
     }
 }

--- a/src/QA/QA.Web/ViewModels/ReviewViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ReviewViewModel.cs
@@ -70,8 +70,8 @@ namespace Esfa.Recruit.Qa.Web.ViewModels
 
         public bool IsAnonymous => EmployerNameOption == EmployerNameOption.Anonymous;
         public bool IsApproved => ManualOutcome.GetValueOrDefault() == ManualQaOutcome.Approved;
-        public string ReviewedDateDay => ReviewedDate.ToLocalTime().AsGdsDate();
-        public string ReviewedDateTime => ReviewedDate.ToLocalTime().AsGdsTime();
+        public string ReviewedDateDay => ReviewedDate.ToUkTime().AsGdsDate();
+        public string ReviewedDateTime => ReviewedDate.ToUkTime().AsGdsTime();
         public bool IsFirstSubmission => IsResubmission == false;
         public bool HasChangedFields => FieldIdentifiers.Any(f => f.FieldValueHasChanged);
         public bool HasSpecifiedThroughFaaApplicationMethod => ApplicationMethod == ApplicationMethod.ThroughFindAnApprenticeship;
@@ -81,7 +81,7 @@ namespace Esfa.Recruit.Qa.Web.ViewModels
         public bool HasPreviouslySubmitted => VacancyReviewsApprovedCount > 0;
         public bool HasNotPreviouslySubmitted => HasPreviouslySubmitted == false;
         public bool HasOneAnonymousApproved => AnonymousApprovedCount == 1;
-        public string SubmittedDateTime => SubmittedDate.AsGdsDateTime();
+        public string SubmittedDateTime => SubmittedDate.ToUkTime().AsGdsDateTime();
         public bool IsNotDisabilityConfident => IsDisabilityConfident == false;
         public bool IsEmployerVacancy => OwnerType == OwnerType.Employer;
         public bool IsProviderVacancy => OwnerType == OwnerType.Provider;

--- a/src/QA/QA.Web/Views/Dashboard/Index.cshtml
+++ b/src/QA/QA.Web/Views/Dashboard/Index.cshtml
@@ -75,7 +75,7 @@
                     <td class="govuk-table__cell">@vacancy.EmployerName</td>
                     <td class="govuk-table__cell">@vacancy.VacancyTitle</td>
                     <td class="govuk-table__cell"><span>VAC</span>@vacancy.VacancyReference</td>
-                    <td class="govuk-table__cell">@vacancy.SubmittedDate.ToLocalTime().AsGdsDateTime()</td>
+                    <td class="govuk-table__cell">@vacancy.SubmittedDate.ToUkTime().AsGdsDateTime()</td>
                     <td class="govuk-table__cell">@vacancy.ClosingDate.AsGdsDate()</td>
                     <td class="govuk-table__cell">
                         @assignmentInfoCaption <br />
@@ -114,7 +114,7 @@
                     <td class="govuk-table__cell">@vacancy.EmployerName</td>
                     <td class="govuk-table__cell">@vacancy.VacancyTitle</td>
                     <td class="govuk-table__cell"><span>VAC</span>@vacancy.VacancyReference</td>
-                    <td class="govuk-table__cell">@vacancy.SubmittedDate.ToLocalTime().AsGdsDateTime()</td>
+                    <td class="govuk-table__cell">@vacancy.SubmittedDate.ToUkTime().AsGdsDateTime()</td>
                     <td class="govuk-table__cell">@vacancy.ClosingDate.AsGdsDate()</td>
                     <td class="govuk-table__cell">
                         <span asp-show="@vacancy.ShowAssignmentInfoCaption">@assignmentInfoCaption<br /></span>

--- a/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
+++ b/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
@@ -30,9 +30,9 @@ namespace Esfa.Recruit.Shared.Web.Extensions
             return postcode;
         }
 
-        public static DateTime? AsDateTimeUk(this string date, DateTimeStyles style = DateTimeStyles.AssumeUniversal)
+        public static DateTime? AsDateTimeUk(this string date)
         {
-            if(DateTime.TryParseExact(date, "d/M/yyyy", _ukCulture, style, out var d))
+            if(DateTime.TryParseExact(date, "d/M/yyyy", _ukCulture, DateTimeStyles.AssumeUniversal, out var d))
             {
                 return d;
             }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/DateTimeExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/DateTimeExtensions.cs
@@ -46,5 +46,11 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
 
             return $"{hours} {minutes}";
         }
+
+        public static DateTime ToUkTime(this DateTime datetime)
+        {
+            var ukTimezone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+            return TimeZoneInfo.ConvertTime(datetime, ukTimezone);
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services.Reports;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -92,7 +93,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
 
             var results = JArray.Parse(report.Data);
 
-            _csvBuilder.WriteCsvToStream(stream, results, report.RequestedOn.ToLocalTime(), reportStrategy.ResolveFormat);
+            _csvBuilder.WriteCsvToStream(stream, results, report.RequestedOn.ToUkTime(), reportStrategy.ResolveFormat);
         }
     }
 }


### PR DESCRIPTION
We have various places in the system where we display the time.  As we have been using `.ToLocalTime()` this works fine when developing locally as our machines are set to handle daylight savings.  However the Azure boxes are set to use UTC so are an hour out in the summer.

There are various ways of fixing this.  We could in config set the Azure services to run in GMT Standard Time and handle daylight savings, however this feels a bit of a sledge hammer to crack a nut and it makes sense to me that cloud services are not time zone aware.

As this is an England only service I don't think we need to be too clever regarding localisation of time 
so instead I've created an extension method `.ToUkTime()` which will explicitly set the time to `GMT Standard Time` (which handles daylight saving). 

So the rule is:

>  **Don't use `.ToLocalTime()` use `.ToUkTime()`**

Let me know your thoughts on this approach.  Thanks