### PR TITLE
ER-1414 - Added TransferReason

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TransferInfo.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TransferInfo.cs
@@ -9,5 +9,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public string LegalEntityName { get; set; }
         public VacancyUser TransferredByUser { get; set; }
         public DateTime TransferredDate { get; set; }
+        public TransferReason Reason { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TransferReason.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/TransferReason.cs
@@ -1,0 +1,8 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
+{
+    public enum TransferReason
+    {
+        EmployerRevokedPermission,
+        BlockedByQa
+    }
+}


### PR DESCRIPTION
We need to know the reason why a vacancy was transferred.  The 2 possibilities are:

1. The Employer revoked a provider's permission
2. The QA has blocked a provider

For closed vacancies we could use the `ClosureReason` to work this out however for Drafts that just get transferred and not closed we are missing this data to make this decision.



 


