### PR TITLE
ER-1343 Persisting wizard from legal entities selection results pages

### DIFF
--- a/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/EmployerController.cs
@@ -4,7 +4,6 @@ using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.Employer;
 using Microsoft.AspNetCore.Mvc;
-using Esfa.Recruit.Shared.Web.Mappers;
 using Microsoft.AspNetCore.Hosting;
 using Esfa.Recruit.Employer.Web.ViewModels;
 
@@ -42,6 +41,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
                 return RedirectToRoute(RouteNames.EmployerName_Get, new {Wizard = wizard});
             }
 
+            vm.Pager.OtherRouteValues.Add(nameof(wizard), wizard);
             vm.PageInfo.SetWizard(wizard);
             return View(vm);
         }
@@ -50,7 +50,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         public async Task<IActionResult> Employer(EmployerEditModel m, [FromQuery] bool wizard)
         {
             var info = GetVacancyEmployerInfoCookie(m.VacancyId);
-            if(info == null)
+            if (info == null)
             {
                 //something went wrong, the matching cookie was not found
                 //Redirect the user with validation error to allow them to continue
@@ -62,11 +62,12 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
             {
                 var vm = await _orchestrator.GetEmployerViewModelAsync(m, m.SearchTerm, m.Page, info?.LegalEntityId);
                 SetVacancyEmployerInfoCookie(vm.VacancyEmployerInfoModel);
+                vm.Pager.OtherRouteValues.Add(nameof(wizard), wizard.ToString());
                 vm.PageInfo.SetWizard(wizard);
                 return View(vm);
             }
 
-            if(info.LegalEntityId != m.SelectedOrganisationId)
+            if (info.LegalEntityId != m.SelectedOrganisationId)
             {
                 info.LegalEntityId = m.SelectedOrganisationId;
                 info.HasLegalEntityChanged = true;

--- a/src/Provider/Provider.Web/Controllers/Part1/LegalEntityController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/LegalEntityController.cs
@@ -42,6 +42,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
                 return RedirectToRoute(RouteNames.EmployerName_Get, new {Wizard = wizard});
             }
 
+            vm.Pager.OtherRouteValues.Add(nameof(wizard), wizard);
             vm.PageInfo.SetWizard(wizard);
             return View(vm);
         }
@@ -62,6 +63,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
             {
                 var vm = await _orchestrator.GetLegalEntityViewModelAsync(m, User.GetUkprn(), m.SearchTerm, m.Page, info.LegalEntityId);
                 SetVacancyEmployerInfoCookie(vm.VacancyEmployerInfoModel);
+                vm.Pager.OtherRouteValues.Add(nameof(wizard), wizard.ToString());
                 vm.PageInfo.SetWizard(wizard);
                 return View(vm);
             }


### PR DESCRIPTION
Bug where returning to the legal entity selection page from part 2 and paging through search results and then clicking cancel would take the user back to dashboard instead of part 2 preview. Clicking continue would take the user through the legal entity sub-journey and then through the rest of part 1 instead of through to part 2 preview.