### PR TITLE
ER-1367 ER-1445 Implements Provider blocked by QA

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Models;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
+{
+    public class ProviderBlockedDomainEventHandler : DomainEventHandler, IDomainEventHandler<ProviderBlockedEvent>
+    {
+        private readonly IQueryStoreReader _queryStoreReader;
+        private readonly IVacancyQuery _vacancyQuery;
+        private readonly IMessaging _messaging;
+        ILogger<ProviderBlockedDomainEventHandler> _logger;
+
+        public ProviderBlockedDomainEventHandler(
+            IQueryStoreReader queryStoreReader,
+            IVacancyQuery vacancyQuery,
+            IMessaging messaging,
+            ILogger<ProviderBlockedDomainEventHandler> logger) : base(logger)
+        {
+            _queryStoreReader = queryStoreReader;
+            _vacancyQuery = vacancyQuery;
+            _messaging = messaging;
+            _logger = logger;
+        }
+
+        public async Task HandleAsync(string eventPayload)
+        {
+            var eventData = DeserializeEvent<ProviderBlockedEvent>(eventPayload);
+
+            _logger.LogInformation($"Begining to queue required updates as provider {eventData.Ukprn} was blocked");
+
+            var tasks = new List<Task>();
+
+            var providerInfoTask = _queryStoreReader.GetProviderVacancyDataAsync(eventData.Ukprn);
+            var vacanciesTask = _vacancyQuery.GetVacanciesAssociatedToProvider(eventData.Ukprn);
+            await Task.WhenAll(providerInfoTask, vacanciesTask);
+            var providerInfo = providerInfoTask.Result;
+            var vacancies = vacanciesTask.Result;
+
+            if (providerInfo?.Employers != null)
+            {
+                tasks.AddRange(RaiseEventsToRevokePermission(providerInfo.Employers, eventData.Ukprn));
+            }
+
+            tasks.AddRange(RaiseEventsToUpdateVacancies(vacancies, eventData.QaVacancyUser));
+
+            tasks.Add(RequestProviderCommunication(eventData.ProviderName));
+
+            tasks.AddRange(RequestEmployerCommunications(vacancies));
+
+            //TODO update employer and provider dashboard
+
+            //TODO update providereditinfo... delete Employers list ???
+
+            await Task.WhenAll(tasks);
+        }
+
+        private List<Task> RaiseEventsToRevokePermission(IEnumerable<EmployerInfo> employers, long ukprn)
+        {
+            var tasks = new List<Task>();
+            foreach (var employer in employers)
+            {
+                foreach (var legalEntity in employer.LegalEntities)
+                {
+                    var providerBlockedOnLegalEntityEvent = new ProviderBlockedOnLegalEntityEvent()
+                    {
+                        Ukprn = ukprn,
+                        EmployerAccountId = employer.EmployerAccountId,
+                        LegalEntityId = legalEntity.LegalEntityId
+                    };
+
+                    tasks.Add(_messaging.PublishEvent(providerBlockedOnLegalEntityEvent));
+                }
+            }
+            return tasks;
+        }
+
+        private List<Task> RaiseEventsToUpdateVacancies(IEnumerable<ProviderVacancySummary> vacancies, VacancyUser qaVacancyUser)
+        {
+            var tasks = new List<Task>();
+
+            foreach (var vacancy in vacancies)
+            {
+                var providerBlockedOnVacancyEvent = new ProviderBlockedOnVacancyEvent()
+                {
+                    VacancyId = vacancy.Id,
+                    QaVacancyUser = qaVacancyUser,
+                    VacancyReference = vacancy.VacancyReference
+                };
+
+                tasks.Add(_messaging.PublishEvent(providerBlockedOnVacancyEvent));
+            }
+
+            return tasks;
+        }
+
+        private Task RequestProviderCommunication(string providerName)
+        {
+            //TODO 
+            // - raise communication request 
+            // - add DataItems collection to CommunicationRequest object
+            // - add provider's name in the data items collection (no Entities are required)
+
+            //TODO Communications
+            // - modify Comm Processor to add data items from the comm request 
+            //      and make sure it works having no data entites 
+            // - Modify user preferences to always return email channel with immediate effect for this comm request
+            // - create templates in gov notify
+            // - add configs to employer config
+            // - update template id provider
+            return Task.CompletedTask;
+        }
+
+        private List<Task> RequestEmployerCommunications(IEnumerable<ProviderVacancySummary> vacancies)
+        {
+            var tasks = new List<Task>();
+
+            //TODO 
+            // - find all the vacancies OWNED by the provider
+            // - get unique list of employers from the vacancy list
+            // - Raise one communication request for each employer
+            //      Add entity data item for BlockedProvider entity, the value will consist of the ukprn, employer account id and blocked date
+
+            //TODO Communications
+            // - Create new (or extend) user provider plugin that works directly off employer account id
+            // - Create new data item plugin for the request type that will return the count of vacancies that were transferred
+            //      look for vacancies associated to the employer and provider with TransferInfo marked with blocked timestamp
+
+            return tasks;
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedOnLegalEntityDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedOnLegalEntityDomainEventHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
+{
+    public class ProviderBlockedOnLegalEntityDomainEventHandler : DomainEventHandler, IDomainEventHandler<ProviderBlockedOnLegalEntityEvent>
+    {
+        ILogger<ProviderBlockedOnLegalEntityDomainEventHandler> _logger;
+        public ProviderBlockedOnLegalEntityDomainEventHandler(ILogger<ProviderBlockedOnLegalEntityDomainEventHandler> logger) : base(logger)
+        {
+            _logger = logger;
+        }
+
+        public Task HandleAsync(string eventPayload)
+        {
+            var eventData = DeserializeEvent<ProviderBlockedOnLegalEntityEvent>(eventPayload);
+            //TODO 
+            // call provider permissions api to revoke permission for each legal entity
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
@@ -1,0 +1,100 @@
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Services;
+using Entities = Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
+{
+    public class ProviderBlockedOnVacancyDomainEventHandler : DomainEventHandler, IDomainEventHandler<ProviderBlockedOnVacancyEvent>
+    {
+        private readonly IVacancyRepository _vacancyRepository;
+        private readonly IVacancyReviewQuery _vacancyReviewQuery;
+        private readonly IVacancyReviewRepository _vacancyReviewRepository;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IVacancyService _vacancyService;
+        private readonly ILogger<ProviderBlockedOnVacancyDomainEventHandler> _logger;
+        public ProviderBlockedOnVacancyDomainEventHandler(
+            IVacancyRepository vacancyRepository,
+            IVacancyReviewQuery vacancyReviewQuery,
+            IVacancyReviewRepository vacancyReviewRepository,
+            ITimeProvider timeProvider,
+            IVacancyService vacancyService,
+            ILogger<ProviderBlockedOnVacancyDomainEventHandler> logger) : base(logger)
+        {
+            _logger = logger;
+            _vacancyRepository = vacancyRepository;
+            _vacancyReviewQuery = vacancyReviewQuery;
+            _vacancyReviewRepository = vacancyReviewRepository;
+            _timeProvider = timeProvider;
+            _vacancyService = vacancyService;
+        }
+
+        public async Task HandleAsync(string eventPayload)
+        {
+            var eventData = DeserializeEvent<ProviderBlockedOnVacancyEvent>(eventPayload);
+
+            _logger.LogInformation($"Updating vacancy {eventData.VacancyId} as the provider {eventData.Ukprn} is blocked");
+
+            var vacancy = await _vacancyRepository.GetVacancyAsync(eventData.VacancyId);
+
+            var isVacancyUpdated = false;
+
+            if (vacancy.OwnerType == Entities.OwnerType.Provider && vacancy.TransferInfo == null)
+            {
+                _logger.LogInformation($"Transferring the vacancy {vacancy.VacancyReference} to the employer as the provider {eventData.Ukprn} is blocked");
+                isVacancyUpdated = true;
+                vacancy.TransferInfo = new Entities.TransferInfo()
+                {
+                    Ukprn = eventData.Ukprn,
+                    ProviderName = vacancy.TrainingProvider.Name,
+                    LegalEntityName = vacancy.LegalEntityName,
+                    TransferredByUser = eventData.QaVacancyUser,
+                    TransferredDate = eventData.BlockedDate,
+                    Reason = Entities.TransferReason.BlockedByQa
+                };
+                vacancy.OwnerType = Entities.OwnerType.Employer;
+            }
+
+            if(vacancy.Status == Entities.VacancyStatus.Submitted)
+            {
+                var review = await _vacancyReviewQuery.GetLatestReviewByReferenceAsync(vacancy.VacancyReference.GetValueOrDefault());
+                if (review.IsPending)
+                {
+                    await ClosePendingReview(review);
+                    isVacancyUpdated = true;
+                    vacancy.Status = Entities.VacancyStatus.Draft;
+                    vacancy.LastUpdatedByUser = eventData.QaVacancyUser;
+                    vacancy.LastUpdatedDate = eventData.BlockedDate;
+                }
+                else
+                {
+                    _logger.LogInformation($"The vacancy {vacancy.VacancyReference} is under review and cannot be closed.");
+                }
+            }
+
+            if(isVacancyUpdated)
+            {
+                await _vacancyRepository.UpdateAsync(vacancy);
+            }
+
+            if(vacancy.Status == Entities.VacancyStatus.Live)
+            {
+                _logger.LogInformation($"Closing live vacancy {eventData.VacancyId} as the provider {eventData.Ukprn} is blocked");
+                await _vacancyService.CloseVacancyImmediately(eventData.VacancyId, eventData.QaVacancyUser, Entities.ClosureReason.BlockedByQa);
+            }
+        }
+
+        private async Task ClosePendingReview(Entities.VacancyReview review)
+        {
+            _logger.LogInformation($"Closing pending review {review.Id} as the provider is blocked");
+            review.ManualOutcome = Entities.ManualQaOutcome.Withdrawn;
+            review.Status = Entities.ReviewStatus.Closed;
+            review.ClosedDate = _timeProvider.Now;
+
+            await _vacancyReviewRepository.UpdateAsync(review);
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
@@ -10,6 +10,8 @@ using Esfa.Recruit.Vacancies.Jobs.Configuration;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Application;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Candidate;
+using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Employer;
+using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy;
 using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.VacancyReview;
 using Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers;
@@ -67,6 +69,7 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddScoped<IDomainEventHandler<IEvent>, DraftVacancyUpdatedHandler>();
             services.AddScoped<IDomainEventHandler<IEvent>, VacancyReferredDomainEventHandler>();
             services.AddScoped<IDomainEventHandler<IEvent>, VacancySubmittedHandler>();
+            services.AddScoped<IDomainEventHandler<IEvent>, ProviderBlockedOnVacancyDomainEventHandler>();
 
             // VacancyReview
             services.AddScoped<IDomainEventHandler<IEvent>, VacancyReviewApprovedHandler>();
@@ -78,10 +81,12 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddScoped<IDomainEventHandler<IEvent>, ApplicationWithdrawnHandler>();
 
             // Employer
-            services.AddScoped<IDomainEventHandler<IEvent>, DomainEvents.Handlers.Employer.SetupEmployerHandler>();
+            services.AddScoped<IDomainEventHandler<IEvent>, SetupEmployerHandler>();
 
             // Provider
-            services.AddScoped<IDomainEventHandler<IEvent>, DomainEvents.Handlers.Provider.SetupProviderHandler>();
+            services.AddScoped<IDomainEventHandler<IEvent>, SetupProviderHandler>();
+            services.AddScoped<IDomainEventHandler<IEvent>, ProviderBlockedDomainEventHandler>();
+            services.AddScoped<IDomainEventHandler<IEvent>, ProviderBlockedOnLegalEntityDomainEventHandler>();
 
             //Candidate
             services.AddScoped<IDomainEventHandler<IEvent>, DeleteCandidateHandler>();

--- a/src/QA/QA.Web/Configuration/Routing/RouteNames.cs
+++ b/src/QA/QA.Web/Configuration/Routing/RouteNames.cs
@@ -15,5 +15,14 @@
         public const string Vacancy_Review_Unassign_Get = "Vacancy_Review_Unassign_Get";
         public const string Vacancy_Review_Unassign_Post = "Vacancy_Review_Unassign_Post";
         public const string Vacancy_Readonly_Review_Get = "Vacancy_Readonly_Review_Get";
+        public const string BlockedOrganisations_Get = "BlockedOrganisations_Get";
+        public const string BlockProvider_Find_Get = "BlockProvider_Find_Get";
+        public const string BlockProvider_Find_Post = "BlockProvider_Find_Post";
+        public const string BlockProvider_Confirm_Get = "BlockProvider_Confirm_Get";
+        public const string BlockProvider_Confirm_Post = "BlockProvider_Confirm_Post";
+        public const string BlockProvider_Consent_Get = "BlockProvider_Consent_Get";
+        public const string BlockProvider_Consent_Post = "BlockProvider_Consent_Post";
+        public const string BlockProvider_Acknowledgement_Get = "BlockProvider_Acknowledgement_Get";
+        public const string BlockProvider_AlreadyBlocked_Get = "BlockProvider_AlreadyBlocked_Get";
     }
 }

--- a/src/QA/QA.Web/Configuration/Routing/RoutePaths.cs
+++ b/src/QA/QA.Web/Configuration/Routing/RoutePaths.cs
@@ -5,7 +5,7 @@ namespace Esfa.Recruit.Qa.Web.Configuration.Routing
         public const string VacancyReviewsRoutePath = "reviews/{reviewId:guid}";
         public const string AccessDeniedPath = "/error/403";
         public const string ExceptionHandlingPath = "/error/handle";
-
+        public const string BlockedOrganisations = "/blockedorganisations";
         //Reports 
         public const string ReportsRoutePath = "/reports";
         public const string ApplicationsReportRoutePath = ReportsRoutePath + "/applications";

--- a/src/QA/QA.Web/Configuration/TempDataKeys.cs
+++ b/src/QA/QA.Web/Configuration/TempDataKeys.cs
@@ -3,5 +3,6 @@
     public class TempDataKeys
     {
         public const string DashboardMessage = "Dashboard_Message";
+        public const string BlockProviderUkprnKey = "BlockProviderUkprnKey";
     }
 }

--- a/src/QA/QA.Web/Controllers/BlockedOrganisationsController.cs
+++ b/src/QA/QA.Web/Controllers/BlockedOrganisationsController.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Mvc;
+using Esfa.Recruit.Qa.Web.Configuration.Routing;
+using System.Threading.Tasks;
+using Esfa.Recruit.QA.Web.Orchestrators;
+using Esfa.Recruit.Qa.Web.Security;
+using Microsoft.AspNetCore.Authorization;
+using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+using Esfa.Recruit.Qa.Web.Configuration;
+using Esfa.Recruit.Qa.Web.Extensions;
+
+namespace Esfa.Recruit.QA.Web.Controllers
+{
+    [Authorize(Policy = AuthorizationPolicyNames.TeamLeadUserPolicyName)]
+    [Route(RoutePaths.BlockedOrganisations)]
+    public class BlockedOrganisationsController : Controller
+    {
+        private readonly BlockedOrganisationsOrchestrator _orchestrator;
+        private readonly UserAuthorizationService _userAuthorizationService;
+        public BlockedOrganisationsController(UserAuthorizationService userAuthorizationService, BlockedOrganisationsOrchestrator orchestrator)
+        {
+            _orchestrator = orchestrator;
+            _userAuthorizationService = userAuthorizationService;
+        }
+
+        [HttpGet("", Name = RouteNames.BlockedOrganisations_Get)]
+        public async Task<IActionResult> Index()
+        {
+            var vm = await _orchestrator.GetBlockedOrganisationsViewModel();
+            return View(vm);
+        }
+
+        [HttpGet("find-training-provider", Name = RouteNames.BlockProvider_Find_Get)]
+        public IActionResult FindTrainingProvider()
+        {
+            if(TempData.ContainsKey(TempDataKeys.BlockProviderUkprnKey)) TempData.Remove(TempDataKeys.BlockProviderUkprnKey);
+            return View(new FindTrainingProviderViewModel());
+        }
+
+        [HttpPost("find-training-provider", Name = RouteNames.BlockProvider_Find_Post)]
+        public async Task<IActionResult> FindTrainingProvider(FindTrainingProviderEditModel model)
+        {
+            if (ModelState.IsValid == false)
+            {
+                return View(new FindTrainingProviderViewModel() { Ukprn = model.Ukprn, Postcode = model.Postcode });
+            }
+            var isBlocked = await _orchestrator.IsProviderAlreadyBlocked(model.Ukprn.GetValueOrDefault());
+
+            TempData[TempDataKeys.BlockProviderUkprnKey] = model.Ukprn;
+
+            if(isBlocked)
+            {
+                return RedirectToRoute(RouteNames.BlockProvider_AlreadyBlocked_Get);
+            }
+
+            return RedirectToRoute(RouteNames.BlockProvider_Confirm_Get);
+        }
+
+        [HttpGet("already-blocked", Name = RouteNames.BlockProvider_AlreadyBlocked_Get)]
+        public async Task<IActionResult> ProviderAlreadyBlocked()
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+            TempData.Remove(TempDataKeys.BlockProviderUkprnKey);
+
+            var vm = await _orchestrator.GetProviderAlreadyBlockedViewModelAsync(ukprn);
+            return View(vm);
+        }
+
+        [HttpGet("confirm-blocking", Name = RouteNames.BlockProvider_Confirm_Get)]
+        public async Task<IActionResult> ConfirmTrainingProviderBlocking()
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+
+            var vm = await _orchestrator.GetConfirmTrainingProviderBlockingViewModelAsync(ukprn);
+            return View(vm);
+        }
+
+        [HttpPost("confirm-blocking", Name = RouteNames.BlockProvider_Confirm_Post)]
+        public IActionResult ConfirmTrainingProviderBlocking_Post()
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+
+            return RedirectToRoute(RouteNames.BlockProvider_Consent_Get);
+        }
+
+        [HttpGet("consent-blocking", Name = RouteNames.BlockProvider_Consent_Get)]
+        public async Task<IActionResult> ConsentForProviderBlocking()
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+
+            var vm = await _orchestrator.GetConsentForProviderBlockingViewModelAsync(ukprn);
+            return View(vm);
+        }
+
+        [HttpPost("consent-blocking", Name = RouteNames.BlockProvider_Consent_Post)]
+        public async Task<IActionResult> ConsentForProviderBlocking(ConsentForProviderBlockingEditModel model)
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+
+            if (ModelState.IsValid == false)
+            {
+                var vm = await _orchestrator.GetConsentForProviderBlockingViewModelAsync(ukprn);
+                return View(vm);
+            }
+            
+            await _orchestrator.BlockProviderAsync(ukprn, model.Reason, User.GetVacancyUser());
+
+            return RedirectToRoute(RouteNames.BlockProvider_Acknowledgement_Get);
+        }
+
+        [HttpGet("blocking-acknowledgement", Name = RouteNames.BlockProvider_Acknowledgement_Get)]
+        public async Task<IActionResult> ProviderBlockedAcknowledgement()
+        {
+            var data = TempData.Peek(TempDataKeys.BlockProviderUkprnKey)?.ToString();
+            if(long.TryParse(data, out var ukprn) == false) return BadRequest();
+            TempData.Remove(TempDataKeys.BlockProviderUkprnKey);
+
+            var vm = await _orchestrator.GetAcknowledgementViewModelAsync(ukprn);
+            return View(vm);
+        }
+    }
+}

--- a/src/QA/QA.Web/Orchestrators/BlockedOrganisationsOrchestrator.cs
+++ b/src/QA/QA.Web/Orchestrators/BlockedOrganisationsOrchestrator.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+using Esfa.Recruit.Shared.Web.Extensions;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
+using Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
+
+namespace Esfa.Recruit.QA.Web.Orchestrators
+{
+    public class BlockedOrganisationsOrchestrator
+    {
+        private readonly IBlockedOrganisationQuery _blockedOrganisationQuery;
+        private readonly IQueryStoreReader _queryStore;
+        private readonly IMessaging _messaging;
+        private readonly ITimeProvider _timeProvider;
+        private readonly ITrainingProviderService _trainingProviderService;
+        public BlockedOrganisationsOrchestrator(
+            IBlockedOrganisationQuery blockedOrganisationQuery, IQueryStoreReader queryStore,
+            IMessaging messaging, ITimeProvider timeProvider, ITrainingProviderService trainingProviderService)
+        {
+            _blockedOrganisationQuery = blockedOrganisationQuery;
+            _queryStore = queryStore;
+            _messaging = messaging;
+            _timeProvider = timeProvider;
+            _trainingProviderService = trainingProviderService;
+        }
+
+        public async Task<ConfirmTrainingProviderBlockingViewModel> GetConfirmTrainingProviderBlockingViewModelAsync(long ukprn)
+        {
+            var providerDetailTask = _trainingProviderService.GetProviderAsync(ukprn);
+            var providerEditVacancyInfoTask = _queryStore.GetProviderVacancyDataAsync(ukprn);
+            await Task.WhenAll(providerEditVacancyInfoTask, providerDetailTask);
+            var providerDetail = providerDetailTask.Result;             
+            var providerVacancyInfo = providerEditVacancyInfoTask.Result;
+
+            var permissionCount = 0;
+            if(providerVacancyInfo?.Employers != null)
+            {
+                permissionCount = providerVacancyInfo.Employers.SelectMany(e => e.LegalEntities).Count();
+            }
+            
+            return ConvertToConfirmViewModel(providerDetail, permissionCount);
+        }
+        public async Task<ConsentForProviderBlockingViewModel> GetConsentForProviderBlockingViewModelAsync(long ukprn)
+        {
+            var providerDetailTask = _trainingProviderService.GetProviderAsync(ukprn);
+            var providerEditVacancyInfoTask = _queryStore.GetProviderVacancyDataAsync(ukprn);
+            await Task.WhenAll(providerEditVacancyInfoTask, providerDetailTask);
+            var providerDetail = providerDetailTask.Result;             
+            var providerVacancyInfo = providerEditVacancyInfoTask.Result;
+
+            var permissionCount = 0;
+            if(providerVacancyInfo?.Employers != null)
+            {
+                permissionCount = providerVacancyInfo.Employers.SelectMany(e => e.LegalEntities).Count();
+            }
+            
+            return ConvertToConsentViewModel(providerDetail, permissionCount);
+        }
+
+        public Task BlockProviderAsync(long ukprn, string reason, VacancyUser user)
+        {
+            var command = new BlockProviderCommand(ukprn, user, _timeProvider.Now, reason);
+            return _messaging.SendCommandAsync(command);
+        }
+
+        public async Task<ProviderBlockedAcknowledgementViewModel> GetAcknowledgementViewModelAsync(long ukprn)
+        {
+            var providerDetail = await _trainingProviderService.GetProviderAsync(ukprn);
+
+            return new ProviderBlockedAcknowledgementViewModel 
+            {
+                Name = providerDetail.Name,
+                Ukprn = ukprn
+            };
+        }
+
+        public async Task<bool> IsProviderAlreadyBlocked(long ukprn)
+        {
+            var blockedOrganisation = await _blockedOrganisationQuery.GetByOrganisationIdAsync(ukprn.ToString());
+            return blockedOrganisation != null;
+        }
+
+        public async Task<ProviderAlreadyBlockedViewModel> GetProviderAlreadyBlockedViewModelAsync(long ukprn)
+        {
+            var provider = await _trainingProviderService.GetProviderAsync(ukprn);
+            return new ProviderAlreadyBlockedViewModel{ Ukprn = ukprn, Name = provider.Name };
+        }
+
+        public async Task<BlockedOrganisationsViewModel> GetBlockedOrganisationsViewModel()
+        {
+            var blockedProviders = await _queryStore.GetBlockedProvidersAsync();
+
+            if (blockedProviders?.Data == null) return new BlockedOrganisationsViewModel();
+
+            var blockedOrganisationViewModels = new List<BlockedOrganisationViewModel>();
+
+            foreach(var provider in blockedProviders.Data)
+            {
+                blockedOrganisationViewModels.Add(ConvertToBlockedOrganisationViewModel(provider));
+            }
+
+            foreach( var vm in blockedOrganisationViewModels)
+            {
+                var ukprn = long.Parse(vm.OrganisationId);
+                var prov = await _trainingProviderService.GetProviderAsync(ukprn);
+                vm.OrganisationName = prov?.Name;
+                vm.Postcode = prov?.Address?.Postcode;
+            }
+
+            return new BlockedOrganisationsViewModel { BlockedOrganisations = blockedOrganisationViewModels };
+        }
+
+        private BlockedOrganisationViewModel ConvertToBlockedOrganisationViewModel(BlockedOrganisationSummary summary) 
+        {
+            return new BlockedOrganisationViewModel
+            {
+                OrganisationId = summary.BlockedOrganisationId,
+                BlockedOn = summary.BlockedDate.ToUkTime().AsGdsDateTime(),
+                BlockedBy = summary.BlockedByUser
+            };
+        }
+
+        private ConfirmTrainingProviderBlockingViewModel ConvertToConfirmViewModel(TrainingProvider provider, int permissionCount)
+        {
+            return new ConfirmTrainingProviderBlockingViewModel
+            {
+                Ukprn = provider.Ukprn.GetValueOrDefault(),
+                Name = provider.Name,
+                Address = provider.Address.ToAddressString(),
+                PermissionCount = permissionCount
+            };
+        }
+        private ConsentForProviderBlockingViewModel ConvertToConsentViewModel(TrainingProvider provider, int permissionCount)
+        {
+            return new ConsentForProviderBlockingViewModel
+            {
+                Name = provider.Name,
+                PermissionCount = permissionCount
+            };
+        }
+    }
+}

--- a/src/QA/QA.Web/Orchestrators/DashboardOrchestrator.cs
+++ b/src/QA/QA.Web/Orchestrators/DashboardOrchestrator.cs
@@ -33,8 +33,8 @@ namespace Esfa.Recruit.Qa.Web.Orchestrators
             var reviews = await _vacancyClient.GetDashboardAsync();
             var vm = MapToViewModel(reviews);
 
-            vm.DisplayInProgressVacancies = await _userAuthorizationService.IsTeamLeadAsync(user);
-            if (vm.DisplayInProgressVacancies)
+            vm.IsUserAdmin = await _userAuthorizationService.IsTeamLeadAsync(user);
+            if (vm.IsUserAdmin)
             {
                 var inProgressSummaries = await _vacancyClient.GetVacancyReviewsInProgressAsync();
 

--- a/src/QA/QA.Web/Startup.ConfigureServices.cs
+++ b/src/QA/QA.Web/Startup.ConfigureServices.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Qa.Web.Orchestrators.Reports;
 using Esfa.Recruit.Qa.Web.Security;
 using Esfa.Recruit.QA.Web.Configuration;
 using Esfa.Recruit.QA.Web.Filters;
+using Esfa.Recruit.QA.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.Configuration;
 using Esfa.Recruit.Shared.Web.Mappers;
 using Esfa.Recruit.Shared.Web.RuleTemplates;
@@ -73,6 +74,8 @@ namespace Esfa.Recruit.Qa.Web
             services.AddScoped<ReviewOrchestrator>();
             services.AddScoped<ReportDashboardOrchestrator>();
             services.AddScoped<ApplicationsReportOrchestrator>();
+            services.AddScoped<BlockedOrganisationsOrchestrator>();
+            
             services.AddScoped<ReportConfirmationOrchestrator>();
             services.AddTransient<UserAuthorizationService>();
 

--- a/src/QA/QA.Web/ViewModels/DashboardViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/DashboardViewModel.cs
@@ -20,9 +20,9 @@ namespace Esfa.Recruit.Qa.Web.ViewModels
         public bool DisplayNoSearchResultsMessage => DisplayLastSearchTerm && !SearchResults.Any();
         public bool DisplaySearchResults => DisplayLastSearchTerm && SearchResults.Any();
         public bool HasDashboardMessage => string.IsNullOrWhiteSpace(DashboardMessage) == false;
-        public bool DisplayInProgressVacancies { get; set; }
+        public bool IsUserAdmin { get; set; }
         public List<VacancyReviewSearchResultViewModel> InProgressVacancies { get; set; } = new List<VacancyReviewSearchResultViewModel>();
-        public bool DisplayNoInProgressVacanciesMessage => DisplayInProgressVacancies && !InProgressVacancies.Any();
-        public bool DisplayInProgressResults => DisplayInProgressVacancies && InProgressVacancies.Any();
+        public bool DisplayNoInProgressVacanciesMessage => IsUserAdmin && !InProgressVacancies.Any();
+        public bool DisplayInProgressResults => IsUserAdmin && InProgressVacancies.Any();
     }
 }

--- a/src/QA/QA.Web/ViewModels/ManageProvider/BlockedOrganisationViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/BlockedOrganisationViewModel.cs
@@ -1,0 +1,11 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class BlockedOrganisationViewModel
+    {
+        public string OrganisationId { get; set; }
+        public string OrganisationName { get; set; }
+        public string Postcode { get; set; }
+        public string BlockedOn { get; set; }
+        public string BlockedBy { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/BlockedOrganisationsViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/BlockedOrganisationsViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class BlockedOrganisationsViewModel
+    {
+        public List<BlockedOrganisationViewModel> BlockedOrganisations { get; set; } = new List<BlockedOrganisationViewModel>();
+        public bool HasBlockedOrganisations => BlockedOrganisations.Count > 0;
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/ConfirmTrainingProviderBlockingViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/ConfirmTrainingProviderBlockingViewModel.cs
@@ -1,0 +1,11 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class ConfirmTrainingProviderBlockingViewModel
+    {
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public long Ukprn { get; set; }
+        public int PermissionCount { get; set; }
+        public bool ShowPermissionsMessage => PermissionCount > 0;
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/ConsentForProviderBlockingEditModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/ConsentForProviderBlockingEditModel.cs
@@ -1,0 +1,8 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class ConsentForProviderBlockingEditModel
+    {
+        public bool HasConsent { get; set; }
+        public string Reason { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/ConsentForProviderBlockingViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/ConsentForProviderBlockingViewModel.cs
@@ -1,0 +1,11 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class ConsentForProviderBlockingViewModel
+    {
+        public string Name { get; set; }
+        public int PermissionCount { get; set; }
+        public bool ShowPermissionsMessage => PermissionCount > 0;
+        public bool HasConsent { get; set; }
+        public string Reason { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/FindTrainingProviderEditModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/FindTrainingProviderEditModel.cs
@@ -1,0 +1,8 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class FindTrainingProviderEditModel
+    {
+        public long? Ukprn { get; set; }
+        public string Postcode { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/FindTrainingProviderViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/FindTrainingProviderViewModel.cs
@@ -1,0 +1,8 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class FindTrainingProviderViewModel
+    {
+        public long? Ukprn { get; set; }
+        public string Postcode { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/ProviderAlreadyBlockedViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/ProviderAlreadyBlockedViewModel.cs
@@ -1,0 +1,8 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class ProviderAlreadyBlockedViewModel
+    {
+        public string Name { get; set; }
+        public long Ukprn { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/ProviderBlockedAcknowledgementViewModel.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/ProviderBlockedAcknowledgementViewModel.cs
@@ -1,0 +1,8 @@
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+{
+    public class ProviderBlockedAcknowledgementViewModel
+    {
+        public string Name { get; set; }
+        public long Ukprn { get; set; }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/Validations/ConsentForProviderBlockingEditModelValidator.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/Validations/ConsentForProviderBlockingEditModelValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider.Validations
+{
+    public class ConsentForProviderBlockingEditModelValidator : AbstractValidator<ConsentForProviderBlockingEditModel>
+    {
+        public ConsentForProviderBlockingEditModelValidator()
+        {
+            RuleFor(m => m.HasConsent)
+                .Equal(true)
+                .WithMessage("Please tick the box to continue");
+            RuleFor(m => m.Reason)
+                .NotEmpty()
+                .WithMessage("Please enter a reason");
+        }
+    }
+}

--- a/src/QA/QA.Web/ViewModels/ManageProvider/Validations/FindTrainingProviderEditModelValidator.cs
+++ b/src/QA/QA.Web/ViewModels/ManageProvider/Validations/FindTrainingProviderEditModelValidator.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
+using FluentValidation;
+using Esfa.Recruit.Shared.Web.Extensions;
+
+namespace Esfa.Recruit.QA.Web.ViewModels.ManageProvider.Validations
+{
+    public class FindTrainingProviderEditModelValidator : AbstractValidator<FindTrainingProviderEditModel>
+    {
+        public FindTrainingProviderEditModelValidator(ITrainingProviderService service)
+        {
+            RuleFor(m => m.Ukprn)
+                .NotNull()
+                .WithMessage("Please add a UKPRN to continue")
+                .GreaterThan(10000000)
+                .WithMessage("Please add a valid UKPRN to continue");
+
+            RuleFor(m => m.Postcode)
+                .NotEmpty()
+                .WithMessage("Please add a postcode to continue");
+
+            When(x => x.Ukprn != null && string.IsNullOrWhiteSpace(x.Postcode) == false, () => 
+            {
+                RuleFor(m => m.Ukprn)
+                    .MustAsync((model, ukprn, cancellation) => DoesProviderExists(model, service))
+                    .WithMessage("Please add a valid postcode and UKPRN to continue");
+            });
+        }
+
+        private async Task<bool> DoesProviderExists(FindTrainingProviderEditModel model, ITrainingProviderService service)
+        {
+            if(model.Ukprn == null) return true;
+            var provider = await service.GetProviderAsync(model.Ukprn.GetValueOrDefault());
+            return provider != null && provider.Address.Postcode.IsEqualWithoutSymbols(model.Postcode);
+        }
+    }
+}

--- a/src/QA/QA.Web/Views/BlockedOrganisations/ConfirmTrainingProviderBlocking.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ConfirmTrainingProviderBlocking.cshtml
@@ -1,0 +1,27 @@
+@using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+@model ConfirmTrainingProviderBlockingViewModel;
+<div class="govuk-grid-row">
+    <div class="govuk-column-two-thirds">
+        <h1 class="govuk-heading-xl">Confirm the training provider you are removing</h1>
+        <div class="verification-summary">
+            <h2 class="govuk-heading-m">
+                @Model.Name
+            </h2>
+            <span class="govuk-body">
+                @Model.Address
+                <br />UKPRN: @Model.Ukprn
+            </span>
+            <div asp-show="@Model.ShowPermissionsMessage">
+                <span class="govuk-body">@Model.PermissionCount employers have given @Model.Name permission to recruit apprentices.</span>                
+            </div>
+            <p class="govuk-body govuk-!-margin-bottom-0">
+                <a asp-route="@RouteNames.BlockProvider_Find_Get" class="govuk-link">Search again</a>
+            </p>
+        </div>
+        <form asp-route="@RouteNames.BlockProvider_Confirm_Post">
+            <input type="hidden" asp-for="Ukprn">
+            <button type="submit" class="govuk-button">Confirm and continue</button>
+            <a asp-route="@RouteNames.BlockProvider_Find_Get" class="govuk-link das-button-link">Cancel</a>
+        </form>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/BlockedOrganisations/ConsentForProviderBlocking.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ConsentForProviderBlocking.cshtml
@@ -1,0 +1,42 @@
+@using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+@model ConsentForProviderBlockingViewModel;
+<div class="govuk-grid-row">
+    <div class="govuk-column-two-thirds govuk-body">
+        <h1 class="govuk-heading-xl">Remove @Model.Name from the recruitment service</h1>
+        <p>Removing a training provider will do the following:</p>
+        <ul class="list list-bullet">
+            <li asp-show="@Model.ShowPermissionsMessage">no longer be able to recruit on behalf of @Model.PermissionCount employers</li>
+            <li asp-show="@Model.ShowPermissionsMessage">not be able to create or manage vacancies on the behalf of @Model.PermissionCount employers</li>
+            <li>any vacancies created by @Model.Name will be transferred to the employer</li>
+            <li>no longer be able to access the recruitment service. Can still access the rest of the account</li>
+            <li>live vacancies using @Model.Name as the training provider will close</li>
+        </ul>
+        <form asp-route="@RouteNames.BlockProvider_Consent_Post">
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-label govuk-!-font-weight-bold"></legend>
+                    <span esfa-validation-message-for="HasConsent" class="govuk-error-message"></span>
+                    <div class="govuk-checkboxes" data-module="checkboxes">
+                        <div class="govuk-checkboxes__item">
+                            <input asp-for="HasConsent" class="govuk-checkboxes__input" data-aria-controls="consent-conditional" id="consent" type="checkbox" value="true" >
+                            <label asp-for="HasConsent" class="govuk-label govuk-checkboxes__label">I understand the above and wish to remove this training provider</label>
+                        </div>
+                        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="consent-conditional">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" asp-for="Reason">
+                                    Why do you want to remove this training provider?
+                                </label>
+                                <span esfa-validation-message-for="Reason" class="govuk-error-message"></span>
+                                <textarea asp-for="Reason" data-val-length-max="200" class="govuk-textarea govuk-!-width-three-quarters" rows="5" type="text"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="govuk-button warning-button">Remove training provider</button>
+                <a asp-route="@RouteNames.BlockedOrganisations_Get" class="govuk-link das-button-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/BlockedOrganisations/FindTrainingProvider.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/FindTrainingProvider.cshtml
@@ -1,0 +1,33 @@
+@using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+
+@model FindTrainingProviderViewModel
+<div class="govuk-grid-row">
+    <div class="govuk-column-two-thirds">
+        <h1 class="govuk-heading-xl">Which training provider would you like to remove?</h1>
+        <p class="govuk-body">Removing a training provider will prevent them from using the recruitment service.</p>
+        <form asp-route="@RouteNames.BlockProvider_Find_Post">
+            <div class="govuk-form-group">
+                <label class="govuk-label" asp-for="Ukprn">
+                    Provider UKPRN
+                </label>
+                <span class="govuk-hint">For example, ‘10002343’.</span>
+                <span esfa-validation-message-for="Ukprn" class="govuk-error-message"></span>
+                <input asp-for="Ukprn" type="text" maxlength="8" class="govuk-input govuk-input--width-10">
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" asp-for="Postcode">
+                    Provider postcode
+                    <span class="govuk-hint">
+                    For example, ‘CV1 2RT’.
+                    </span>
+                </label>
+                <span esfa-validation-message-for="Postcode" class="govuk-error-message"></span>
+                <input asp-for="Postcode" type="text" maxlength="8" class="govuk-input govuk-input-width-5">
+            </div>
+            <div class="govuk-form-group">
+                <button type="submit" class="govuk-button">Find provider</button>
+                <a asp-route="@RouteNames.BlockedOrganisations_Get" class="govuk-link das-button-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/BlockedOrganisations/Index.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/Index.cshtml
@@ -1,0 +1,47 @@
+@using Esfa.Recruit.QA.Web.ViewModels.ManageProvider
+@model BlockedOrganisationsViewModel
+<div asp-hide="Model.HasBlockedOrganisations" class="grid-row">
+    <div class="column-two-thirds">
+        <p><a asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6">Return to dashboard</a></p>
+        <h1 class="govuk-heading-xl">Remove a training provider from the recruitment service</h1>
+        <p class="govuk-body">You can remove a training provider and prevent them using the recruitment service. They will no longer be able to recruit on behalf of employers.</p>
+        <a asp-route="@RouteNames.BlockProvider_Find_Get" class="govuk-button">Find training provider</a>
+    </div>
+</div>
+
+<div asp-show="Model.HasBlockedOrganisations" class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p><a asp-route="@RouteNames.Dashboard_Index_Get" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6">Return to dashboard</a></p>
+        <h1 class="govuk-heading-xl">Removed training providers</h1>
+        <p>
+            <a asp-route="@RouteNames.BlockProvider_Find_Get" class="govuk-button">Find a provider</a>
+        </p>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0"> training providers removed from the recruitment service</h2>
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">Provider</th>
+                        <th class="govuk-table__header">Postcode</th>
+                        <th class="govuk-table__header">Removed on</th>
+                        <th class="govuk-table__header">Removed by</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                @foreach (var organisation in Model.BlockedOrganisations)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">@organisation.OrganisationName</td>
+                        <td class="govuk-table__cell">@organisation.Postcode</td>
+                        <td class="govuk-table__cell">@organisation.BlockedOn</td>
+                        <td class="govuk-table__cell">@organisation.BlockedBy</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/BlockedOrganisations/ProviderAlreadyBlocked.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ProviderAlreadyBlocked.cshtml
@@ -1,0 +1,14 @@
+@using Esfa.Recruit.QA.Web.ViewModels.ManageProvider;
+@model ProviderAlreadyBlockedViewModel;
+<div class="govuk-grid-row">
+    <div class="govuk-column-two-thirds">
+        <h1 class="govuk-heading-xl">You have already removed @Model.Name (@Model.Ukprn)
+        </h1>
+    </div>
+</div>
+<div class="govuk-grid-row">
+    <div class="govuk-column-two-thirds">
+        <a asp-route="@RouteNames.BlockProvider_Find_Get" class="govuk-button">Search again</a>
+        <a asp-route="@RouteNames.BlockedOrganisations_Get" class="govuk-link das-button-link">Cancel</a>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/BlockedOrganisations/ProviderBlockedAcknowledgement.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ProviderBlockedAcknowledgement.cshtml
@@ -1,0 +1,27 @@
+@model Esfa.Recruit.QA.Web.ViewModels.ManageProvider.ProviderBlockedAcknowledgementViewModel
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">
+                Removed training provider
+            </h1>
+            <div class="govuk-panel__body">
+                <p>
+                    @Model.Name <br>
+                    <strong class="govuk-!-font-weight-bold">UKPRN:@Model.Ukprn</strong>
+                </p>
+            </div>
+        </div>
+        <div>
+            <p class="govuk-body">
+                It may take up to 2 hours to remove this training provider. 
+            </p>
+            <p class="govuk-body">
+                We will email the employers and let them know about this change.
+            </p>
+        </div>
+        <div>
+            <a asp-route="@RouteNames.BlockedOrganisations_Get" class="govuk-button">Back to permissions dashboard</a>
+        </div>
+    </div>
+</div>

--- a/src/QA/QA.Web/Views/Dashboard/Index.cshtml
+++ b/src/QA/QA.Web/Views/Dashboard/Index.cshtml
@@ -50,7 +50,7 @@
     </div>
 </div>
 
-<h2 asp-show="@Model.DisplayInProgressVacancies" class="govuk-heading-m govuk-!-margin-bottom-0">In-progress vacancies</h2>
+<h2 asp-show="@Model.IsUserAdmin" class="govuk-heading-m govuk-!-margin-bottom-0">In-progress vacancies</h2>
 
 <span asp-show="@Model.DisplayNoInProgressVacanciesMessage" class="govuk-body">There are no vacancy reviews currently in progress</span>
 
@@ -139,3 +139,12 @@
         <p class="govuk-body">Create and download reports for your vacancies for any period of time.</p>
     </div>
 </div>
+<div asp-show="@Model.IsUserAdmin" class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-s">
+            <a class="govuk-link  govuk-link--no-visited-state" asp-route="@RouteNames.BlockedOrganisations_Get">Remove training provider</a>
+        </h3>
+        <p class="govuk-body">Remove a training provider</p>
+    </div>
+</div>
+

--- a/src/QA/QA.Web/wwwroot/css/application.css
+++ b/src/QA/QA.Web/wwwroot/css/application.css
@@ -375,3 +375,56 @@ mce-tinymce {
       #global-outage-message p {
         font-size: 16px;
         line-height: 1.25; } }
+
+/*** Verification summary ***/
+.verification-summary {
+  background-color: #f4f4f4;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding: 15px 10px
+}
+
+@media (min-width: 641px) {
+  .verification-summary {
+      background-color: #f4f4f4;
+      margin-top: 30px;
+      margin-bottom: 30px;
+      padding: 20px 15px 15px
+  }
+}
+
+.verification-summary .error-summary-heading {
+  margin-top: 0
+}
+
+.verification-summary p {
+  margin-bottom: 10px
+}
+
+.verification-summary .verification-summary-list {
+  padding-left: 0
+}
+
+@media (min-width: 641px) {
+  .verification-summary .verification-summary-list li {
+      margin-bottom: 5px
+  }
+}
+
+.verification-summary .verification-summary-list a {
+  color: #b10e1e;
+  font-weight: 700;
+  text-decoration: underline
+}
+
+.verification-summary .govuk-heading-s {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  color: #6F777B;
+  font-weight: 400;
+}
+
+.warning-button {
+  background-color: #b10e1e;
+  box-shadow: 0 2px 0 #000000;
+}

--- a/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
+++ b/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
@@ -78,5 +78,11 @@ namespace Esfa.Recruit.Shared.Web.Extensions
         {
             return text.Replace(", and ", " and ");
         }
+		
+        public static bool IsEqualWithoutSymbols(this string source, string target)
+        {
+            if (target == null) return false;
+            return String.Compare(source, target, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols) == 0;
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/BlockProviderCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/BlockProviderCommandHandler.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
+{
+    public class BlockProviderCommandHandler : IRequestHandler<BlockProviderCommand>
+    {
+        private readonly ILogger<BlockProviderCommandHandler> _logger;
+        private readonly IBlockedOrganisationQuery _blockedOrganisationQuery;
+        private readonly IBlockedOrganisationRepository _blockedOrganisationRepository;
+        private readonly IMessaging _messaging;
+        public BlockProviderCommandHandler(
+            ILogger<BlockProviderCommandHandler> logger,
+            IBlockedOrganisationQuery blockedOrganisationQuery,
+            IBlockedOrganisationRepository blockedOrganisationRepository,
+            IMessaging messaging)
+        {
+            _logger = logger;
+            _blockedOrganisationQuery = blockedOrganisationQuery;
+            _blockedOrganisationRepository = blockedOrganisationRepository;
+            _messaging = messaging;
+        }
+        
+        public async Task Handle(BlockProviderCommand message, CancellationToken cancellationToken)
+        {
+            var blockedOrg = await _blockedOrganisationQuery.GetByOrganisationIdAsync(message.Ukprn.ToString());
+            if (blockedOrg?.BlockedStatus == BlockedStatus.Blocked)
+            {
+                _logger.LogWarning($"Ignoring request to block provider with ukprn {message.Ukprn} as the provider is already blocked.");
+                return;
+            }
+
+            await _blockedOrganisationRepository.CreateAsync(ConvertToBlockedOrganisation(message));
+
+            await _messaging.PublishEvent(new ProviderBlockedEvent()
+            {
+                Ukprn = message.Ukprn,
+                BlockedDate = message.BlockedDate,
+                QaVacancyUser = message.QaVacancyUser
+            });
+        }
+
+        private static BlockedOrganisation ConvertToBlockedOrganisation(BlockProviderCommand message)
+        {
+            return new BlockedOrganisation()
+            {
+                BlockedStatus = BlockedStatus.Blocked,
+                OrganisationType = OrganisationType.Provider,
+                OrganisationId = message.Ukprn.ToString(),
+                UpdatedByUser = message.QaVacancyUser,
+                UpdatedDate = message.BlockedDate,
+                Reason = message.Reason
+            };
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
@@ -17,7 +17,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
         public Task Handle(CloseVacancyCommand message, CancellationToken cancellationToken)
         {
-            return _vacancyService.CloseVacancyImmediately(message.VacancyId, message.User);
+            return _vacancyService.CloseVacancyImmediately(message.VacancyId, message.User, message.ClosureReason);
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/PatchVacancyTrainingProviderCommandHandler.cs
@@ -65,6 +65,11 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
         private void PatchVacancyTrainingProvider(Esfa.Recruit.Vacancies.Client.Domain.Entities.Vacancy vacancy, Esfa.Recruit.Vacancies.Client.Domain.Entities.TrainingProvider tp)
         {
+            if (tp == null) 
+            {
+                _logger.LogError($"Unable to patch training provider for vacancy {vacancy.VacancyReference}");
+                return;
+            }
             vacancy.TrainingProvider.Name = tp.Name;
             vacancy.TrainingProvider.Address = tp.Address;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/BlockProviderCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/BlockProviderCommand.cs
@@ -1,0 +1,22 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Commands
+{
+    public class BlockProviderCommand : ICommand, IRequest
+    {
+        public long Ukprn { get; private set; }
+        public VacancyUser QaVacancyUser { get; private set; }
+        public DateTime BlockedDate { get; private set; }
+        public string Reason { get; private set; }
+        public BlockProviderCommand(long ukprn, VacancyUser qaVacancyUser, DateTime blockedDate, string blockReason)
+        {
+            Ukprn = ukprn;
+            QaVacancyUser = qaVacancyUser;
+            BlockedDate = blockedDate;
+            Reason = blockReason;
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
@@ -9,5 +9,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
     {
         public Guid VacancyId { get; set; }
         public VacancyUser User { get; internal set; }
+        public ClosureReason ClosureReason { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/EventHandlers/RePublishEventToEventStoreEventHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/EventHandlers/RePublishEventToEventStoreEventHandler.cs
@@ -16,7 +16,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.EventHandlers
                                             INotificationHandler<VacancyReviewReferredEvent>,
                                             INotificationHandler<SetupEmployerEvent>,
                                             INotificationHandler<SetupProviderEvent>,
-                                            INotificationHandler<VacancyReviewCreatedEvent>
+                                            INotificationHandler<VacancyReviewCreatedEvent>,
+                                            INotificationHandler<ProviderBlockedEvent>,
+                                            INotificationHandler<ProviderBlockedOnLegalEntityEvent>,
+                                            INotificationHandler<ProviderBlockedOnVacancyEvent>
     {
         private readonly ILogger<RePublishEventToEventStoreEventHandler> _logger;
         private readonly IEventStore _eventStore;
@@ -49,6 +52,15 @@ namespace Esfa.Recruit.Vacancies.Client.Application.EventHandlers
             => HandleUsingEventStore(notification);
 
         public Task Handle(VacancyReviewCreatedEvent notification, CancellationToken cancellationToken)
+            => HandleUsingEventStore(notification);
+
+        public Task Handle(ProviderBlockedEvent notification, CancellationToken cancellationToken)
+            => HandleUsingEventStore(notification);
+
+        public Task Handle(ProviderBlockedOnLegalEntityEvent notification, CancellationToken cancellationToken)
+            => HandleUsingEventStore(notification);
+
+        public Task Handle(ProviderBlockedOnVacancyEvent notification, CancellationToken cancellationToken)
             => HandleUsingEventStore(notification);
 
         private async Task HandleUsingEventStore(IEvent @event)

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
@@ -7,7 +7,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
     public interface IVacancyService
     {
         Task CloseExpiredVacancy(Guid vacancyId);
-        Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user);
+        Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason);
         Task PerformRulesCheckAsync(Guid reviewId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
@@ -56,13 +56,14 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
             });
         }
 
-        public async Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user)
+        public async Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason)
         {
             _logger.LogInformation("Closing vacancy {vacancyId} by user {userEmail}.", vacancyId, user.Email);
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyId);
 
             vacancy.ClosedByUser = user;
+            vacancy.ClosureReason = closureReason;
 
             await CloseVacancyAsync(vacancy);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ManualQaOutcome.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ManualQaOutcome.cs
@@ -4,6 +4,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
     {
         Approved,
         Referred,
-        Transferred
+        Transferred,
+        Withdrawn
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyReview.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/VacancyReview.cs
@@ -60,6 +60,8 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         /// </summary>
         public bool CanUnassign => Status == ReviewStatus.UnderReview && ReviewedByUser != null;
 
+        public bool IsPending => Status == ReviewStatus.New || Status == ReviewStatus.PendingReview;
+
         public RuleSetOutcome AutomatedQaOutcome { get; set; }
         public IEnumerable<RuleOutcomeIndicator> AutomatedQaOutcomeIndicators { get; set; } = new List<RuleOutcomeIndicator>();        
     }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedEvent.cs
@@ -1,0 +1,15 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    public class ProviderBlockedEvent : EventBase, INotification
+    {
+        public long Ukprn { get; set; }
+        public string ProviderName { get; set; }
+        public DateTime BlockedDate { get; set; }
+        public VacancyUser QaVacancyUser { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedOnLegalEntityEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedOnLegalEntityEvent.cs
@@ -1,0 +1,12 @@
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    public class ProviderBlockedOnLegalEntityEvent : EventBase, INotification
+    {
+        public long Ukprn { get; set; }
+        public string EmployerAccountId { get; set; }
+        public long LegalEntityId { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedOnVacancyEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/ProviderBlockedOnVacancyEvent.cs
@@ -1,0 +1,16 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    public class ProviderBlockedOnVacancyEvent : EventBase, INotification
+    {
+        public Guid VacancyId { get; set; }
+        public VacancyUser QaVacancyUser { get; set; }
+        public long Ukprn { get; set; }
+        public DateTime BlockedDate { get; set; }
+        public long VacancyReference { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Models/ProviderVacancySummary.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Models/ProviderVacancySummary.cs
@@ -1,0 +1,13 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Models
+{
+    public class ProviderVacancySummary
+    {
+        public Guid Id { get; set; }
+        public OwnerType VacancyOwner { get; set; }
+        public string EmployerAccountId { get; set; }
+        public long VacancyReference { get; internal set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyQuery.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyQuery.cs
@@ -2,6 +2,7 @@
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Models;
 
 namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
 {
@@ -16,5 +17,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
         Task<IEnumerable<string>> GetDistinctVacancyOwningEmployerAccountsAsync();
         Task<IEnumerable<long>> GetDistinctVacancyOwningProviderAccountsAsync();
         Task<IEnumerable<long>> GetAllVacancyReferencesAsync();
+        Task<IEnumerable<ProviderVacancySummary>> GetVacanciesAssociatedToProvider(long ukprn);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -115,7 +115,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             if (!TryGetVacancyReference(searchTerm, out var vacancyReference)) return result;
 
             var review = await _vacancyReviewQuery.GetLatestReviewByReferenceAsync(vacancyReference);
-            if (review != null) result.Add(review);
+            if (review != null && review.Status != ReviewStatus.New) result.Add(review);
             
             return result;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateBlockedOrganisationList.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateBlockedOrganisationList.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Projections;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
+{
+    public class UpdateBlockedOrganisationList : INotificationHandler<ProviderBlockedEvent>
+    {
+        private readonly IBlockedOrganisationsProjectionService _projectionService;
+        public UpdateBlockedOrganisationList(IBlockedOrganisationsProjectionService projectionService)
+        {
+            _projectionService = projectionService;
+        }
+        public Task Handle(ProviderBlockedEvent notification, CancellationToken cancellationToken)
+        {
+            return _projectionService.RebuildAllBlockedOrganisationsAsync();
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyReviewRepository.cs
@@ -25,8 +25,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
         {
             var filterBuilder = Builders<VacancyReview>.Filter;
 
-            var filter = !filterBuilder.Eq(r => r.Status, ReviewStatus.New)
-                         & filterBuilder.Eq(r => r.VacancyReference, vacancyReference);
+            var filter = filterBuilder.Eq(r => r.VacancyReference, vacancyReference);
             var results = await GetVacancyReviewsAsync(filter);
             return results.OrderByDescending(r => r.CreatedDate).FirstOrDefault();
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
@@ -28,8 +28,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Failed to retrieve provider information for UKPRN: {ukprn}");
-                throw;
+                _logger.LogInformation(ex, $"Failed to retrieve provider information for UKPRN: {ukprn}");
+                return null;
             }
 
             return TrainingProviderMapper.MapFromApiProvider(provider);


### PR DESCRIPTION
### Cosmos changes
- New collection **blockedOrganisation**
- Script to update new field **ClosureReason** on closed vacancies

There are some //TODO's in this commit as some of these will be determined or fulfilled in the near future. 

The blocking of provider is initiated from BlockProviderCommandHandler which inserts a row in the blockedOrganisations collection and raises  Provider blocked domain event. The handler for the domain event then queues up all the required changes that needs to take place. This handler is not complete yet and may change post merge depending on the requirement for revoking permission. 
