### PR TITLE
ER-1378 - blocked training provider validation. Employer.Web

### DIFF
--- a/src/Employer/Employer.Web/Controllers/Part1/TrainingProviderController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/TrainingProviderController.cs
@@ -1,15 +1,17 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
 using Esfa.Recruit.Employer.Web.Extensions;
-using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.TrainingProvider;
-using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Shared.Web.Mappers;
+using Esfa.Recruit.Shared.Web.Orchestrators;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Esfa.Recruit.Employer.Web.Controllers.Part1
 {
@@ -17,7 +19,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
     public class TrainingProviderController : Controller
     {
         private readonly TrainingProviderOrchestrator _orchestrator;
-        private const string InvalidUkprnMessageFormat = "The UKPRN {0} is not valid or the associated provider is not active.";
+        private const string InvalidUkprnMessageFormat = "The UKPRN {0} is not valid or the associated provider is not active";
         private const string InvalidSearchTerm = "Please enter a training provider name or UKPRN";
 
         public TrainingProviderController(TrainingProviderOrchestrator orchestrator, IRecruitVacancyClient vacancyClient)
@@ -44,24 +46,23 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("select-training-provider", Name = RouteNames.TrainingProvider_Select_Post)]
         public async Task<IActionResult> SelectTrainingProvider(SelectTrainingProviderEditModel m, [FromQuery] bool wizard)
         {
-            if (!ModelState.IsValid)
+            if (ModelState.IsValid)
             {
-                var vm = await _orchestrator.GetSelectTrainingProviderViewModelAsync(m);
-                vm.PageInfo.SetWizard(wizard);
-                return View(vm);
+                var response = await _orchestrator.PostSelectTrainingProviderAsync(m, User.ToVacancyUser());
+
+                if (response.Success)
+                {
+                    return response.Data.FoundTrainingProviderUkprn.HasValue
+                        ? RedirectToRoute(RouteNames.TrainingProvider_Confirm_Get, new { ukprn = response.Data.FoundTrainingProviderUkprn.Value, wizard })
+                        : GetRedirectToNextPage(wizard);
+                }
+
+                AddTrainingProviderErrorsToModelState(m.SelectionType, m.Ukprn, response, ModelState);
             }
 
-            var result = await _orchestrator.PostSelectTrainingProviderAsync(m, User.ToVacancyUser());
-
-            switch (result.ResponseType)
-            {
-                case SelectTrainingProviderResponseType.Continue:
-                    return GetRedirectToNextPage(wizard);
-                case SelectTrainingProviderResponseType.NotFound:
-                    return await ProviderNotFound(m, wizard);
-                default:
-                    return RedirectToRoute(RouteNames.TrainingProvider_Confirm_Get, new { ukprn = result.FoundProviderUkprn, wizard });
-            }
+            var vm = await _orchestrator.GetSelectTrainingProviderViewModelAsync(m);
+            vm.PageInfo.SetWizard(wizard);
+            return View(vm);
         }
 
         [HttpGet("confirm-training-provider", Name = RouteNames.TrainingProvider_Confirm_Get)]
@@ -81,56 +82,70 @@ namespace Esfa.Recruit.Employer.Web.Controllers.Part1
         [HttpPost("confirm-training-provider", Name = RouteNames.TrainingProvider_Confirm_Post)]
         public async Task<IActionResult> ConfirmTrainingProvider(ConfirmTrainingProviderEditModel m, [FromQuery] bool wizard)
         {
-            if (!ModelState.IsValid)
+            if (ModelState.IsValid)
             {
-                return View(m);
-            }
+                var response = await _orchestrator.PostConfirmEditModelAsync(m, User.ToVacancyUser());
 
-            var provider = await _orchestrator.GetProviderAsync(m.Ukprn);
-
-            if (provider == null)
-            {
-                var vm = new SelectTrainingProviderEditModel { VacancyId = m.VacancyId, Ukprn = m.Ukprn, SelectionType = TrainingProviderSelectionType.Ukprn};
-                return await ProviderNotFound(vm, wizard);
-            }
-
-            var response = await _orchestrator.PostConfirmEditModelAsync(m, User.ToVacancyUser());
-
-            if (!response.Success)
-            {
-                response.AddErrorsToModelState(ModelState);
-            }
-
-            if (!ModelState.IsValid)
-            {
-                var vm = await _orchestrator.GetSelectTrainingProviderViewModelAsync(m);
-                return View(ViewNames.SelectTrainingProvider, vm);
-            }
-
-            return GetRedirectToNextPage(wizard);
-        }
-
-        private async Task<IActionResult> ProviderNotFound(SelectTrainingProviderEditModel m, bool wizard)
-        {
-            if (m.SelectionType == TrainingProviderSelectionType.Ukprn)
-            {
-                ModelState.AddModelError(nameof(SelectTrainingProviderEditModel.Ukprn), string.Format(InvalidUkprnMessageFormat, m.Ukprn));
-            }
-            else
-            {
-                ModelState.AddModelError(nameof(SelectTrainingProviderEditModel.TrainingProviderSearch), InvalidSearchTerm);
+                if(response.Success)
+                    return GetRedirectToNextPage(wizard);
+                
+                AddTrainingProviderErrorsToModelState(TrainingProviderSelectionType.Ukprn, m.Ukprn, response, ModelState);
             }
 
             var vm = await _orchestrator.GetSelectTrainingProviderViewModelAsync(m);
             vm.PageInfo.SetWizard(wizard);
             return View(ViewNames.SelectTrainingProvider, vm);
         }
-
+        
         private IActionResult GetRedirectToNextPage(bool wizard)
         {
             return wizard
                 ? RedirectToRoute(RouteNames.NumberOfPositions_Get)
                 : RedirectToRoute(RouteNames.Vacancy_Preview_Get, null, Anchors.TrainingProviderSection);
+        }
+
+        public void AddTrainingProviderErrorsToModelState(TrainingProviderSelectionType selectionType, string ukprn, OrchestratorResponse response, ModelStateDictionary modelState)
+        {
+            string[] providerNotFoundErrorCodes = { ErrorCodes.TrainingProviderUkprnNotEmpty, ErrorCodes.TrainingProviderMustExist };
+
+            if (!response.Success && response.Errors?.Errors != null)
+            {
+                foreach (var error in response.Errors.Errors)
+                {
+                    if (providerNotFoundErrorCodes.Contains(error.ErrorCode))
+                    {
+                        AddProviderNotFoundErrorToModelState(selectionType, ukprn);
+                        continue;
+                    }
+                    
+                    if (error.ErrorCode == ErrorCodes.TrainingProviderMustNotBeBlocked)
+                    {
+                        AddProviderBlockedErrorToModelState(selectionType, error);
+                        continue;
+                    }
+                    
+                    modelState.AddModelError(error.PropertyName, error.ErrorMessage);
+                }
+            }
+        }
+
+        private void AddProviderNotFoundErrorToModelState(TrainingProviderSelectionType selectionType, string searchedUkprn)
+        {
+            if (selectionType == TrainingProviderSelectionType.Ukprn)
+            {
+                ModelState.AddModelError(nameof(SelectTrainingProviderEditModel.Ukprn), string.Format(InvalidUkprnMessageFormat, searchedUkprn));
+            }
+            else
+            {
+                ModelState.AddModelError(nameof(SelectTrainingProviderEditModel.TrainingProviderSearch), InvalidSearchTerm);
+            }
+        }
+
+        private void AddProviderBlockedErrorToModelState(TrainingProviderSelectionType selectionType, EntityValidationError error)
+        {
+            var errorKey = selectionType == TrainingProviderSelectionType.Ukprn ? nameof(SelectTrainingProviderEditModel.Ukprn) : nameof(SelectTrainingProviderEditModel.TrainingProviderSearch);
+
+            ModelState.AddModelError(errorKey, error.ErrorMessage);
         }
     }
 }

--- a/src/Employer/Employer.Web/Models/PostSelectTrainingProviderResult.cs
+++ b/src/Employer/Employer.Web/Models/PostSelectTrainingProviderResult.cs
@@ -1,16 +1,7 @@
 ﻿namespace Esfa.Recruit.Employer.Web.Models
 {
-    public enum SelectTrainingProviderResponseType
-    {
-        NotFound,
-        Continue,
-        Confirm
-    }
-
     public class PostSelectTrainingProviderResult
     {
-        public long? FoundProviderUkprn { get; set; }
-
-        public SelectTrainingProviderResponseType ResponseType { get; set; }
+        public long? FoundTrainingProviderUkprn { get; set; }
     }
 }

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/Part1/TrainingProviderOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/Part1/TrainingProviderOrchestratorTests.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Employer.Web.Orchestrators.Part1;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.TrainingProvider;
 using Esfa.Recruit.Shared.Web.Services;
-using Esfa.Recruit.Vacancies.Client.Application.Cache;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -24,7 +20,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
         private readonly Guid VacancyId = Guid.Parse("0a8e54c9-e284-4023-b688-14b9d841fcd7");
         
         [Fact]
-        public async Task PostSelectTrainingProviderAsync_WhenNotChoosingThenRemoveExistingTrainingProviderAndContinue()
+        public async Task PostSelectTrainingProviderAsync_WhenNotChoosingThenRemoveExistingTrainingProvider()
         {
             var vacancy = new Vacancy
             {
@@ -46,14 +42,14 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
 
             var result = await orch.PostSelectTrainingProviderAsync(m, new VacancyUser());
 
-            result.ResponseType.Should().Be(SelectTrainingProviderResponseType.Continue);
             vacancy.TrainingProvider.Should().BeNull();
+            result.Data.FoundTrainingProviderUkprn.Should().BeNull();
         }
 
         [Theory]
         [InlineData("This search won't match a single provider")]
         [InlineData("88888")] //will match multiple providers
-        public async Task PostSelectTrainingProviderAsync_TrainingProviderSearch_WhenNoSingleProviderFoundShouldReturnNotFoundResult(string trainingProviderSearch)
+        public async Task PostSelectTrainingProviderAsync_TrainingProviderSearch_WhenNoSingleProviderFoundShouldNotReturnFoundProvider(string trainingProviderSearch)
         {
             var vacancy = new Vacancy
             {
@@ -77,39 +73,11 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
             
             var result = await orch.PostSelectTrainingProviderAsync(m, new VacancyUser());
 
-            result.ResponseType.Should().Be(SelectTrainingProviderResponseType.NotFound);
+            result.Data.FoundTrainingProviderUkprn.Should().BeNull();
         }
 
         [Fact]
-        public async Task PostSelectTrainingProviderAsync_UKPRN_WhenNoProviderFoundShouldReturnNotFoundResult()
-        {
-            var vacancy = new Vacancy
-            {
-                Id = VacancyId,
-                EmployerAccountId = EmployerAccountId,
-                TrainingProvider = new TrainingProvider(),
-                Title = "specified for route validation",
-                ProgrammeId = "specified for route validation"
-            };
-
-            var orch = GetTrainingProviderOrchestrator(vacancy);
-
-            var m = new SelectTrainingProviderEditModel
-            {
-                IsTrainingProviderSelected = true,
-                SelectionType = TrainingProviderSelectionType.Ukprn,
-                Ukprn = "12345678",
-                EmployerAccountId = EmployerAccountId,
-                VacancyId = VacancyId
-            };
-
-            var result = await orch.PostSelectTrainingProviderAsync(m, new VacancyUser());
-
-            result.ResponseType.Should().Be(SelectTrainingProviderResponseType.NotFound);
-        }
-
-        [Fact]
-        public async Task PostSelectTrainingProviderAsync_TrainingProviderSearch_WhenSingleProviderFoundShouldReturnConfirmResult()
+        public async Task PostSelectTrainingProviderAsync_TrainingProviderSearch_WhenSingleProviderFoundShouldReturnFoundProvider()
         {
             var vacancy = new Vacancy
             {
@@ -133,12 +101,11 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
 
             var result = await orch.PostSelectTrainingProviderAsync(m, new VacancyUser());
 
-            result.ResponseType.Should().Be(SelectTrainingProviderResponseType.Confirm);
-            result.FoundProviderUkprn.Should().Be(88888888);
+            result.Data.FoundTrainingProviderUkprn.Should().Be(88888888);
         }
 
         [Fact]
-        public async Task PostSelectTrainingProviderAsync_UKPRN_WhenSingleProviderFoundShouldReturnConfirmResult()
+        public async Task PostSelectTrainingProviderAsync_UKPRN_WhenSingleProviderFoundShouldReturnFoundProvider()
         {
             var vacancy = new Vacancy
             {
@@ -162,21 +129,25 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Part1
 
             var result = await orch.PostSelectTrainingProviderAsync(m, new VacancyUser());
 
-            result.ResponseType.Should().Be(SelectTrainingProviderResponseType.Confirm);
-            result.FoundProviderUkprn.Should().Be(88888888);
+            result.Data.FoundTrainingProviderUkprn.Should().Be(88888888);
         }
 
         private TrainingProviderOrchestrator GetTrainingProviderOrchestrator(Vacancy vacancy)
         {
             var mockClient = new Mock<IEmployerVacancyClient>();
+            mockClient.Setup(c => c.GetTrainingProviderAsync(88888888))
+                .ReturnsAsync(new TrainingProvider {Ukprn = 88888888});
 
             var mockRecruitClient = new Mock<IRecruitVacancyClient>();
             mockRecruitClient.Setup(c => c.GetVacancyAsync(VacancyId)).ReturnsAsync(vacancy);
             mockRecruitClient.Setup(c => c.GetAllTrainingProvidersAsync()).ReturnsAsync(new List<TrainingProviderSummary>
             {
-                new TrainingProviderSummary{ProviderName = "MR EGG",Ukprn = 88888888},
-                new TrainingProviderSummary{ProviderName = "MRS EGG",Ukprn = 88888889}
+                new TrainingProviderSummary{ProviderName = "MR EGG", Ukprn = 88888888},
+                new TrainingProviderSummary{ProviderName = "MRS EGG", Ukprn = 88888889}
             });
+
+            mockRecruitClient.Setup(c => c.Validate(It.IsAny<Vacancy>(), VacancyRuleSet.TrainingProvider))
+                .Returns(new EntityValidationResult());
 
             var mockLog = new Mock<ILogger<TrainingProviderOrchestrator>>();
             var mockReview = new Mock<IReviewSummaryService>();

--- a/src/Shared/Recruit.Vacancies.Client/Application/Providers/ITrainingProviderSummaryProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Providers/ITrainingProviderSummaryProvider.cs
@@ -7,5 +7,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Providers
     public interface ITrainingProviderSummaryProvider
     {
         Task<IEnumerable<TrainingProviderSummary>> FindAllAsync();
+        Task<TrainingProviderSummary> GetAsync(long ukprn);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
@@ -1,0 +1,10 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Application.Validation
+{
+    public static class ErrorCodes
+    {
+        public const string TrainingProviderUkprnNotEmpty = "101";
+        public const string TrainingProviderUkprnMustBeCorrectLength = "99";
+        public const string TrainingProviderMustExist = "102";
+        public const string TrainingProviderMustNotBeBlocked = "103";
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using FluentValidation;
 using FluentValidation.Internal;
 using FluentValidation.Results;
@@ -49,11 +51,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
             });
         }
 
-        internal static IRuleBuilderInitial<Vacancy, Vacancy> TrainingMustBeActiveForStartDate(this IRuleBuilder<Vacancy, Vacancy> ruleBuilder, Lazy<IEnumerable<IApprenticeshipProgramme>> programmes)
+        internal static IRuleBuilderInitial<Vacancy, Vacancy> TrainingMustBeActiveForStartDate(this IRuleBuilder<Vacancy, Vacancy> ruleBuilder, IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider)
         {
-            return ruleBuilder.Custom((vacancy, context) =>
+            return ruleBuilder.CustomAsync(async (vacancy, context, cancellationToken) =>
             {
-                var matchingProgramme = programmes.Value.SingleOrDefault(x => x.Id.Equals(vacancy.ProgrammeId, StringComparison.InvariantCultureIgnoreCase));
+                var allProgrammes = await apprenticeshipProgrammesProvider.GetApprenticeshipProgrammesAsync();
+
+                var matchingProgramme = allProgrammes.SingleOrDefault(x => x.Id.Equals(vacancy.ProgrammeId, StringComparison.InvariantCultureIgnoreCase));
 
                 if (matchingProgramme.EffectiveTo != null && matchingProgramme.EffectiveTo < vacancy.StartDate)
                 {
@@ -64,6 +68,43 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
                     };
                     context.AddFailure(failure);
                 }
+            });
+        }
+
+        internal static IRuleBuilderInitial<TrainingProvider, TrainingProvider> TrainingProviderMustExistInRoatp(this IRuleBuilder<TrainingProvider, TrainingProvider> ruleBuilder, ITrainingProviderSummaryProvider trainingProviderSummaryProvider)
+        {
+            return ruleBuilder.CustomAsync(async (trainingProvider, context, cancellationToken) =>
+            {
+                if (trainingProvider.Ukprn != null && 
+                    await trainingProviderSummaryProvider.GetAsync(trainingProvider.Ukprn.Value) != null)
+                return;
+
+                var failure = new ValidationFailure(nameof(Vacancy.TrainingProvider), "The UKPRN is not valid or the associated provider is not active")
+                {
+                    ErrorCode = ErrorCodes.TrainingProviderMustExist,
+                    CustomState = VacancyRuleSet.TrainingProvider
+                };
+                context.AddFailure(failure);
+            });
+        }
+
+        internal static IRuleBuilderInitial<TrainingProvider, TrainingProvider> TrainingProviderMustNotBeBlocked(this IRuleBuilder<TrainingProvider, TrainingProvider> ruleBuilder, IBlockedOrganisationQuery blockedOrganisationRep)
+        {
+            return ruleBuilder.CustomAsync(async (trainingProvider, context, cancellationToken) =>
+            {
+                if (trainingProvider.Ukprn != null)
+                {
+                    var organisation = await blockedOrganisationRep.GetByOrganisationIdAsync(trainingProvider.Ukprn.Value.ToString());
+                    if(organisation == null || organisation.BlockedStatus != BlockedStatus.Blocked)
+                        return;
+                }
+                
+                var failure = new ValidationFailure(nameof(Vacancy.TrainingProvider), $"{trainingProvider.Name} can no longer be used as a training provider")
+                {
+                    ErrorCode = ErrorCodes.TrainingProviderMustNotBeBlocked,
+                    CustomState = VacancyRuleSet.TrainingProvider
+                };
+                context.AddFailure(failure);
             });
         }
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using FluentValidation;
 using FluentValidation.Internal;
 using FluentValidation.Results;
@@ -75,7 +73,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
         {
             return ruleBuilder.CustomAsync(async (trainingProvider, context, cancellationToken) =>
             {
-                if (trainingProvider.Ukprn != null && 
+                if (trainingProvider.Ukprn.HasValue && 
                     await trainingProviderSummaryProvider.GetAsync(trainingProvider.Ukprn.Value) != null)
                 return;
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -1,9 +1,8 @@
-using System;
-using System.Collections.Generic;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators.VacancyValidators;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using FluentValidation;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
@@ -13,16 +12,27 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
         private readonly ITimeProvider _timeProvider;
         private readonly IMinimumWageProvider _minimumWageService;
         private readonly IQualificationsProvider _qualificationsProvider;
-        private readonly Lazy<IEnumerable<IApprenticeshipProgramme>> _apprenticeshipProgrammes;
+        private readonly IApprenticeshipProgrammeProvider _apprenticeshipProgrammesProvider;
         private readonly IHtmlSanitizerService _htmlSanitizerService;
+        private readonly ITrainingProviderSummaryProvider _trainingProviderSummaryProvider;
+        private readonly IBlockedOrganisationQuery _blockedOrganisationRepo;
 
-        public FluentVacancyValidator(ITimeProvider timeProvider, IMinimumWageProvider minimumWageService, IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider, IQualificationsProvider qualificationsProvider, IHtmlSanitizerService htmlSanitizerService)
+        public FluentVacancyValidator(
+            ITimeProvider timeProvider, 
+            IMinimumWageProvider minimumWageService, 
+            IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider, 
+            IQualificationsProvider qualificationsProvider, 
+            IHtmlSanitizerService htmlSanitizerService, 
+            ITrainingProviderSummaryProvider trainingProviderSummaryProvider, 
+            IBlockedOrganisationQuery blockedOrganisationRepo)
         {
             _timeProvider = timeProvider;
             _minimumWageService = minimumWageService;
             _qualificationsProvider = qualificationsProvider;
-            _apprenticeshipProgrammes = new Lazy<IEnumerable<IApprenticeshipProgramme>>(() => apprenticeshipProgrammesProvider.GetApprenticeshipProgrammesAsync().Result);
+            _apprenticeshipProgrammesProvider = apprenticeshipProgrammesProvider;
             _htmlSanitizerService = htmlSanitizerService;
+            _trainingProviderSummaryProvider = trainingProviderSummaryProvider;
+            _blockedOrganisationRepo = blockedOrganisationRepo;
 
             SingleFieldValidations();
 
@@ -576,11 +586,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
 
         private void ValidateTrainingProvider()
         {
+            var trainingProviderValidator = new TrainingProviderValidator((long) VacancyRuleSet.TrainingProvider, _trainingProviderSummaryProvider, _blockedOrganisationRepo);
+
             RuleFor(x => x.TrainingProvider)
                 .NotNull()
                     .WithMessage("You must enter a training provider")
-                    .WithErrorCode("101")
-                .SetValidator(new TrainingProviderValidator((long)VacancyRuleSet.TrainingProvider))
+                    .WithErrorCode(ErrorCodes.TrainingProviderUkprnNotEmpty)
+                .SetValidator(trainingProviderValidator)
                 .RunCondition(VacancyRuleSet.TrainingProvider)
                 .WithRuleId(VacancyRuleSet.TrainingProvider);
         }
@@ -612,7 +624,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
             When(x => x.ProgrammeId != null && !string.IsNullOrWhiteSpace(x.ProgrammeId) && x.StartDate.HasValue, () =>
             {
                 RuleFor(x => x)
-                    .TrainingMustBeActiveForStartDate(_apprenticeshipProgrammes)
+                    .TrainingMustBeActiveForStartDate(_apprenticeshipProgrammesProvider)
                 .RunCondition(VacancyRuleSet.TrainingExpiryDate)
                 .WithRuleId(VacancyRuleSet.TrainingExpiryDate);
             });

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/TrainingProviderValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/TrainingProviderValidator.cs
@@ -17,7 +17,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                     .WithMessage("You must enter a training provider")
                     .WithErrorCode(ErrorCodes.TrainingProviderUkprnNotEmpty)
                 .Length(UkprnLength)
-                    .WithMessage("The UKPRN is 8 digits")
+                    .WithMessage($"The UKPRN is {UkprnLength} digits")
                     .WithErrorCode(ErrorCodes.TrainingProviderUkprnMustBeCorrectLength)
                 .WithRuleId(ruleId);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProviderSummaryProvider/TrainingProviderSummaryProvider.cs
@@ -11,15 +11,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
 {
     public class TrainingProviderSummaryProvider : ITrainingProviderSummaryProvider
     {
-        private readonly ILogger<TrainingProviderSummaryProvider> _logger;
         private readonly IProviderApiClient _providerClient;
         private readonly ICache _cache;
         private readonly ITimeProvider _timeProvider;
 
 
-        public TrainingProviderSummaryProvider(ILogger<TrainingProviderSummaryProvider> logger, IProviderApiClient providerClient, ICache cache, ITimeProvider timeProvider)
+        public TrainingProviderSummaryProvider(IProviderApiClient providerClient, ICache cache, ITimeProvider timeProvider)
         {
-            _logger = logger;
             _providerClient = providerClient;
             _cache = cache;
             _timeProvider = timeProvider;
@@ -31,6 +29,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
                 CacheKeys.TrainingProviders,
                 _timeProvider.NextDay6am,
                 FindAllInternalAsync);
+        }
+
+        public async Task<TrainingProviderSummary> GetAsync(long ukprn)
+        {
+            return (await FindAllAsync()).SingleOrDefault(p => p.Ukprn == ukprn);
         }
 
         private async Task<IEnumerable<TrainingProviderSummary>> FindAllInternalAsync()

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
@@ -4,6 +4,7 @@ using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -15,6 +16,8 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
         protected readonly Mock<IApprenticeshipProgrammeProvider> MockApprenticeshipProgrammeProvider;
         protected readonly Mock<IQualificationsProvider> MockQualificationsProvider;
         protected readonly IHtmlSanitizerService SanitizerService;
+        protected readonly Mock<ITrainingProviderSummaryProvider> MockTrainingProviderSummaryProvider;
+        protected readonly Mock<IBlockedOrganisationQuery> MockBlockedOrganisationRepo;
 
         protected VacancyValidationTestsBase()
         {
@@ -22,6 +25,8 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
             MockApprenticeshipProgrammeProvider = new Mock<IApprenticeshipProgrammeProvider>();
             MockQualificationsProvider = new Mock<IQualificationsProvider>();
             SanitizerService = new HtmlSanitizerService(new Mock<ILogger<HtmlSanitizerService>>().Object);
+            MockTrainingProviderSummaryProvider = new Mock<ITrainingProviderSummaryProvider>();
+            MockBlockedOrganisationRepo = new Mock<IBlockedOrganisationQuery>();
         }
 
         protected IEntityValidator<Vacancy, VacancyRuleSet> Validator
@@ -29,7 +34,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation
             get
             {
                 var timeProvider = new CurrentUtcTimeProvider();
-                var fluentValidator = new FluentVacancyValidator(timeProvider, MockMinimumWageService.Object, MockApprenticeshipProgrammeProvider.Object, MockQualificationsProvider.Object, SanitizerService);
+                var fluentValidator = new FluentVacancyValidator(timeProvider, MockMinimumWageService.Object, MockApprenticeshipProgrammeProvider.Object, MockQualificationsProvider.Object, SanitizerService, MockTrainingProviderSummaryProvider.Object, MockBlockedOrganisationRepo.Object);
                 return new EntityValidator<Vacancy, VacancyRuleSet>(fluentValidator);
             }
         }


### PR DESCRIPTION
- Moved the checking of the provider is in RoATP and is also not Blocked out of the Training Provider orchestrator and into the Validations.  This allows the same logic to be run as part of the vacancy submit process too.
- Changed the list of Apprenticeship Programmes in the Validator from a Lazy list to using the cached lookup.  As Fluent validation is Singleton then I think this list wouldn't get updated unless the application recycled so now its using the cached provider it will be in sync.
- Added an ErrorCodes class to list some error codes that I needed the orchestrator to be aware of.  Maybe this class could become the beginning of the definitive list of error codes?
- I've changed some of the validations from `.Custom` to `.CustomAsync`. This allows us to write the validation code in an async manner without using `.Result`.  However because we call `.Validate` and not `.ValidateAsync` on the actual validation these will still be run synchronously for now. I've added a tech debt item to update the code to use .`ValidateAsync`.  Its too much of a job for me to do this in this ticket.
