### PR TITLE
ER-1294 - Employer landing page content

### DIFF
--- a/src/Employer/Employer.Web/Configuration/ExternalLinksConfiguration.cs
+++ b/src/Employer/Employer.Web/Configuration/ExternalLinksConfiguration.cs
@@ -5,6 +5,7 @@ namespace Esfa.Recruit.Employer.Web.Configuration
         public string ManageApprenticeshipSiteUrl { get; set; }
         public string EmployerIdamsSiteUrl { get; set; }
         public string FindAnApprenticeshipUrl { get; set; }
+        public string FindApprenticeshipTrainingUrl { get; set; }
         public string FindProviderUrl { get; set; }
         public string CommitmentsSiteUrl { get; set; }
     }

--- a/src/Employer/Employer.Web/ViewModels/DashboardViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/DashboardViewModel.cs
@@ -17,6 +17,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels
         public string ResultsHeading { get; internal set; }
         public FilteringOptions Filter { get; set; }
         public bool HasVacancies { get; internal set; }
+        
         public bool ShowResultsTable => Vacancies.Any();
         public bool IsFiltered => Filter != FilteringOptions.All;
     }

--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -25,7 +25,7 @@
     </div>
 </div>
 
-<partial name="_NoVacanciesContent" model="@Model" />
+<partial asp-hide="@Model.HasVacancies" name="_NoVacanciesContent" />
 
 <div asp-show="Model.HasVacancies">
     <div class="govuk-grid-row">

--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Esfa.Recruit.Vacancies.Client.Domain.Entities
-@using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections
 @model DashboardViewModel
 @{
     string GetLinkText(VacancySummaryViewModel vacancySummary)
@@ -20,138 +19,119 @@
         <div asp-show="Model.HasWarning" class="warning-summary govuk-!-margin-bottom-0">
             <p>@Model.WarningMessage</p>
         </div>
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Your vacancies</h1>
         <div asp-show="Model.HasInfo" class="info-summary govuk-!-margin-bottom-0">
             <p>@Model.InfoMessage</p>
         </div>
     </div>
 </div>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
 
-        <div asp-hide="Model.HasVacancies">
-            <esfaFeatureEnabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
-                <p class="govuk-body">
-                    You must be a levy-paying employer to post a vacancy.
-                </p>
-                <p class="govuk-body">
-                    You can clone vacancies once they've been submitted.
-                </p>
-                <p class="govuk-body">
-                    Vacancies will be approved or rejected within 24 hours.
-                </p>
-            </esfaFeatureEnabled>
+<partial name="_NoVacanciesContent" model="@Model" />
 
-            <esfaFeatureDisabled name="@FeatureNames.AllowLevyPayingEmployersOnly">
-                <p class="govuk-body">
-                    Your dashboard is empty, start by creating your first vacancy.
-                </p>
-                <p class="govuk-body">
-                    You can clone vacancies once they've been submitted.
-                </p>
-                <p class="govuk-body">
-                    Vacancies will be approved or rejected within 24 hours.
-                </p>
-            </esfaFeatureDisabled>
-        </div>
-
-        <a asp-route="@RouteNames.CreateVacancyOptions_Get" class="govuk-button govuk-!-margin-bottom-6" esfa-automation="create-vacancy">Create vacancy</a>
-    </div>
-</div>
-
-<div asp-hide="true" class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <form method="get">
-            <div class="govuk-form-group">
-                <label asp-for="Filter" class="govuk-label">Filter vacancies by</label>
-                <select asp-for="Filter" class="govuk-select">
-                    <optgroup label="Status">
-                        <option value="@FilteringOptions.All">all vacancies</option>
-                        <option value="@FilteringOptions.Live">live vacancies</option>
-                        <option value="@FilteringOptions.Referred">rejected vacancies</option>
-                        <option value="@FilteringOptions.Submitted">vacancies pending review</option>
-                        <option value="@FilteringOptions.Draft">draft vacancies</option>
-                        <option value="@FilteringOptions.Closed">closed vacancies</option>
-                    </optgroup>
-                    <optgroup label="Other">
-                        <option value="@FilteringOptions.NewApplications">with new applications</option>
-                        <option value="@FilteringOptions.AllApplications">with applications</option>
-                        <option value="@FilteringOptions.ClosingSoonWithNoApplications">closing soon with no applications</option>
-                        <option value="@FilteringOptions.ClosingSoon">closing soon</option>
-                    </optgroup>
-                </select>
-                <button type="submit" id="filter-submit" class="das-button-filter das-button-secondary govuk-button govuk-!-margin-top-3">Filter</button>
-            </div>
-        </form>
-    </div>
-</div>
-<div asp-show="@Model.HasVacancies" class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <h3 class="govuk-heading-m">
-            @Model.ResultsHeading <a asp-show="@Model.IsFiltered" asp-route="@RouteNames.Dashboard_Index_Get" asp-route-filter="All" class="govuk-!-font-weight-regular govuk-component__link govuk-!-font-size-19">Show all vacancies</a>
-        </h3>
-        <p asp-hide="@Model.ShowResultsTable" class="govuk-body">No vacancies match the criteria</p>
-    </div>
-</div>
-<div asp-show="@Model.ShowResultsTable">
+<div asp-show="Model.HasVacancies">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <table class="govuk-table responsive das-table--small">
-                <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th class="govuk-table__header">Vacancy title</th>
-                    <th class="govuk-table__header">Vacancy ref</th>
-                    <th class="govuk-table__header">Applications</th>
-                    <th class="govuk-table__header">Closing</th>
-                    <th class="govuk-table__header">Status</th>
-                    <th class="govuk-table__header"></th>
-                </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                @foreach (var vacancy in Model.Vacancies)
-                {
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" data-label="Vacancy title">
-                            <div>@vacancy.Title</div>
-                        </td>
-                        <td class="govuk-table__cell" data-label="Vacancy ref">
-                            <span asp-show="@vacancy.HasVacancyReference"><span>VAC</span>@vacancy.VacancyReference</span>
-                            <span asp-show="@vacancy.HasNoVacancyReference">Not available</span>
-                        </td>
-                        <td asp-show="@vacancy.CanShowVacancyApplicationsCount" class="govuk-table__cell dashboard-applications" data-label="Applications">
-                            <span asp-show="@vacancy.HasNoApplications">0</span>
-                            <span asp-show="@vacancy.HasApplications">@vacancy.NoOfApplications</span>
-                            <span asp-show="@vacancy.HasNewApplications" class="govuk-!-font-weight-bold"> (@vacancy.NoOfNewApplications new)</span>
-                        </td>
-                        <td asp-hide="@vacancy.CanShowVacancyApplicationsCount" class="govuk-table__cell dashboard-applications" data-label="Applications">-</td>
-                        <td class="govuk-table__cell dashboard-closingdate" data-label="Closing date"><span>@vacancy.ClosingDate?.AsGdsDate()</span></td>    
-                        <td class="govuk-table__cell dashboard-status" data-label="Status"><span class="tag tag-@vacancy.Status.ToString().ToLower()">@vacancy.Status.GetDisplayName()</span></td>
-                        <td class="govuk-table__cell dashboard-action" data-label="Action">
-                            <a asp-show="@vacancy.IsNotSubmittable" asp-route="@RouteNames.VacancyManage_Get" asp-route-vacancyId="@vacancy.Id" class="govuk-link">Manage</a>
-                            <a asp-show="@vacancy.IsSubmittable" asp-route="@RouteNames.DisplayVacancy_Get" asp-route-vacancyId="@vacancy.Id" class="govuk-link">@GetLinkText(vacancy)</a>
-                        </td>
-                    </tr>
-                }
-                </tbody>
-            </table>
 
-            <partial name="@PartialNames.Pager" model="@Model.Pager" />
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Your vacancies</h1>
+
+            <a asp-route="@RouteNames.CreateVacancyOptions_Get" class="govuk-button govuk-!-margin-bottom-6" esfa-automation="create-vacancy">Create vacancy</a>
+        </div>
+    </div>
+
+    <div asp-hide="true" class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form method="get">
+                <div class="govuk-form-group">
+                    <label asp-for="Filter" class="govuk-label">Filter vacancies by</label>
+                    <select asp-for="Filter" class="govuk-select">
+                        <optgroup label="Status">
+                            <option value="@FilteringOptions.All">all vacancies</option>
+                            <option value="@FilteringOptions.Live">live vacancies</option>
+                            <option value="@FilteringOptions.Referred">rejected vacancies</option>
+                            <option value="@FilteringOptions.Submitted">vacancies pending review</option>
+                            <option value="@FilteringOptions.Draft">draft vacancies</option>
+                            <option value="@FilteringOptions.Closed">closed vacancies</option>
+                        </optgroup>
+                        <optgroup label="Other">
+                            <option value="@FilteringOptions.NewApplications">with new applications</option>
+                            <option value="@FilteringOptions.AllApplications">with applications</option>
+                            <option value="@FilteringOptions.ClosingSoonWithNoApplications">closing soon with no applications</option>
+                            <option value="@FilteringOptions.ClosingSoon">closing soon</option>
+                        </optgroup>
+                    </select>
+                    <button type="submit" id="filter-submit" class="das-button-filter das-button-secondary govuk-button govuk-!-margin-top-3">Filter</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div asp-show="@Model.HasVacancies" class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h3 class="govuk-heading-m">
+                @Model.ResultsHeading <a asp-show="@Model.IsFiltered" asp-route="@RouteNames.Dashboard_Index_Get" asp-route-filter="All" class="govuk-!-font-weight-regular govuk-component__link govuk-!-font-size-19">Show all vacancies</a>
+            </h3>
+            <p asp-hide="@Model.ShowResultsTable" class="govuk-body">No vacancies match the criteria</p>
+        </div>
+    </div>
+    <div asp-show="@Model.ShowResultsTable">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <table class="govuk-table responsive das-table--small">
+                    <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">Vacancy title</th>
+                        <th class="govuk-table__header">Vacancy ref</th>
+                        <th class="govuk-table__header">Applications</th>
+                        <th class="govuk-table__header">Closing</th>
+                        <th class="govuk-table__header">Status</th>
+                        <th class="govuk-table__header"></th>
+                    </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                    @foreach (var vacancy in Model.Vacancies)
+                    {
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell" data-label="Vacancy title">
+                                <div>@vacancy.Title</div>
+                            </td>
+                            <td class="govuk-table__cell" data-label="Vacancy ref">
+                                <span asp-show="@vacancy.HasVacancyReference"><span>VAC</span>@vacancy.VacancyReference</span>
+                                <span asp-show="@vacancy.HasNoVacancyReference">Not available</span>
+                            </td>
+                            <td asp-show="@vacancy.CanShowVacancyApplicationsCount" class="govuk-table__cell dashboard-applications" data-label="Applications">
+                                <span asp-show="@vacancy.HasNoApplications">0</span>
+                                <span asp-show="@vacancy.HasApplications">@vacancy.NoOfApplications</span>
+                                <span asp-show="@vacancy.HasNewApplications" class="govuk-!-font-weight-bold"> (@vacancy.NoOfNewApplications new)</span>
+                            </td>
+                            <td asp-hide="@vacancy.CanShowVacancyApplicationsCount" class="govuk-table__cell dashboard-applications" data-label="Applications">-</td>
+                            <td class="govuk-table__cell dashboard-closingdate" data-label="Closing date"><span>@vacancy.ClosingDate?.AsGdsDate()</span></td>
+                            <td class="govuk-table__cell dashboard-status" data-label="Status"><span class="tag tag-@vacancy.Status.ToString().ToLower()">@vacancy.Status.GetDisplayName()</span></td>
+                            <td class="govuk-table__cell dashboard-action" data-label="Action">
+                                <a asp-show="@vacancy.IsNotSubmittable" asp-route="@RouteNames.VacancyManage_Get" asp-route-vacancyId="@vacancy.Id" class="govuk-link">Manage</a>
+                                <a asp-show="@vacancy.IsSubmittable" asp-route="@RouteNames.DisplayVacancy_Get" asp-route-vacancyId="@vacancy.Id" class="govuk-link">@GetLinkText(vacancy)</a>
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+                <partial name="@PartialNames.Pager" model="@Model.Pager"/>
+            </div>
         </div>
     </div>
 </div>
+
 @section FooterJS
 {
-    <script nws-csp-add-nonce="true">
-        var filterId = "#@Html.IdFor(m => m.Filter)";
-        $(function() {
-            $("#filter-submit").hide();
+<script nws-csp-add-nonce="true">
+    var filterId = "#@Html.IdFor(m => m.Filter)";
+    $(function() {
+        $("#filter-submit").hide();
 
-            $(filterId).on("change",
-                function() {
-                    var $filterForm = $(this).parents("form");
-                    $filterForm.areYouSure({ 'silent': true });
-                    $filterForm.submit();
-                });
-        });
-    </script>
+        $(filterId).on("change",
+            function() {
+                var $filterForm = $(this).parents("form");
+                $filterForm.areYouSure({ 'silent': true });
+                $filterForm.submit();
+            });
+    });
+</script>
 }

--- a/src/Employer/Employer.Web/Views/Dashboard/_NoVacanciesContent.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/_NoVacanciesContent.cshtml
@@ -1,8 +1,7 @@
 ﻿@using Microsoft.Extensions.Options
 @inject IOptions<ExternalLinksConfiguration> _externalLinks
-@model DashboardViewModel
 
-<div asp-hide="Model.HasVacancies" class="govuk-grid-row">
+<div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Recruitment</h1>
         <p class="govuk-body-l">

--- a/src/Employer/Employer.Web/Views/Dashboard/_NoVacanciesContent.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/_NoVacanciesContent.cshtml
@@ -1,0 +1,36 @@
+﻿@using Microsoft.Extensions.Options
+@inject IOptions<ExternalLinksConfiguration> _externalLinks
+@model DashboardViewModel
+
+<div asp-hide="Model.HasVacancies" class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Recruitment</h1>
+        <p class="govuk-body-l">
+            Recruit an apprentice by creating a vacancy. Vacancies will be advertised on
+            <a href="@_externalLinks.Value.FindAnApprenticeshipUrl">Find an apprenticeship</a>.
+        </p>
+        <h2 class="govuk-heading-m">What you will need</h2>
+        <p class="govuk-body">
+            Before you create your vacancy, you’ll need to choose appropriate
+            <a href="@_externalLinks.Value.FindApprenticeshipTrainingUrl">apprenticeship training</a> and get some information from your training provider. If you don’t have a training provider yet, you can
+            <a href="@_externalLinks.Value.FindProviderUrl">find a provider</a>
+        </p>
+        <p class="govuk-body">You’ll need the following: </p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>
+                The name of the apprenticeship training
+            </li>
+            <li>
+                The training provider ID (UKPRN)
+            </li>
+            <li>The duration of the apprenticeship</li>
+            <li>
+                The amount of hours spent working and training
+            </li>
+            <li>The amount you’d like to pay your apprentice</li>
+        </ul>
+        <div class="govuk-inset-text">It should take no longer than 30 minutes to create your first vacancy</div>
+
+        <a asp-route="@RouteNames.CreateVacancyOptions_Get" role="button" class="govuk-button govuk-button--start" esfa-automation="create-vacancy">Start now</a>
+    </div>
+</div>

--- a/src/Employer/Employer.Web/appsettings.json
+++ b/src/Employer/Employer.Web/appsettings.json
@@ -35,6 +35,7 @@
     "ManageApprenticeshipSiteUrl": "https://manage-apprenticeships.service.gov.uk/",
     "EmployerIdamsSiteUrl": "https://beta-login.apprenticeships.education.gov.uk",
     "FindAnApprenticeshipUrl": "https://www.gov.uk/apply-apprenticeship",
+    "FindApprenticeshipTrainingUrl": "https://findapprenticeshiptraining.apprenticeships.education.gov.uk",
     "FindProviderUrl": "https://findapprenticeshiptraining.apprenticeships.education.gov.uk/provider/search",
     "CommitmentsSiteUrl": "https://manage-apprenticeships.service.gov.uk/"
   },


### PR DESCRIPTION
We now display quite a lot of content on the landing page when an employer has no vacancies. So I've moved this content into a partial

We now want to display the same content on DEMO and PROD so I have removed the Employer Levy feature toggle (That was short lived!)

We now display links to FAT for searching for training and providers.  I've added these url to appsettings.json