### PR TITLE
ER-1445 refactor close vacancy

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/CloseVacancyOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/CloseVacancyOrchestrator.cs
@@ -7,6 +7,8 @@ using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.Models;
 using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators
 {
@@ -14,11 +16,13 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
     {
         private readonly IEmployerVacancyClient _client;
         private readonly IRecruitVacancyClient _vacancyClient;
+        private readonly IMessaging _messaging;
 
-        public CloseVacancyOrchestrator(IEmployerVacancyClient client, IRecruitVacancyClient vacancyClient)
+        public CloseVacancyOrchestrator(IEmployerVacancyClient client, IRecruitVacancyClient vacancyClient, IMessaging messaging)
         {
             _client = client;
             _vacancyClient = vacancyClient;
+            _messaging = messaging;
         }
 
         public async Task<CloseViewModel> GetCloseViewModelAsync(VacancyRouteModel vrm)
@@ -48,7 +52,9 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             if (!vacancy.CanClose)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForClosing, vacancy.Title));
 
-            await _client.CloseVacancyAsync(vacancy.Id, user);
+             var command = new CloseVacancyCommand(m.VacancyId, user, ClosureReason.Manual);
+
+            await _messaging.SendCommandAsync(command);
 
             return new OrchestratorResponse<VacancyInfo>(new VacancyInfo
             {

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
@@ -56,9 +56,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
             tasks.AddRange(RequestEmployerCommunications(vacancies));
 
             //TODO update employer and provider dashboard
-
-            //TODO update providereditinfo... delete Employers list ???
-
+            
             await Task.WhenAll(tasks);
         }
 

--- a/src/Provider/Provider.Web/Orchestrators/CloseVacancyOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/CloseVacancyOrchestrator.cs
@@ -7,6 +7,8 @@ using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.Models;
 using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 
 namespace Esfa.Recruit.Provider.Web.Orchestrators
 {
@@ -14,11 +16,13 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
     {
         private readonly IProviderVacancyClient _client;
         private readonly IRecruitVacancyClient _vacancyClient;
+        private readonly IMessaging _messaging;
 
-        public CloseVacancyOrchestrator(IProviderVacancyClient client, IRecruitVacancyClient vacancyClient)
+        public CloseVacancyOrchestrator(IProviderVacancyClient client, IRecruitVacancyClient vacancyClient, IMessaging messaging)
         {
             _client = client;
             _vacancyClient = vacancyClient;
+            _messaging = messaging;
         }
 
         public async Task<CloseViewModel> GetCloseViewModelAsync(VacancyRouteModel vrm)
@@ -47,7 +51,9 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             if (!vacancy.CanClose)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForClosing, vacancy.Title));
 
-            await _client.CloseVacancyAsync(vacancy.Id, user);
+            var command = new CloseVacancyCommand(m.VacancyId.GetValueOrDefault(), user, ClosureReason.Manual);
+
+            await _messaging.SendCommandAsync(command);
 
             return new OrchestratorResponse<VacancyInfo>(new VacancyInfo {
                 Id = vacancy.Id,

--- a/src/QA/UnitTests/Qa.Web/Orchestrators/WithdrawVacancyOrchestrator/PostFindVacancyEditModelAsyncTests.cs
+++ b/src/QA/UnitTests/Qa.Web/Orchestrators/WithdrawVacancyOrchestrator/PostFindVacancyEditModelAsyncTests.cs
@@ -2,6 +2,7 @@
 using Esfa.Recruit.Qa.Web.Models.WithdrawVacancy;
 using Esfa.Recruit.Qa.Web.ViewModels.WithdrawVacancy;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Exceptions;
 using FluentAssertions;
@@ -22,11 +23,12 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
         public async Task ShouldReturnNotFoundIfVacancyIsInWrongState(VacancyStatus status)
         {
             var mockClient = new Mock<IQaVacancyClient>();
+            var mockMessaging = new Mock<IMessaging>();
 
             mockClient.Setup(c => c.GetVacancyAsync(VacancyReference))
                 .ReturnsAsync(new Vacancy {Status = status});
 
-            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object);
+            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object, mockMessaging.Object);
 
             var m = new FindVacancyEditModel
             {
@@ -42,11 +44,12 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
         public async Task ShouldReturnNotFoundIfVacancyDoesNotExist()
         {
             var mockClient = new Mock<IQaVacancyClient>();
+            var mockMessaging = new Mock<IMessaging>();
 
             mockClient.Setup(c => c.GetVacancyAsync(VacancyReference))
                 .ThrowsAsync(new VacancyNotFoundException("not found"));
 
-            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object);
+            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object, mockMessaging.Object);
 
             var m = new FindVacancyEditModel
             {
@@ -62,11 +65,12 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
         public async Task ShouldReturnAlreadyClosedIfVacancyIsClosed()
         {
             var mockClient = new Mock<IQaVacancyClient>();
+            var mockMessaging = new Mock<IMessaging>();
 
             mockClient.Setup(c => c.GetVacancyAsync(VacancyReference))
                 .ReturnsAsync(new Vacancy { Status = VacancyStatus.Closed });
 
-            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object);
+            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object, mockMessaging.Object);
 
             var m = new FindVacancyEditModel
             {
@@ -82,11 +86,12 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
         public async Task ShouldReturnCanCloseIfVacancyCanBeClosed()
         {
             var mockClient = new Mock<IQaVacancyClient>();
+            var mockMessaging = new Mock<IMessaging>();
 
             mockClient.Setup(c => c.GetVacancyAsync(VacancyReference))
                 .ReturnsAsync(new Vacancy { Status = VacancyStatus.Live });
 
-            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object);
+            var orch = new Esfa.Recruit.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator(mockClient.Object, mockMessaging.Object);
 
             var m = new FindVacancyEditModel
             {

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
@@ -1,6 +1,12 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,16 +14,40 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
     public class CloseVacancyCommandHandler : IRequestHandler<CloseVacancyCommand>
     {
-        private readonly IVacancyService _vacancyService;
+        private readonly ILogger<CloseVacancyCommandHandler> _logger;
+        private readonly IVacancyRepository _vacancyRepository;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IMessaging _messaging;
 
-        public CloseVacancyCommandHandler(IVacancyService vacancyService)
+        public CloseVacancyCommandHandler(ILogger<CloseVacancyCommandHandler> logger, IVacancyRepository vacancyRepository, ITimeProvider timeProvider, IMessaging messaging)
         {
-            _vacancyService = vacancyService;
+            _logger = logger;
+            _vacancyRepository = vacancyRepository;
+            _timeProvider = timeProvider;
+            _messaging = messaging;
         }
 
-        public Task Handle(CloseVacancyCommand message, CancellationToken cancellationToken)
+        public async Task Handle(CloseVacancyCommand message, CancellationToken cancellationToken)
         {
-            return _vacancyService.CloseVacancyImmediately(message.VacancyId, message.User, message.ClosureReason);
+            _logger.LogInformation("Closing vacancy {vacancyId} with reason {closureReason}.", message.VacancyId, message.ClosureReason);
+
+            var vacancy = await _vacancyRepository.GetVacancyAsync(message.VacancyId);
+
+            //When expired vacancies are being closed automatically, there is no user to associate.
+            if(message.User != null) vacancy.ClosedByUser = message.User;
+            vacancy.ClosureReason = message.ClosureReason;
+
+            vacancy.ClosedDate = _timeProvider.Now;
+            vacancy.Status = VacancyStatus.Closed;
+
+            await _vacancyRepository.UpdateAsync(vacancy);
+
+            await _messaging.PublishEvent(new VacancyClosedEvent
+            {
+                VacancyReference = vacancy.VacancyReference.Value,
+                VacancyId = vacancy.Id
+            });
+            
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
@@ -7,7 +7,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class CloseVacancyCommand : ICommand, IRequest
     {
-        public Guid VacancyId { get; set; }
+        public CloseVacancyCommand(Guid vacancyId, VacancyUser user, ClosureReason reason)
+        {
+            VacancyId = vacancyId;
+            User = user;
+            ClosureReason = reason;
+        }
+        public Guid VacancyId { get; internal set; }
         public VacancyUser User { get; internal set; }
         public ClosureReason ClosureReason { get; set; }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Threading.Tasks;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Services
 {
     public interface IVacancyService
     {
-        Task CloseExpiredVacancy(Guid vacancyId);
-        Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason);
         Task PerformRulesCheckAsync(Guid reviewId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
@@ -33,41 +33,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
             _vacancyReviewRepository = vacancyReviewRepository;
         }
 
-        public async Task CloseExpiredVacancy(Guid vacancyId)
-        {
-            _logger.LogInformation("Closing vacancy {vacancyId}.", vacancyId);
-
-            var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyId);
-
-            await CloseVacancyAsync(vacancy);
-        }
-
-        private async Task CloseVacancyAsync(Vacancy vacancy)
-        {
-            vacancy.ClosedDate = _timeProvider.Now;
-            vacancy.Status = VacancyStatus.Closed;
-
-            await _vacancyRepository.UpdateAsync(vacancy);
-
-            await _messaging.PublishEvent(new VacancyClosedEvent
-            {
-                VacancyReference = vacancy.VacancyReference.Value,
-                VacancyId = vacancy.Id
-            });
-        }
-
-        public async Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason)
-        {
-            _logger.LogInformation("Closing vacancy {vacancyId} by user {userEmail}.", vacancyId, user.Email);
-
-            var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyId);
-
-            vacancy.ClosedByUser = user;
-            vacancy.ClosureReason = closureReason;
-
-            await CloseVacancyAsync(vacancy);
-        }
-
         public async Task PerformRulesCheckAsync(Guid reviewId)
         {
             var review = await _vacancyReviewRepository.GetAsync(reviewId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -13,7 +13,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
     {
         Task<Guid> CreateVacancyAsync(string title, string employerAccountId, VacancyUser user);
         Task GenerateDashboard(string employerAccountId);
-        Task CloseVacancyAsync(Guid vacancyId, VacancyUser user);        
         Task SubmitVacancyAsync(Guid vacancyId, string employerDescription, VacancyUser user);
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<EmployerDashboard> GetDashboardAsync(string employerAccountId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
@@ -17,7 +17,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<ProviderEditVacancyInfo> GetProviderEditVacancyInfoAsync(long ukprn);
         Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId);
         Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user);
-        Task CloseVacancyAsync(Guid vacancyId, VacancyUser user);
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<Guid> CreateProviderApplicationsReportAsync(long ukprn, DateTime fromDate, DateTime toDate, VacancyUser user, string reportName);
         Task<List<ReportSummary>> GetReportsForProviderAsync(long ukprn);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
@@ -36,6 +36,5 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<Report> GetReportAsync(Guid reportId);
         void WriteReportAsCsv(Stream stream, Report report);
         Task IncrementReportDownloadCountAsync(Guid reportId);
-        Task CloseVacancyAsync(Guid vacancyId, VacancyUser user);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -258,17 +258,5 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         {
             return _reportRepository.IncrementReportDownloadCountAsync(reportId);
         }
-
-        public async Task CloseVacancyAsync(Guid vacancyId, VacancyUser user)
-        {
-            var command = new CloseVacancyCommand
-            ( 
-                vacancyId,
-                user,
-                ClosureReason.WithdrawnByQa
-            );
-
-            await _messaging.SendCommandAsync(command);
-        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -262,11 +262,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         public async Task CloseVacancyAsync(Guid vacancyId, VacancyUser user)
         {
             var command = new CloseVacancyCommand
-            {
-                VacancyId = vacancyId,
-                User = user,
-                ClosureReason = ClosureReason.WithdrawnByQa
-            };
+            ( 
+                vacancyId,
+                user,
+                ClosureReason.WithdrawnByQa
+            );
 
             await _messaging.SendCommandAsync(command);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -345,18 +345,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
 
             await _messaging.SendCommandAsync(command);
         }
-
-        public async Task CloseVacancyAsync(Guid vacancyId, VacancyUser user)
-        {
-            var command = new CloseVacancyCommand
-            {
-                VacancyId = vacancyId,
-                User = user
-            };
-
-            await _messaging.SendCommandAsync(command);
-        }
-
+        
         public async Task CloseExpiredVacancies()
         {
             var command = new CloseExpiredVacanciesCommand();

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Polly;
 using Esfa.Recruit.Vacancies.Client.Domain.Models;
+using MongoDB.Bson;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
 {
@@ -207,15 +208,15 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
         public async Task<IEnumerable<ProviderVacancySummary>> GetVacanciesAssociatedToProvider(long ukprn)
         {
             var builder = Builders<Vacancy>.Filter;
-            var filter = builder.Eq(ProviderUkprnFieldName, ukprn) &
-                        builder.Ne(IsDeletedFieldName, true);
-                
+            var filter = 
+                builder.Eq(ProviderUkprnFieldName, ukprn) &
+                builder.Ne(IsDeletedFieldName, true);
+            
             var collection = GetCollection<Vacancy>();
 
             var result = await RetryPolicy.ExecuteAsync(_ => 
                 collection
-                    .Aggregate()
-                    .Match(filter)
+                    .Find(filter)
                     .Project(x => new ProviderVacancySummary 
                     {
                         Id = x.Id,

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloseExpiredVacanciesCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/CloseExpiredVacanciesCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Esfa.Recruit.Vacancies.Client.Application.Commands;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -38,15 +39,15 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.C
             mockTimeProvider.Setup(t => t.Today).Returns(DateTime.Parse("2019-03-24"));
 
             var mockVacancyService = new Mock<IVacancyService>();
+            var mockMessaging = new Mock<IMessaging>();
 
-            var handler = new CloseExpiredVacanciesCommandHandler(mockLogger.Object, mockQuery.Object, mockTimeProvider.Object, mockVacancyService.Object);
+            var handler = new CloseExpiredVacanciesCommandHandler(mockLogger.Object, mockQuery.Object, mockTimeProvider.Object, mockVacancyService.Object, mockMessaging.Object);
 
             var command = new CloseExpiredVacanciesCommand();
 
             await handler.Handle(command, new CancellationToken());
 
-            mockVacancyService.Verify(s => s.CloseExpiredVacancy(It.IsAny<Guid>()), Times.Once);
-            mockVacancyService.Verify(s => s.CloseExpiredVacancy(It.Is<Guid>(g => g == Guid.Parse("4913c8fb-4f5b-4069-9301-858e405c1651"))), Times.Once);
+            mockMessaging.Verify(m => m.SendCommandAsync(It.Is<CloseVacancyCommand>(c => c.ClosureReason == ClosureReason.Auto && c.User == null)));
         }
     }
 }


### PR DESCRIPTION
As per discussion with @mgwilliam and @sachpatel  this PR is to refactor the closing of vacancies as it impacts current stories that are being worked on.  

- I have deleted all methods from the client, this is to reduce the use of client which serves no purpose. 
- Orchestrator now directly invokes commands
- The `CloseVacancyCommand` is refactored to raise the `VacancyClosedEvent`