### PR TITLE
ER-1106 Withdrawn live vacancy +semver: patch

### DIFF
--- a/src/QA/QA.Web/Models/WithdrawVacancy/PostFindVacancyEditModelResult.cs
+++ b/src/QA/QA.Web/Models/WithdrawVacancy/PostFindVacancyEditModelResult.cs
@@ -4,7 +4,8 @@
     {
         NotFound,
         AlreadyClosed,
-        CanClose
+        CanClose,
+        NotLive
     }
 
     public class PostFindVacancyEditModelResult

--- a/src/QA/QA.Web/Orchestrators/WithdrawVacancyOrchestrator.cs
+++ b/src/QA/QA.Web/Orchestrators/WithdrawVacancyOrchestrator.cs
@@ -39,6 +39,9 @@ namespace Esfa.Recruit.Qa.Web.Orchestrators
             if(vacancy != null && vacancy.Status == VacancyStatus.Closed)
                 return new PostFindVacancyEditModelResult { ResultType = PostFindVacancyEditModelResultType.AlreadyClosed, VacancyReference = vacancy.VacancyReference };
 
+            if (vacancy != null && vacancy.Status != VacancyStatus.Live)
+                return new PostFindVacancyEditModelResult { ResultType = PostFindVacancyEditModelResultType.NotLive, VacancyReference = vacancy.VacancyReference };
+
             return new PostFindVacancyEditModelResult {ResultType = PostFindVacancyEditModelResultType.NotFound};
         }
 

--- a/src/QA/QA.Web/Views/WithdrawVacancy/Confirm.cshtml
+++ b/src/QA/QA.Web/Views/WithdrawVacancy/Confirm.cshtml
@@ -21,7 +21,6 @@
 
         <p class="govuk-body">
             <a asp-route="@RouteNames.WithdrawVacancy_Consent_Get" class="govuk-button">Confirm and continue</a>
-            <a asp-route="@RouteNames.WithdrawVacancy_FindVacancy_Get" class="govuk-link das-button-link">Cancel</a>
         </p>
         
     </div>

--- a/src/QA/UnitTests/Qa.Web/Orchestrators/WithdrawVacancyOrchestrator/PostFindVacancyEditModelAsyncTests.cs
+++ b/src/QA/UnitTests/Qa.Web/Orchestrators/WithdrawVacancyOrchestrator/PostFindVacancyEditModelAsyncTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
         [InlineData(VacancyStatus.Submitted)]
         [InlineData(VacancyStatus.Referred)]
         [InlineData(VacancyStatus.Approved)]
-        public async Task ShouldReturnNotFoundIfVacancyIsInWrongState(VacancyStatus status)
+        public async Task ShouldReturnNotLiveIfVacancyExistsAndIsNotLive(VacancyStatus status)
         {
             var mockClient = new Mock<IQaVacancyClient>();
 
@@ -35,7 +35,7 @@ namespace UnitTests.Qa.Web.Orchestrators.WithdrawVacancyOrchestrator
 
             var result = await orch.PostFindVacancyEditModelAsync(m);
 
-            result.ResultType.Should().Be(PostFindVacancyEditModelResultType.NotFound);
+            result.ResultType.Should().Be(PostFindVacancyEditModelResultType.NotLive);
         }
 
         [Fact]


### PR DESCRIPTION
ER-1106 Show correct error message when closing a vacancy that isn't live
ER-1106 Preserve user input when cancelling vacancy closure
ER-1106 Remove Cancel option from Confirmation screen