### PR TITLE
ER-1337 ER-1344 - Handling unmatched training searches

### DIFF
--- a/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Training/Training.cshtml
@@ -56,7 +56,14 @@
 
             $selectElement.parents("form").on("submit",
                 function () {
-                    if ($(selectElementSelector).val() === "") {
+                    var searchedValue = $(selectElementSelector).val();
+                    var $originalSelectElementOptions = $(selectElementSelector + '-select option');
+
+                    var $selectedOption = $originalSelectElementOptions.filter(function (i, optionElement) {
+                        return optionElement.text === searchedValue;
+                    });
+
+                    if ($selectedOption.length === 0) {
                         $(selectElementSelector + '-select option[value=""]').prop('selected', true);
                     }
                 });

--- a/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
@@ -56,7 +56,14 @@
 
             $selectElement.parents("form").on("submit",
                 function () {
-                    if ($(selectElementSelector).val() === "") {
+                    var searchedValue = $(selectElementSelector).val();
+                    var $originalSelectElementOptions = $(selectElementSelector + '-select option');
+
+                    var $selectedOption = $originalSelectElementOptions.filter(function (i, optionElement) {
+                        return optionElement.text === searchedValue;
+                    });
+
+                    if ($selectedOption.length === 0) {
                         $(selectElementSelector + '-select option[value=""]').prop('selected', true);
                     }
                 });


### PR DESCRIPTION
If someone goes back to change the training and searches for 'fffffff' then the page would continue to the confirm page using their existing training.

This now defaults the selected option to the default "" if they try and submit an unmatched entry. This will then kick in the validation error.

I'm not liking Accessible Autocomplete. Its lacking somewhat.