### PR TITLE
ER-919 - Provider RoATP check

### DIFF
--- a/src/Employer/Employer.Web/Controllers/Part1/TrainingProviderController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TrainingProviderController.cs
@@ -2,6 +2,7 @@
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
+using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.TrainingProvider;

--- a/src/Employer/Employer.Web/Models/PostSelectTrainingProviderResult.cs
+++ b/src/Employer/Employer.Web/Models/PostSelectTrainingProviderResult.cs
@@ -1,0 +1,16 @@
+﻿namespace Esfa.Recruit.Employer.Web.Models
+{
+    public enum SelectTrainingProviderResponseType
+    {
+        NotFound,
+        Continue,
+        Confirm
+    }
+
+    public class PostSelectTrainingProviderResult
+    {
+        public long? FoundProviderUkprn { get; set; }
+
+        public SelectTrainingProviderResponseType ResponseType { get; set; }
+    }
+}

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/Part1/TrainingProviderOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/Part1/TrainingProviderOrchestratorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.TrainingProvider;
 using Esfa.Recruit.Shared.Web.Services;
@@ -166,29 +167,16 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
 
             var mockRecruitClient = new Mock<IRecruitVacancyClient>();
             mockRecruitClient.Setup(c => c.GetVacancyAsync(VacancyId)).ReturnsAsync(vacancy);
+            mockRecruitClient.Setup(c => c.GetAllTrainingProvidersAsync()).ReturnsAsync(new List<TrainingProviderSummary>
+            {
+                new TrainingProviderSummary{ProviderName = "MR EGG",Ukprn = 88888888},
+                new TrainingProviderSummary{ProviderName = "MRS EGG",Ukprn = 88888889}
+            });
 
             var mockLog = new Mock<ILogger<TrainingProviderOrchestrator>>();
             var mockReview = new Mock<IReviewSummaryService>();
 
-            var mockCache = new Mock<ICache>();
-            Func<Task<IEnumerable<TrainingProviderSuggestion>>> cacheFunc = () =>
-            {
-                var providers = new List<TrainingProviderSuggestion>
-                {
-                    new TrainingProviderSuggestion{ProviderName = "MR EGG",Ukprn = 88888888},
-                    new TrainingProviderSuggestion{ProviderName = "MRS EGG",Ukprn = 88888889}
-                };
-                return Task.FromResult(providers.AsEnumerable());
-            };
-            mockCache.Setup(c => c.CacheAsideAsync(CacheKeys.TrainingProviders, It.IsAny<DateTime>(), It.IsAny<Func<Task<IEnumerable<TrainingProviderSuggestion>>>>()))
-                .Returns(Task.FromResult(new List<TrainingProviderSuggestion>
-                {
-                    new TrainingProviderSuggestion{ProviderName = "MR EGG",Ukprn = 88888888},
-                    new TrainingProviderSuggestion{ProviderName = "MRS EGG",Ukprn = 88888889}
-                }.AsEnumerable()));
-            var timeProvider = new CurrentUtcTimeProvider();
-
-            return new TrainingProviderOrchestrator(mockClient.Object, mockRecruitClient.Object, mockLog.Object, mockReview.Object, mockCache.Object, timeProvider);
+            return new TrainingProviderOrchestrator(mockClient.Object, mockRecruitClient.Object, mockLog.Object, mockReview.Object);
         }
     }
 }

--- a/src/Provider/Provider.Web/Controllers/ErrorController.cs
+++ b/src/Provider/Provider.Web/Controllers/ErrorController.cs
@@ -10,6 +10,7 @@ using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels;
 using Esfa.Recruit.Provider.Web.ViewModels.Error;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
@@ -25,13 +26,13 @@ namespace Esfa.Recruit.Provider.Web.Controllers
     {
         private readonly ILogger<ErrorController> _logger;
         private readonly ExternalLinksConfiguration _externalLinks;
-        private readonly IProviderApiClient _roatpClient;
+        private readonly IRecruitVacancyClient _vacancyClient;
 
-        public ErrorController(ILogger<ErrorController> logger, IOptions<ExternalLinksConfiguration> externalLinks, IProviderApiClient roatpClient)
+        public ErrorController(ILogger<ErrorController> logger, IOptions<ExternalLinksConfiguration> externalLinks, IRecruitVacancyClient vacancyClient)
         {
             _logger = logger;
             _externalLinks = externalLinks.Value;
-            _roatpClient = roatpClient;
+            _vacancyClient = vacancyClient;
         }
 
         [Route("error/{id?}")]
@@ -151,7 +152,8 @@ namespace Esfa.Recruit.Provider.Web.Controllers
                 bool ukprnIsNotListedInRoatp;
                 try
                 {
-                    var provider = _roatpClient.Get(ukprn);
+                    var allProviders = _vacancyClient.GetAllTrainingProvidersAsync().Result;
+                    var provider = allProviders.SingleOrDefault(p => p.Ukprn == ukprn);
                     ukprnIsNotListedInRoatp = provider == null;
                 }
                 catch (Exception)

--- a/src/Provider/Provider.Web/Middleware/ProviderAccountHandler.cs
+++ b/src/Provider/Provider.Web/Middleware/ProviderAccountHandler.cs
@@ -4,12 +4,11 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
-using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Configuration;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Filters;
-using SFA.DAS.Providers.Api.Client;
 
 namespace Esfa.Recruit.Provider.Web.Middleware
 {
@@ -95,8 +94,15 @@ namespace Esfa.Recruit.Provider.Web.Middleware
             try
             {
                 var ukprnFromClaim = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
+
+                if (long.TryParse(ukprnFromClaim, out var ukprn) == false)
+                    return false;
+
+                if (ukprn == EsfaTestTrainingProvider.Ukprn)
+                    return true;
+
                 var allProviders = await _vacancyClient.GetAllTrainingProvidersAsync();
-                var provider = allProviders.SingleOrDefault(p => p.Ukprn == long.Parse(ukprnFromClaim));
+                var provider = allProviders.SingleOrDefault(p => p.Ukprn == ukprn);
                 return provider != null;
             }
             catch (Exception)

--- a/src/Provider/Provider.Web/Middleware/ProviderAccountHandler.cs
+++ b/src/Provider/Provider.Web/Middleware/ProviderAccountHandler.cs
@@ -4,12 +4,11 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
-using Esfa.Recruit.Provider.Web.Extensions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
+using SFA.DAS.Providers.Api.Client;
 
 namespace Esfa.Recruit.Provider.Web.Middleware
 {
@@ -17,24 +16,33 @@ namespace Esfa.Recruit.Provider.Web.Middleware
     {
         private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IProviderVacancyClient _client;
+        private readonly IProviderApiClient _roatpClient;
 
-        public ProviderAccountHandler(IHostingEnvironment hostingEnvironment, IProviderVacancyClient client)
+        private readonly Predicate<Claim> _ukprnClaimFinderPredicate = c => c.Type.Equals(ProviderRecruitClaims.IdamsUserUkprnClaimsTypeIdentifier);
+
+        public ProviderAccountHandler(IHostingEnvironment hostingEnvironment, IProviderVacancyClient client, IProviderApiClient roatpClient)
         {
             _hostingEnvironment = hostingEnvironment;
             _client = client;
+            _roatpClient = roatpClient;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, ProviderAccountRequirement requirement)
         {
-            var authorized = false;
-
-            if (HasServiceAuthorization(context))
-            {
-                authorized = await HasUkprnAuthorizationAsync(context);
-            }
+            var authorized = HasServiceAuthorization(context) &&
+                             HasUkprnAuthorization(context) &&
+                             HasRoatpAuthorization(context);
 
             if (authorized)
             {
+                if (HasDoneOncePerAuthorizedSessionActions(context) == false)
+                {
+                    //Run actions that must be done only once per authorized session
+                    await SetupProvider(context);
+
+                    SetOncePerAuthorizedSessionActionsCompleted(context);
+                }
+                
                 context.Succeed(requirement);
             }
         }
@@ -53,22 +61,18 @@ namespace Esfa.Recruit.Provider.Web.Middleware
             return false;
         }
 
-        private async Task<bool> HasUkprnAuthorizationAsync(AuthorizationHandlerContext context)
+        private bool HasUkprnAuthorization(AuthorizationHandlerContext context)
         {
-            Predicate<Claim> ukprnClaimFinderPredicate = c => c.Type.Equals(ProviderRecruitClaims.IdamsUserUkprnClaimsTypeIdentifier);
-
             if (context.Resource is AuthorizationFilterContext mvcContext && mvcContext.RouteData.Values.ContainsKey(RouteValues.Ukprn))
             {
-                if (context.User.HasClaim(ukprnClaimFinderPredicate))
+                if (context.User.HasClaim(_ukprnClaimFinderPredicate))
                 {
-                    var ukprnFromClaim = context.User.FindFirst(ukprnClaimFinderPredicate).Value;
+                    var ukprnFromClaim = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
                     var ukprnFromUrl = mvcContext.RouteData.Values[RouteValues.Ukprn].ToString();
 
                     if (!string.IsNullOrEmpty(ukprnFromUrl) && ukprnFromUrl.Equals(ukprnFromClaim))
                     {
                         mvcContext.HttpContext.Items.Add(ContextItemKeys.ProviderIdentifier, ukprnFromClaim);
-
-                        await EnsureProviderIsSetup(mvcContext.HttpContext, long.Parse(ukprnFromClaim));
 
                         return true;
                     }
@@ -81,16 +85,62 @@ namespace Esfa.Recruit.Provider.Web.Middleware
 
             return false;
         }
-        
-        private async Task EnsureProviderIsSetup(HttpContext context, long ukprn)
-        {
-            var key = string.Format(CookieNames.SetupProvider, ukprn);
 
-            if (context.Request.Cookies[key] == null)
+        private bool HasRoatpAuthorization(AuthorizationHandlerContext context)
+        {
+            if (HasDoneOncePerAuthorizedSessionActions(context))
+                return true;
+
+            try
             {
-                await _client.SetupProviderAsync(ukprn);
-                context.Response.Cookies.Append(key, "1", EsfaCookieOptions.GetDefaultHttpCookieOption(_hostingEnvironment));
+                var ukprnFromClaim = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
+                var provider = _roatpClient.Get(ukprnFromClaim);
+                return provider != null;
             }
+            catch (Exception)
+            {
+                return false;
+            } 
+        }
+        
+        private async Task SetupProvider(AuthorizationHandlerContext context)
+        {
+            if (context.Resource is AuthorizationFilterContext mvcContext && 
+                mvcContext.RouteData.Values.ContainsKey(RouteValues.Ukprn))
+            {
+                var ukprn = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
+
+                await _client.SetupProviderAsync(long.Parse(ukprn));
+            }
+        }
+
+        private bool HasDoneOncePerAuthorizedSessionActions(AuthorizationHandlerContext context)
+        {
+            if (!(context.Resource is AuthorizationFilterContext mvcContext))
+                return false;
+
+            var ukprn = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
+
+            var cookieKey = GetOncePerAuthorizedSessionCookieKey(ukprn);
+            var cookie = mvcContext.HttpContext.Request.Cookies[cookieKey];
+
+            return cookie != null;
+        }
+
+        private void SetOncePerAuthorizedSessionActionsCompleted(AuthorizationHandlerContext context)
+        {
+            if (!(context.Resource is AuthorizationFilterContext mvcContext))
+                return;
+
+            var ukprn = context.User.FindFirst(_ukprnClaimFinderPredicate).Value;
+            var cookieKey = GetOncePerAuthorizedSessionCookieKey(ukprn);
+
+            mvcContext.HttpContext.Response.Cookies.Append(cookieKey, "1", EsfaCookieOptions.GetDefaultHttpCookieOption(_hostingEnvironment));
+        }
+
+        private string GetOncePerAuthorizedSessionCookieKey(string ukprn)
+        {
+            return string.Format(CookieNames.SetupProvider, ukprn);
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
@@ -1,8 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Configuration;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using MediatR;
@@ -13,32 +13,15 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
     public class PatchVacancyTrainingProviderCommandHandler : IRequestHandler<PatchVacancyTrainingProviderCommand>
     {
         private readonly IVacancyRepository _repository;
-        private readonly IMessaging _messaging;
         private readonly ILogger<PatchVacancyTrainingProviderCommandHandler> _logger;
         private readonly ITrainingProviderService _trainingProviderService;
-
-        private readonly TrainingProvider _esfaTrainingProvider = new TrainingProvider
-        {
-            Ukprn = 10033670,
-            Name = "Education Skills Funding Agency",
-            Address = new Address
-            {
-                AddressLine1 = "Cheylesmore House",
-                AddressLine2 = "Quinton Road",
-                AddressLine3 = "Coventry",
-                AddressLine4 = "",
-                Postcode = "CV1 2WT"
-            }
-        };
 
         public PatchVacancyTrainingProviderCommandHandler(
             ILogger<PatchVacancyTrainingProviderCommandHandler> logger,
             IVacancyRepository repository,
-            IMessaging messaging,
             ITrainingProviderService trainingProviderService)
         {
             _repository = repository;
-            _messaging = messaging;
             _logger = logger;
             _trainingProviderService = trainingProviderService;
         }
@@ -63,9 +46,9 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
             TrainingProvider tp;
 
-            if (vacancy.TrainingProvider.Ukprn.Value.Equals(_esfaTrainingProvider.Ukprn))
+            if (vacancy.TrainingProvider.Ukprn.Value.Equals(EsfaTestTrainingProvider.Ukprn))
             {
-                tp = _esfaTrainingProvider;
+                tp = GetEsfaTestTrainingProvider();
             }
             else
             {
@@ -84,6 +67,23 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
         {
             vacancy.TrainingProvider.Name = tp.Name;
             vacancy.TrainingProvider.Address = tp.Address;
+        }
+
+        private TrainingProvider GetEsfaTestTrainingProvider()
+        {
+            return new TrainingProvider
+            {
+                Ukprn = EsfaTestTrainingProvider.Ukprn,
+                Name = EsfaTestTrainingProvider.Name,
+                Address = new Address
+                {
+                    AddressLine1 = EsfaTestTrainingProvider.AddressLine1,
+                    AddressLine2 = EsfaTestTrainingProvider.AddressLine2,
+                    AddressLine3 = EsfaTestTrainingProvider.AddressLine3,
+                    AddressLine4 = EsfaTestTrainingProvider.AddressLine4,
+                    Postcode = EsfaTestTrainingProvider.Postcode
+                }
+            };
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Configuration/EsfaTestTrainingProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Configuration/EsfaTestTrainingProvider.cs
@@ -1,0 +1,13 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Application.Configuration
+{
+    public static class EsfaTestTrainingProvider
+    {
+        public const long Ukprn = 10033670;
+        public const string Name = "Education Skills Funding Agency";
+        public const string AddressLine1 = "Cheylesmore House";
+        public const string AddressLine2 = "Quinton Road";
+        public const string AddressLine3 = "Coventry";
+        public const string AddressLine4 = "";
+        public const string Postcode = "CV1 2WT";
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Providers/ITrainingProviderSummaryProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Providers/ITrainingProviderSummaryProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Providers
+{
+    public interface ITrainingProviderSummaryProvider
+    {
+        Task<IEnumerable<TrainingProviderSummary>> FindAllAsync();
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TrainingProviderSummary.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TrainingProviderSummary.cs
@@ -1,0 +1,8 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+{
+    public class TrainingProviderSummary
+    {
+        public string ProviderName { get; set; }
+        public long Ukprn { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -25,6 +25,5 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<User> GetUsersDetailsAsync(string userId);
         Task SaveLevyDeclarationAsync(string userId, string employerAccountId);
         Task<TrainingProvider> GetTrainingProviderAsync(long ukprn);
-        Task<IEnumerable<TrainingProviderSuggestion>> GetAllTrainingProviders();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
@@ -28,7 +28,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<string> GetEmployerDescriptionAsync(Vacancy vacancy);
         Task<EmployerProfile> GetEmployerProfileAsync(string employerAccountId, long legalEntityId);
         Task UpdateEmployerProfileAsync(EmployerProfile employerProfile, VacancyUser user);
-
+        Task<IEnumerable<TrainingProviderSummary>> GetAllTrainingProvidersAsync();
         Task<VacancyAnalyticsSummary> GetVacancyAnalyticsSummaryAsync(long vacancyReference);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -41,6 +41,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         private readonly IEmployerService _employerService;
         private readonly IReportRepository _reportRepository;
         private readonly IReportService _reportService;
+        private readonly ITrainingProviderSummaryProvider _trainingProviderSummaryProvider;
 
         public VacancyClient(
             IVacancyRepository repository,
@@ -61,7 +62,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             ITrainingProviderService trainingProviderService,
             IEmployerService employerService,
             IReportRepository reportRepository,
-            IReportService reportService)
+            IReportService reportService,
+            ITrainingProviderSummaryProvider trainingProviderSummaryProvider)
         {
             _repository = repository;
             _reader = reader;
@@ -82,6 +84,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             _employerService = employerService;
             _reportRepository = reportRepository;
             _reportService = reportService;
+            _trainingProviderSummaryProvider = trainingProviderSummaryProvider;
         }
 
         public Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user)
@@ -450,9 +453,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _trainingProviderService.GetProviderAsync(ukprn);
         }
 
-        public Task<IEnumerable<TrainingProviderSuggestion>> GetAllTrainingProviders()
+        public Task<IEnumerable<TrainingProviderSummary>> GetAllTrainingProvidersAsync()
         {
-            return _trainingProviderService.FindAllAsync();
+            return _trainingProviderSummaryProvider.FindAllAsync();
         }
 
         public Task<VacancyAnalyticsSummary> GetVacancyAnalyticsSummaryAsync(long vacancyReference)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
 {
     public interface ITrainingProviderService
     {
         Task<Domain.Entities.TrainingProvider> GetProviderAsync(long ukprn);
-        Task<IEnumerable<TrainingProviderSuggestion>> FindAllAsync();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using System.Threading.Tasks;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
 {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
@@ -2,8 +2,6 @@
 using SFA.DAS.Apprenticeships.Api.Types.Providers;
 using SFA.DAS.Providers.Api.Client;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
@@ -35,17 +33,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
             }
 
             return TrainingProviderMapper.MapFromApiProvider(provider);
-        }
-
-        public async Task<IEnumerable<TrainingProviderSuggestion>> FindAllAsync()
-        {
-            var response = await _providerClient.FindAllAsync();
-
-            return response.Select(r => new TrainingProviderSuggestion
-            {
-                Ukprn = r.Ukprn,
-                ProviderName = r.ProviderName
-            });
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderSuggestion.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderSuggestion.cs
@@ -1,8 +1,0 @@
-﻿namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
-{
-    public class TrainingProviderSuggestion
-    {
-        public string ProviderName { get; set; }
-        public long Ukprn { get; set; }
-    }
-}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Cache;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Providers.Api.Client;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProviderSummaryProvider
+{
+    public class TrainingProviderSummaryProvider : ITrainingProviderSummaryProvider
+    {
+        private readonly ILogger<TrainingProviderSummaryProvider> _logger;
+        private readonly IProviderApiClient _providerClient;
+        private readonly ICache _cache;
+        private readonly ITimeProvider _timeProvider;
+
+
+        public TrainingProviderSummaryProvider(ILogger<TrainingProviderSummaryProvider> logger, IProviderApiClient providerClient, ICache cache, ITimeProvider timeProvider)
+        {
+            _logger = logger;
+            _providerClient = providerClient;
+            _cache = cache;
+            _timeProvider = timeProvider;
+        }
+
+        public Task<IEnumerable<TrainingProviderSummary>> FindAllAsync()
+        {
+            return _cache.CacheAsideAsync(
+                CacheKeys.TrainingProviders,
+                _timeProvider.NextDay6am,
+                FindAllAsyncInternal);
+        }
+
+        private async Task<IEnumerable<TrainingProviderSummary>> FindAllAsyncInternal()
+        {
+            var response = await _providerClient.FindAllAsync();
+
+            return response.Select(r => new TrainingProviderSummary
+            {
+                Ukprn = r.Ukprn,
+                ProviderName = r.ProviderName
+            });
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
@@ -30,10 +30,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
             return _cache.CacheAsideAsync(
                 CacheKeys.TrainingProviders,
                 _timeProvider.NextDay6am,
-                FindAllAsyncInternal);
+                FindAllInternalAsync);
         }
 
-        private async Task<IEnumerable<TrainingProviderSummary>> FindAllAsyncInternal()
+        private async Task<IEnumerable<TrainingProviderSummary>> FindAllInternalAsync()
         {
             var response = await _providerClient.FindAllAsync();
 

--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Geocode;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Projections;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProviderSummaryProvider;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummariesProvider;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Slack;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
@@ -144,6 +145,8 @@ namespace Esfa.Recruit.Vacancies.Client.Ioc
             services.AddTransient<ISlackClient, SlackClient>();
             services.AddTransient<IGeocodeServiceFactory, GeocodeServiceFactory>();
             services.AddTransient<IGetVacancyTitlesProvider, VacancyApiTitlesProvider>();
+            services.AddTransient<ITrainingProviderService, TrainingProviderService>();
+            services.AddTransient<ITrainingProviderSummaryProvider, TrainingProviderSummaryProvider>();
 
             // Projection services
             services.AddTransient<IEmployerDashboardProjectionService, EmployerDashboardProjectionService>();
@@ -161,7 +164,6 @@ namespace Esfa.Recruit.Vacancies.Client.Ioc
             services.AddTransient<IProfanityListProvider, ProfanityListProvider>();
             services.AddTransient<IBannedPhrasesProvider, BannedPhrasesProvider>();
             services.AddTransient<IBlockedEmployersProvider, BlockedEmployersProvider>();
-            services.AddTransient<ITrainingProviderService, TrainingProviderService>();
 
             // Query Data Providers
             services.AddTransient<IVacancySummariesProvider, VacancySummariesProvider>();

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandlerTests.cs
@@ -38,7 +38,6 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
             _handler = new PatchVacancyTrainingProviderCommandHandler(
                 Mock.Of<ILogger<PatchVacancyTrainingProviderCommandHandler>>(),
                 _mockRepository.Object,
-                Mock.Of<IMessaging>(),
                 _mockTrainingProvider.Object
             );
         }


### PR DESCRIPTION
Whenever a user accesses Provider.Web we need to check that the Provider is listed on RoATP.

This check is done in `ProviderAccountHandler` which is called on every page request. To prevent this triggering a call to the FAT API on every request I'm using the existing SetupProvider cookie to determine if this check has been done already in the session.

Assumption: All we need to do to check if a provider is in RoATP is to try and get the provider from from the FAT Api and if the provider does not exist then this means they are not in RoATP.  Is this correct?  This is how PAS does it.
