### PR TITLE
ER-1362 - Transfer vacancies alert Provider.Web

### DIFF
--- a/src/Employer/Employer.Web/Controllers/DashboardController.cs
+++ b/src/Employer/Employer.Web/Controllers/DashboardController.cs
@@ -5,7 +5,7 @@ using Esfa.Recruit.Employer.Web.Orchestrators;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Extensions;
-using Esfa.Recruit.Employer.Web.ViewModels.Dashboard;
+using Esfa.Recruit.Shared.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Hosting;
 

--- a/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Esfa.Recruit.Employer.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;

--- a/src/Employer/Employer.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
@@ -1,5 +1,4 @@
-﻿@using Esfa.Recruit.Employer.Web.ViewModels.Dashboard
-@using Esfa.Recruit.Vacancies.Client.Domain.Entities
+﻿@using Esfa.Recruit.Vacancies.Client.Domain.Entities
 @model Esfa.Recruit.Employer.Web.ViewModels.Dashboard.TransferredVacanciesAlertViewModel
 
 <div class="govuk-grid-row">

--- a/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
+++ b/src/Provider/Provider.Web/Configuration/Routing/RouteNames.cs
@@ -25,6 +25,7 @@
         public const string Dashboard_YourCohorts = "Dashboard_YourCohorts";
         public const string Dashboard_AccountsAgreements = "Dashboard_AccountsAgreements";
         public const string Dashboard_Account_Home = "Dashboard_Account_Home";
+        public const string Dashboard_DismissAlert = "Dashboard_DismissAlert";
         public const string Dashboard_Help = "Dashboard_Help";
         public const string Dashboard_Feedback = "Dashboard_Feedback";
         public const string Dashboard_Privacy = "Dashboard_Privacy";

--- a/src/Provider/Provider.Web/Controllers/DashboardController.cs
+++ b/src/Provider/Provider.Web/Controllers/DashboardController.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
 using Esfa.Recruit.Provider.Web.Extensions;
 using Esfa.Recruit.Provider.Web.Orchestrators;
+using Esfa.Recruit.Shared.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Esfa.Recruit.Provider.Web.Controllers
@@ -19,8 +22,19 @@ namespace Esfa.Recruit.Provider.Web.Controllers
         [HttpGet("", Name = RouteNames.Dashboard_Get)]
         public async Task<IActionResult> Dashboard()
         {
-            var vm = await _orchestrator.GetDashboardViewModelAsync(User.GetUkprn());
+            var vm = await _orchestrator.GetDashboardViewModelAsync(User.ToVacancyUser());
             return View(vm);
+        }
+
+        [HttpPost("dismiss-alert", Name = RouteNames.Dashboard_DismissAlert)]
+        public async Task<IActionResult> DismissAlert([FromRoute] string employerAccountId, AlertDismissalEditModel model)
+        {
+            if (Enum.TryParse(typeof(AlertType), model.AlertType, out var alertTypeEnum))
+            {
+                await _orchestrator.DismissAlert(User.ToVacancyUser(), (AlertType)alertTypeEnum);
+            }
+
+            return RedirectToRoute(RouteNames.Dashboard_Get);
         }
     }
 }

--- a/src/Provider/Provider.Web/Orchestrators/DashboardOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/DashboardOrchestrator.cs
@@ -50,7 +50,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
                 NoOfVacanciesClosingSoon = vacancies.Count(v =>
                     v.ClosingDate <= _timeProvider.Today.AddDays(ClosingSoonDays) &&
                     v.Status == VacancyStatus.Live),
-                TransferredVacanciesAlert = GetTransferredVacanciesAlertViewModel(dashboard.TrasferredVacancies, userDetails.TransferredVacanciesAlertDismissedOn)
+                TransferredVacanciesAlert = GetTransferredVacanciesAlertViewModel(dashboard.TransferredVacancies, userDetails.TransferredVacanciesAlertDismissedOn)
             };
             return vm;
         }

--- a/src/Provider/Provider.Web/ViewModels/Dashboard/DashboardViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Dashboard/DashboardViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Esfa.Recruit.Provider.Web.ViewModels.Dashboard;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
 using Humanizer;
@@ -11,6 +12,8 @@ namespace Esfa.Recruit.Provider.Web.ViewModels
     {
         public IList<VacancySummary> Vacancies { get; set; }
         public bool HasAnyVacancies { get; internal set; }
+        public TransferredVacanciesAlertViewModel TransferredVacanciesAlert { get; internal set; }
+
         public bool HasOneVacancy => Vacancies.Count == 1;
         public Guid CurrentVacancyId => HasOneVacancy ? Vacancies.Single().Id : new Guid();
         public int VacancyCountDraft => Vacancies.Count(v => v.Status == VacancyStatus.Draft);
@@ -38,5 +41,6 @@ namespace Esfa.Recruit.Provider.Web.ViewModels
         public string VacancyTextClosingSoonWithNoApplications => "vacancy".ToQuantity(NoOfVacanciesClosingSoonWithNoApplications, ShowQuantityAs.None);
         public bool ShowNoOfVacanciesClosingSoon => NoOfVacanciesClosingSoon > 0;
         public bool ShowNoOfVacanciesClosingSoonWithNoApplications => NoOfVacanciesClosingSoonWithNoApplications > 0;
+        public bool ShowTransferredVacanciesAlert => TransferredVacanciesAlert != null;
     }
 }

--- a/src/Provider/Provider.Web/ViewModels/Dashboard/TransferredVacanciesAlertViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Dashboard/TransferredVacanciesAlertViewModel.cs
@@ -10,7 +10,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Dashboard
     {
         public IEnumerable<string> LegalEntityNames { get; internal set; }
 
-        public string LegalEntityNamesCaptionRaw => LegalEntityNames.Humanize(s => $"<span class=\"govuk-!-font-weight-bold\">{HttpUtility.HtmlEncode(s)}</span>").RemoveOxfordComma();
+        public string LegalEntityNamesCaption => LegalEntityNames.Humanize().RemoveOxfordComma();
 
         public bool HasTransfersToMultipleEmployers => LegalEntityNames.Count() > 1;
     }

--- a/src/Provider/Provider.Web/ViewModels/Dashboard/TransferredVacanciesAlertViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Dashboard/TransferredVacanciesAlertViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Esfa.Recruit.Shared.Web.Extensions;
+using Humanizer;
+
+namespace Esfa.Recruit.Provider.Web.ViewModels.Dashboard
+{
+    public class TransferredVacanciesAlertViewModel
+    {
+        public IEnumerable<string> LegalEntityNames { get; internal set; }
+
+        public string LegalEntityNamesCaptionRaw => LegalEntityNames.Humanize(s => $"<span class=\"govuk-!-font-weight-bold\">{HttpUtility.HtmlEncode(s)}</span>").RemoveOxfordComma();
+
+        public bool HasTransfersToMultipleEmployers => LegalEntityNames.Count() > 1;
+    }
+}

--- a/src/Provider/Provider.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Provider/Provider.Web/Views/Dashboard/Dashboard.cshtml
@@ -24,181 +24,177 @@
     </div>    
 </div>
 
-<div asp-show="@Model.HasAnyVacancies">
-    <div class="govuk-grid-row" asp-show="@Model.HasAnyVacancies">
-        <div class="govuk-grid-column-one-half">
-            <h1 class="govuk-heading-xl">Recruitment</h1>
+    <div asp-show="@Model.HasAnyVacancies">
+        @if (Model.ShowTransferredVacanciesAlert)
+        {
+            <partial name="_TransferredVacanciesAlert" for="TransferredVacanciesAlert" />
+        }
+    
+        <div class="govuk-grid-row" asp-show="@Model.HasAnyVacancies">
+            <div class="govuk-grid-column-one-half">
+                <h1 class="govuk-heading-xl">Recruitment</h1>
+            </div>
+            <div class="govuk-grid-column-one-half ">
+                <a asp-route="@RouteNames.Employer_Get" class="govuk-button float-right clear govuk-!-margin-top-2 govuk-!-margin-bottom-4" esfa-automation="create-vacancy">Create vacancy</a>
+            </div>
         </div>
-
-        <div class="govuk-grid-column-one-half ">
-            <a asp-route="@RouteNames.Employer_Get" class="govuk-button float-right clear govuk-!-margin-top-2 govuk-!-margin-bottom-4" esfa-automation="create-vacancy">Create vacancy</a>
-        </div>
-    </div>
-
-    <div class="govuk-grid-row">
-        <form asp-route="@RouteNames.Vacancies_Get" method="get" autocomplete="off">
-            <div class="govuk-grid-column-two-thirds">
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <div class="form-group search-field">
-                            <div class="search-input-with-button">
-                                <label class="govuk-label" for="search">
-                                Search vacancies
-                                </label>
-                                <input id="search-input" name="searchTerm" placeholder="Search by title, reference number or employer" class="govuk-input search-input" maxlength="200">
+        <div class="govuk-grid-row">
+            <form asp-route="@RouteNames.Vacancies_Get" method="get" autocomplete="off">
+                <div class="govuk-grid-column-two-thirds">
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <div class="form-group search-field">
+                                <div class="search-input-with-button">
+                                    <label class="govuk-label" for="search">
+                                        Search vacancies
+                                    </label>
+                                    <input id="search-input" name="searchTerm" placeholder="Search by title, reference number or employer" class="govuk-input search-input" maxlength="200">
+                                </div>
+                                <div class="search-submit">
+                                    <!-- hide button for no js version -->
+                                    <button type="submit" id="search-submit-button">Search</button>
+                                </div>
                             </div>
-                            <div class="search-submit">
-                                <!-- hide button for no js version -->
-                                <button type="submit" id="search-submit-button">Search</button>
-                            </div>
-                        </div>
-                    </fieldset>
+                        </fieldset>
+                    </div>
                 </div>
-            </div>
-        </form>
-    </div>
-
-    <div class="govuk-grid-row das-card--row">
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.VacancyCountDraft)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.VacancyCountDraft</span>
-                        <a asp-show="@Model.HasDraftVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Draft" class="govuk-link">
-                            @FilteringOptions.Draft @Model.VacancyTextDraft
-                        </a>
-                        <p asp-hide="@Model.HasDraftVacancy">@FilteringOptions.Draft @Model.VacancyTextDraft</p>
-                    </h3>
-                    <p class="govuk-body das-card--description">Vacancies that need completing and sending for review.</p>
-                </div>
-            </div>
+            </form>
         </div>
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.VacancyCountSubmitted)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.VacancyCountSubmitted</span>
-                        <a asp-show="@Model.HasSubmittedVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Submitted" class="govuk-link">
-                            @FilteringOptions.Submitted.GetDisplayName()
-                        </a>
-                        <span asp-hide="@Model.HasSubmittedVacancy">@FilteringOptions.Submitted</span>
-                    </h3>
-                    <p class="govuk-body das-card--description">Vacancies that have been sent for review.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.VacancyCountReferred)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.VacancyCountReferred</span>
-                        <a asp-show="@Model.HasReferredVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Referred" class="govuk-link">
-                            @FilteringOptions.Referred.GetDisplayName() @Model.VacancyTextReferred
-                        </a>
-                        <span asp-hide="@Model.HasReferredVacancy">@FilteringOptions.Referred.GetDisplayName() @Model.VacancyTextReferred</span>
-                    </h3>
-                    <p class="govuk-body das-card--description">Rejected vacancies will need to be edited and resubmitted.</p>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="govuk-grid-row das-card--row">
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.VacancyCountLive)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.VacancyCountLive</span>
-                        <a asp-show="@Model.HasLiveVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Live" class="govuk-link">
-                            @FilteringOptions.Live @Model.VacancyTextLive
-                        </a>
-                        <span asp-hide="@Model.HasLiveVacancy">@FilteringOptions.Live @Model.VacancyTextLive</span>
-                    </h3>
-                    <span class="govuk-body das-card--description">Vacancies on Find an apprenticeship service.</span>
-                    <p class="govuk-body das-card--description"></p>
-                    <ul class="das-card--tasks govuk-list">
-                        <li asp-show="@Model.ShowNoOfVacanciesClosingSoon">
-                            <a class="govuk-link" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.ClosingSoon">@Model.NoOfVacanciesClosingSoon live @Model.VacancyTextClosingSoon closing soon</a>
-                        </li>
-                        <li asp-show="@Model.ShowNoOfVacanciesClosingSoonWithNoApplications">
-                            <a class="govuk-link" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.ClosingSoonWithNoApplications">
-                                @Model.NoOfVacanciesClosingSoonWithNoApplications live @Model.VacancyTextClosingSoonWithNoApplications closing soon with no applications
+        <div class="govuk-grid-row das-card--row">
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.VacancyCountDraft)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.VacancyCountDraft</span>
+                            <a asp-show="@Model.HasDraftVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Draft" class="govuk-link">
+                                @FilteringOptions.Draft @Model.VacancyTextDraft
                             </a>
-                        </li>
-                    </ul>
+                            <p asp-hide="@Model.HasDraftVacancy">@FilteringOptions.Draft @Model.VacancyTextDraft</p>
+                        </h3>
+                        <p class="govuk-body das-card--description">Vacancies that need completing and sending for review.</p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.NoOfNewApplications)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.NoOfNewApplications</span>
-                        <a asp-show="@Model.HasNewApplications" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.NewApplications" class="govuk-link">
-                            New @Model.ApplicationTextLive
-                        </a>
-                        <span asp-hide="@Model.HasNewApplications">@FilteringOptions.NewApplications.GetDisplayName()</span>
-                    </h3>
-                    <span class="govuk-body das-card--description">Applications from Find an apprenticeship service.</span>
-                    <ul class="das-card--tasks govuk-list" asp-show="@Model.ShowAllApplications">
-                        <li>
-                            <a class="govuk-link ga-track-anchor-click" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.AllApplications" data-ga-event-category="link - click">
-                                View all applications
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.VacancyCountSubmitted)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.VacancyCountSubmitted</span>
+                            <a asp-show="@Model.HasSubmittedVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Submitted" class="govuk-link">
+                                @FilteringOptions.Submitted.GetDisplayName()
                             </a>
-                        </li>
-                    </ul>
+                            <span asp-hide="@Model.HasSubmittedVacancy">@FilteringOptions.Submitted</span>
+                        </h3>
+                        <p class="govuk-body das-card--description">Vacancies that have been sent for review.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.VacancyCountReferred)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.VacancyCountReferred</span>
+                            <a asp-show="@Model.HasReferredVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Referred" class="govuk-link">
+                                @FilteringOptions.Referred.GetDisplayName() @Model.VacancyTextReferred
+                            </a>
+                            <span asp-hide="@Model.HasReferredVacancy">@FilteringOptions.Referred.GetDisplayName() @Model.VacancyTextReferred</span>
+                        </h3>
+                        <p class="govuk-body das-card--description">Rejected vacancies will need to be edited and resubmitted.</p>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="govuk-grid-column-one-third">
-            <div class="das-card @GetCardStatus(Model.VacancyCountClosed)">
-                <div class="das-card--content">
-                    <h3 class="govuk-heading-m das-card--heading">
-                        <span class="das-card--stat">@Model.VacancyCountClosed</span>
-                        <a asp-show="@Model.HasClosedVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Closed" class="govuk-link">
-                            @FilteringOptions.Closed @Model.VacancyTextClosed
-                        </a>
-                        <span asp-hide="@Model.HasClosedVacancy">@FilteringOptions.Closed @Model.VacancyTextClosed</span>
-                    </h3>
-                    <span class="govuk-body das-card--description">Vacancies that have passed the closing date. You can clone these vacancies to republish them.</span>
+        <div class="govuk-grid-row das-card--row">
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.VacancyCountLive)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.VacancyCountLive</span>
+                            <a asp-show="@Model.HasLiveVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Live" class="govuk-link">
+                                @FilteringOptions.Live @Model.VacancyTextLive
+                            </a>
+                            <span asp-hide="@Model.HasLiveVacancy">@FilteringOptions.Live @Model.VacancyTextLive</span>
+                        </h3>
+                        <span class="govuk-body das-card--description">Vacancies on Find an apprenticeship service.</span>
+                        <p class="govuk-body das-card--description"></p>
+                        <ul class="das-card--tasks govuk-list">
+                            <li asp-show="@Model.ShowNoOfVacanciesClosingSoon">
+                                <a class="govuk-link" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.ClosingSoon">@Model.NoOfVacanciesClosingSoon live @Model.VacancyTextClosingSoon closing soon</a>
+                            </li>
+                            <li asp-show="@Model.ShowNoOfVacanciesClosingSoonWithNoApplications">
+                                <a class="govuk-link" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.ClosingSoonWithNoApplications">
+                                    @Model.NoOfVacanciesClosingSoonWithNoApplications live @Model.VacancyTextClosingSoonWithNoApplications closing soon with no applications
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.NoOfNewApplications)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.NoOfNewApplications</span>
+                            <a asp-show="@Model.HasNewApplications" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.NewApplications" class="govuk-link">
+                                New @Model.ApplicationTextLive
+                            </a>
+                            <span asp-hide="@Model.HasNewApplications">@FilteringOptions.NewApplications.GetDisplayName()</span>
+                        </h3>
+                        <span class="govuk-body das-card--description">Applications from Find an apprenticeship service.</span>
+                        <ul class="das-card--tasks govuk-list" asp-show="@Model.ShowAllApplications">
+                            <li>
+                                <a class="govuk-link ga-track-anchor-click" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.AllApplications" data-ga-event-category="link - click">
+                                    View all applications
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-column-one-third">
+                <div class="das-card @GetCardStatus(Model.VacancyCountClosed)">
+                    <div class="das-card--content">
+                        <h3 class="govuk-heading-m das-card--heading">
+                            <span class="das-card--stat">@Model.VacancyCountClosed</span>
+                            <a asp-show="@Model.HasClosedVacancy" asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.Closed" class="govuk-link">
+                                @FilteringOptions.Closed @Model.VacancyTextClosed
+                            </a>
+                            <span asp-hide="@Model.HasClosedVacancy">@FilteringOptions.Closed @Model.VacancyTextClosed</span>
+                        </h3>
+                        <span class="govuk-body das-card--description">Vacancies that have passed the closing date. You can clone these vacancies to republish them.</span>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-
-    <div class="govuk-grid-row">
-        <div asp-show="@Model.HasOneVacancy" class="govuk-grid-column-full">
-            <a asp-route="@RouteNames.VacancyManage_Get" asp-route-vacancyId="@Model.CurrentVacancyId" class="govuk-link govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link--no-visited-state" name="button">
-                View your vacancy
-            </a>
-        </div>
-        <div asp-hide="@Model.HasOneVacancy" class="govuk-grid-column-full">
-            <a asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.All" class="govuk-link govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link--no-visited-state" name="button">
-                View all your vacancies (@Model.Vacancies.Count)
-            </a>
-        </div>
-
-        <div class="govuk-grid-column-one-third">
-            <h3 class="govuk-heading-s">
-                <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
-                <a class="govuk-link  govuk-link--no-visited-state" asp-route="@RouteNames.ReportDashboard_Get">Reports</a>
-            </h3>
-            <p class="govuk-body">Create a report about applicants or vacancies</p>
-        </div>
-        
-        <esfaFeatureEnabled name="@FeatureNames.SetNotificationPreferences">
+        <div class="govuk-grid-row">
+            <div asp-show="@Model.HasOneVacancy" class="govuk-grid-column-full">
+                <a asp-route="@RouteNames.VacancyManage_Get" asp-route-vacancyId="@Model.CurrentVacancyId" class="govuk-link govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link--no-visited-state" name="button">
+                    View your vacancy
+                </a>
+            </div>
+            <div asp-hide="@Model.HasOneVacancy" class="govuk-grid-column-full">
+                <a asp-route="@RouteNames.Vacancies_Get" asp-route-filter="@FilteringOptions.All" class="govuk-link govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link--no-visited-state" name="button">
+                    View all your vacancies (@Model.Vacancies.Count)
+                </a>
+            </div>
             <div class="govuk-grid-column-one-third">
                 <h3 class="govuk-heading-s">
                     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
-                    <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.ManageNotifications_Get">Manage your recruitment emails</a>
+                    <a class="govuk-link  govuk-link--no-visited-state" asp-route="@RouteNames.ReportDashboard_Get">Reports</a>
                 </h3>
-                <p class="govuk-body">Set up and manage the emails you’re sent about your vacancies and applications</p>
+                <p class="govuk-body">Create a report about applicants or vacancies</p>
             </div>
-        </esfaFeatureEnabled>
-
+            <esfaFeatureEnabled name="@FeatureNames.SetNotificationPreferences">
+                <div class="govuk-grid-column-one-third">
+                    <h3 class="govuk-heading-s">
+                        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+                        <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.ManageNotifications_Get">Manage your recruitment emails</a>
+                    </h3>
+                    <p class="govuk-body">Set up and manage the emails you’re sent about your vacancies and applications</p>
+                </div>
+            </esfaFeatureEnabled>
+        </div>
     </div>
-</div>
 
 @section FooterJS
 {

--- a/src/Provider/Provider.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
+++ b/src/Provider/Provider.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
@@ -5,7 +5,7 @@
         <div class="info-summary">
             <p class="govuk-body">
                 <span class="govuk-!-font-weight-bold">
-                    @Html.Raw(Model.LegalEntityNamesCaptionRaw)
+                    @Html.Raw(Model.LegalEntityNamesCaption)
                 </span>
                 <span asp-hide="@Model.HasTransfersToMultipleEmployers">
                     has switched off your permission to create and manage vacancies on their behalf.

--- a/src/Provider/Provider.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
+++ b/src/Provider/Provider.Web/Views/Dashboard/_TransferredVacanciesAlert.cshtml
@@ -1,0 +1,27 @@
+﻿@using Esfa.Recruit.Vacancies.Client.Domain.Entities
+@model Esfa.Recruit.Provider.Web.ViewModels.Dashboard.TransferredVacanciesAlertViewModel
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <div class="info-summary">
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold">
+                    @Html.Raw(Model.LegalEntityNamesCaptionRaw)
+                </span>
+                <span asp-hide="@Model.HasTransfersToMultipleEmployers">
+                    has switched off your permission to create and manage vacancies on their behalf.
+                    Any vacancies created for this employer have been transferred to them
+                </span>
+                <span asp-show="@Model.HasTransfersToMultipleEmployers">
+                    have switched off your permission to create and manage vacancies on their behalf.
+                    Any vacancies created for these employers have been transferred to them
+                </span>
+            </p>
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <form asp-route="@RouteNames.Dashboard_DismissAlert">
+                    <input name="@nameof(AlertDismissalEditModel.AlertType)" value="@AlertType.TransferredVacancies" type="hidden" />
+                    <button type="submit" class="button-fake-link govuk-link govuk-link--no-visited-state">Dismiss this notification</button>
+                </form>   
+            </p>
+        </div>
+    </div>
+</div>

--- a/src/Shared/Recruit.Shared.Web/ViewModels/AlertDismissalEditModel.cs
+++ b/src/Shared/Recruit.Shared.Web/ViewModels/AlertDismissalEditModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Recruit.Employer.Web.ViewModels.Dashboard
+﻿namespace Esfa.Recruit.Shared.Web.ViewModels
 {
     public class AlertDismissalEditModel
     {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreWriter.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Provider;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.QA;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
@@ -14,7 +15,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
     public interface IQueryStoreWriter
     {
         Task UpdateEmployerDashboardAsync(string employerAccountId, IEnumerable<VacancySummary> vacancySummaries);
-        Task UpdateProviderDashboardAsync(long ukprn, IEnumerable<VacancySummary> vacancySummaries);
+        Task UpdateProviderDashboardAsync(long ukprn, IEnumerable<VacancySummary> vacancySummaries, IEnumerable<ProviderDashboardTransferredVacancy> transferredVacancies);
         Task UpdateEmployerVacancyDataAsync(string employerAccountId, IEnumerable<LegalEntity> legalEntities);
         Task UpdateProviderVacancyDataAsync(long ukprn, IEnumerable<EmployerInfo> employers);
         Task UpdateLiveVacancyAsync(LiveVacancy vacancy);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboard.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboard.cs
@@ -12,7 +12,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Pr
 
         public IEnumerable<VacancySummary> Vacancies { get; set; }
 
-        public IEnumerable<ProviderDashboardTransferredVacancy> TrasferredVacancies { get; set; }
+        public IEnumerable<ProviderDashboardTransferredVacancy> TransferredVacancies { get; set; }
 
         public IEnumerable<VacancySummary> CloneableVacancies => Vacancies.Where(
             x => x.Status == VacancyStatus.Live ||

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboard.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboard.cs
@@ -12,6 +12,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Pr
 
         public IEnumerable<VacancySummary> Vacancies { get; set; }
 
+        public IEnumerable<ProviderDashboardTransferredVacancy> TrasferredVacancies { get; set; }
+
         public IEnumerable<VacancySummary> CloneableVacancies => Vacancies.Where(
             x => x.Status == VacancyStatus.Live ||
                  x.Status == VacancyStatus.Closed ||

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboardTransferredVacancy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/Provider/ProviderDashboardTransferredVacancy.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Provider
+{
+    public class ProviderDashboardTransferredVacancy
+    {
+        public string LegalEntityName { get; set; }
+        public DateTime TransferredDate { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -73,7 +73,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             {
                 Id = QueryViewType.ProviderDashboard.GetIdValue(ukprn),
                 Vacancies = vacancySummaries,
-                TrasferredVacancies = transferredVacancies,
+                TransferredVacancies = transferredVacancies,
                 LastUpdated = _timeProvider.Now
             };
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -67,12 +67,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return _queryStore.UpsertAsync(dashboardItem);
         }
 
-        public Task UpdateProviderDashboardAsync(long ukprn, IEnumerable<VacancySummary> vacancySummaries)
+        public Task UpdateProviderDashboardAsync(long ukprn, IEnumerable<VacancySummary> vacancySummaries, IEnumerable<ProviderDashboardTransferredVacancy> transferredVacancies)
         {
             var dashboardItem = new ProviderDashboard
             {
                 Id = QueryViewType.ProviderDashboard.GetIdValue(ukprn),
                 Vacancies = vacancySummaries,
+                TrasferredVacancies = transferredVacancies,
                 LastUpdated = _timeProvider.Now
             };
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/IVacancySummariesProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/IVacancySummariesProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummariesProvider
@@ -8,5 +9,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
     {
          Task<IList<VacancySummary>> GetEmployerOwnedVacancySummariesByEmployerAccountAsync(string employerAccountId);
          Task<IList<VacancySummary>> GetProviderOwnedVacancySummariesByUkprnAsync(long ukprn);
+         Task<IList<TransferInfo>> GetTransferredFromProviderAsync(long ukprn);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
@@ -15,6 +15,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
     internal sealed class VacancySummariesProvider : MongoDbCollectionBase, IVacancySummariesProvider
     {
         private const string TransferInfoUkprn = "transferInfo.ukprn";
+        private const string TransferInfoReason = "transferInfo.reason";
 
         public VacancySummariesProvider(ILoggerFactory loggerFactory, IOptions<MongoDbConnectionDetails> details)
             : base(loggerFactory, MongoDbNames.RecruitDb, MongoDbCollectionNames.Vacancies, details)
@@ -63,7 +64,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
 
         public async Task<IList<TransferInfo>> GetTransferredFromProviderAsync(long ukprn)
         {
-            var filter = Builders<VacancyTransferInfo>.Filter.Eq(TransferInfoUkprn, ukprn.ToString());
+            var builder = Builders<VacancyTransferInfo>.Filter;
+            var filter = builder.Eq(TransferInfoUkprn, ukprn.ToString()) &
+                         builder.Eq(TransferInfoReason, TransferReason.EmployerRevokedPermission.ToString());
 
             var collection = GetCollection<VacancyTransferInfo>();
 


### PR DESCRIPTION
- Extended to Provider dashboard to also include a list of transferred vacancies. This list only includes [LegalEntityName, TransferredDate] 
- This is the equivalent alert to the one that we show on Employer.Web so I've reused the AlertType `TransferredVacancies`