### PR TITLE
ER-1457 hide block provider links

### DIFF
--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -57,7 +57,7 @@
                             <option value="@FilteringOptions.AllApplications">with applications</option>
                             <option value="@FilteringOptions.ClosingSoonWithNoApplications">closing soon with no applications</option>
                             <option value="@FilteringOptions.ClosingSoon">closing soon</option>
-                            <option value="@FilteringOptions.Transferred">transferred from provider</option>
+                            <option asp-hide="true" value="@FilteringOptions.Transferred">transferred from provider</option>
                         </optgroup>
                     </select>
                     <button type="submit" id="filter-submit" class="das-button-filter das-button-secondary govuk-button govuk-!-margin-top-3">Filter</button>

--- a/src/QA/QA.Web/Views/Dashboard/Index.cshtml
+++ b/src/QA/QA.Web/Views/Dashboard/Index.cshtml
@@ -138,19 +138,25 @@
         </h3>
         <p class="govuk-body">Create and download reports for your vacancies for any period of time.</p>
     </div>
+    
+    <div asp-hide="true"><!-- Temporarily hide this for public beta release -->
 
-    <div asp-show="@Model.IsUserAdmin" class="govuk-grid-column-one-third">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
-            <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.BlockedOrganisations_Get">Remove training provider</a>
-        </h3>
-        <p class="govuk-body">Remove a training provider</p>
-    </div>
 
-    <div asp-show="@Model.IsUserAdmin" class="govuk-grid-column-one-third">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
-            <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.WithdrawVacancy_FindVacancy_Get">Close a vacancy</a>
-        </h3>
-        <p class="govuk-body">Find and close a live vacancy and prevent it being found on Find an apprentice.</p>
+        <div asp-show="@Model.IsUserAdmin" class="govuk-grid-column-one-third">
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+                <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.BlockedOrganisations_Get">Remove training provider</a>
+            </h3>
+            <p class="govuk-body">Remove a training provider</p>
+        </div>
+        
+        <div asp-show="@Model.IsUserAdmin" class="govuk-grid-column-one-third">
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+                <a class="govuk-link govuk-link--no-visited-state" asp-route="@RouteNames.WithdrawVacancy_FindVacancy_Get">Close a vacancy</a>
+            </h3>
+            <p class="govuk-body">Find and close a live vacancy and prevent it being found on Find an apprentice.</p>
+        </div>
+
+
     </div>
 </div>
 


### PR DESCRIPTION
Hiding the "block provider" and "withdraw vacancy" from QA web and "transferred" filter from employer web to allow public beta release to go ahead. 