### PR TITLE
ER-1419 - Fixing GetTimeZone call so it works on a mac

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/DateTimeExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/DateTimeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using TimeZoneConverter;
 
 namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
 {
@@ -49,7 +50,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
 
         public static DateTime ToUkTime(this DateTime datetime)
         {
-            var ukTimezone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+            var ukTimezone = TZConvert.GetTimeZoneInfo("GMT Standard Time");
             return TimeZoneInfo.ConvertTime(datetime, ukTimezone);
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
+++ b/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
@@ -45,5 +45,6 @@
     <PackageReference Include="SFA.DAS.Apprenticeships.Api.Types" Version="0.11.98" />
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is to fix an issue that I have running the code on my machine along with unit tests causing the following error

```
System.TimeZoneNotFoundException : The time zone ID 'GMT Standard Time' was not found on the local computer.
---- System.IO.FileNotFoundException : Could not find file '/usr/share/zoneinfo/GMT Standard Time'.
https://stackoverflow.com/questions/47848111/how-should-i-fetch-timezoneinfo-in-a-platform-agnostic-way
```

Issue is described further:
 - https://stackoverflow.com/questions/47848111/how-should-i-fetch-timezoneinfo-in-a-platform-agnostic-way
- https://github.com/dotnet/corefx/issues/11897