### PR TITLE
ER-1445 Refactored vacancy treatment on provider blocked

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
@@ -55,8 +55,6 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
 
             // tasks.AddRange(RequestEmployerCommunications(vacancies));
 
-            //TODO update employer and provider dashboard
-
             await Task.WhenAll(tasks);
 
             _logger.LogInformation($"Finished queuing required updates after provider {eventData.Ukprn} was blocked");

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedOnLegalEntityDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedOnLegalEntityDomainEventHandler.cs
@@ -32,12 +32,5 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
 
             _logger.LogInformation($"Successfully revoked provider {eventData.Ukprn} permission on account {eventData.EmployerAccountId} for legal entity {eventData.LegalEntityId}.");
         }
-
-        private async Task<string> GetAccountLegalEntityPublicHashId(ProviderBlockedOnLegalEntityEvent eventData)
-        {
-            var legalEntities = await _employerAccountProvider.GetLegalEntitiesConnectedToAccountAsync(eventData.EmployerAccountId);
-
-            return legalEntities.FirstOrDefault(l => l.LegalEntityId == eventData.LegalEntityId).AccountLegalEntityPublicHashedId;
-        }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
@@ -31,7 +31,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(eventData.VacancyId);
 
-            if (vacancy.OwnerType == Entities.OwnerType.Employer)
+            if (vacancy.OwnerType == Entities.OwnerType.Provider)
             {
                 await _messaging.SendCommandAsync(
                     new TransferProviderVacancyCommand(

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
@@ -1,35 +1,26 @@
 using System.Threading.Tasks;
-using Esfa.Recruit.Vacancies.Client.Application.Providers;
-using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Entities = Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Events;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Microsoft.Extensions.Logging;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 
 namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 {
     public class ProviderBlockedOnVacancyDomainEventHandler : DomainEventHandler, IDomainEventHandler<ProviderBlockedOnVacancyEvent>
     {
         private readonly IVacancyRepository _vacancyRepository;
-        private readonly IVacancyReviewQuery _vacancyReviewQuery;
-        private readonly IVacancyReviewRepository _vacancyReviewRepository;
-        private readonly ITimeProvider _timeProvider;
-        private readonly IVacancyService _vacancyService;
+        private readonly IMessaging _messaging;
         private readonly ILogger<ProviderBlockedOnVacancyDomainEventHandler> _logger;
         public ProviderBlockedOnVacancyDomainEventHandler(
             IVacancyRepository vacancyRepository,
-            IVacancyReviewQuery vacancyReviewQuery,
-            IVacancyReviewRepository vacancyReviewRepository,
-            ITimeProvider timeProvider,
-            IVacancyService vacancyService,
+            IMessaging messaging,
             ILogger<ProviderBlockedOnVacancyDomainEventHandler> logger) : base(logger)
         {
             _logger = logger;
             _vacancyRepository = vacancyRepository;
-            _vacancyReviewQuery = vacancyReviewQuery;
-            _vacancyReviewRepository = vacancyReviewRepository;
-            _timeProvider = timeProvider;
-            _vacancyService = vacancyService;
+            _messaging = messaging;
         }
 
         public async Task HandleAsync(string eventPayload)
@@ -40,59 +31,26 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(eventData.VacancyId);
 
-            var isVacancyUpdated = false;
-
-            if (vacancy.OwnerType == Entities.OwnerType.Provider && vacancy.TransferInfo == null)
+            if (vacancy.OwnerType == Entities.OwnerType.Employer)
             {
-                _logger.LogInformation($"Transferring the vacancy {vacancy.VacancyReference} to the employer as the provider {eventData.Ukprn} is blocked");
-                isVacancyUpdated = true;
-                vacancy.TransferInfo = new Entities.TransferInfo()
-                {
-                    Ukprn = eventData.Ukprn,
-                    ProviderName = vacancy.TrainingProvider.Name,
-                    LegalEntityName = vacancy.LegalEntityName,
-                    TransferredByUser = eventData.QaVacancyUser,
-                    TransferredDate = eventData.BlockedDate,
-                    Reason = Entities.TransferReason.BlockedByQa
-                };
-                vacancy.OwnerType = Entities.OwnerType.Employer;
+                await _messaging.SendCommandAsync(
+                    new TransferProviderVacancyCommand(
+                        vacancy.Id,
+                        eventData.QaVacancyUser,
+                        eventData.BlockedDate,
+                        Entities.TransferReason.BlockedByQa
+                ));
             }
 
-            if(vacancy.Status == Entities.VacancyStatus.Submitted)
+            if (vacancy.Status == Entities.VacancyStatus.Submitted)
             {
-                var review = await _vacancyReviewQuery.GetLatestReviewByReferenceAsync(vacancy.VacancyReference.GetValueOrDefault());
-                if (review.IsPending)
-                {
-                    await ClosePendingReview(review);
-                    isVacancyUpdated = true;
-                    vacancy.Status = Entities.VacancyStatus.Draft;
-                }
-                else
-                {
-                    _logger.LogInformation($"The vacancy {vacancy.VacancyReference} is under review and cannot be closed.");
-                }
+                await _messaging.SendCommandAsync(new ResetSubmittedVacancyCommand(vacancy.Id));
             }
 
-            if(isVacancyUpdated)
+            if (vacancy.Status == Entities.VacancyStatus.Live)
             {
-                await _vacancyRepository.UpdateAsync(vacancy);
+                await _messaging.SendCommandAsync(new CloseVacancyCommand(vacancy.Id, eventData.QaVacancyUser, Entities.ClosureReason.BlockedByQa));
             }
-
-            if(vacancy.Status == Entities.VacancyStatus.Live)
-            {
-                _logger.LogInformation($"Closing live vacancy {eventData.VacancyId} as the provider {eventData.Ukprn} is blocked");
-                await _vacancyService.CloseVacancyImmediately(eventData.VacancyId, eventData.QaVacancyUser, Entities.ClosureReason.BlockedByQa);
-            }
-        }
-
-        private async Task ClosePendingReview(Entities.VacancyReview review)
-        {
-            _logger.LogInformation($"Closing pending review {review.Id} as the provider is blocked");
-            review.ManualOutcome = Entities.ManualQaOutcome.Withdrawn;
-            review.Status = Entities.ReviewStatus.Closed;
-            review.ClosedDate = _timeProvider.Now;
-
-            await _vacancyReviewRepository.UpdateAsync(review);
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CloseVacancyCommandHandler.cs
@@ -1,6 +1,11 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Application.Commands;
-using Esfa.Recruit.Vacancies.Client.Application.Services;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,16 +13,46 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
     public class CloseVacancyCommandHandler : IRequestHandler<CloseVacancyCommand>
     {
-        private readonly IVacancyService _vacancyService;
-
-        public CloseVacancyCommandHandler(IVacancyService vacancyService)
+        private readonly IVacancyRepository _vacancyRepository;
+        private readonly ILogger<CloseVacancyCommandHandler> _logger;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IMessaging _messaging;
+        public CloseVacancyCommandHandler(
+            IVacancyRepository vacancyRepository,
+            ITimeProvider timeProvider,
+            IMessaging messaging,
+            ILogger<CloseVacancyCommandHandler> logger)
         {
-            _vacancyService = vacancyService;
+            _vacancyRepository = vacancyRepository;
+            _timeProvider = timeProvider;
+            _messaging = messaging;
+            _logger = logger;
         }
 
-        public Task Handle(CloseVacancyCommand message, CancellationToken cancellationToken)
+        public async Task Handle(CloseVacancyCommand message, CancellationToken cancellationToken)
         {
-            return _vacancyService.CloseVacancyImmediately(message.VacancyId, message.User, message.ClosureReason);
+            var vacancy = await _vacancyRepository.GetVacancyAsync(message.VacancyId);
+
+            if (vacancy == null || vacancy.Status != VacancyStatus.Live)
+            {
+                _logger.LogInformation($"Cannot close vacancy {message.VacancyId} as it was not found or is not in status live.");
+            }
+
+            _logger.LogInformation("Closing vacancy {vacancyId} by user {userEmail}.", vacancy.Id, message.User.Email);
+            vacancy.ClosedByUser = message.User;
+            vacancy.ClosureReason = message.ClosureReason;
+
+            vacancy.ClosedDate = _timeProvider.Now;
+            vacancy.Status = VacancyStatus.Closed;
+
+            await _vacancyRepository.UpdateAsync(vacancy);
+
+            await _messaging.PublishEvent(new VacancyClosedEvent
+            {
+                VacancyReference = vacancy.VacancyReference.GetValueOrDefault(),
+                VacancyId = vacancy.Id
+            });
         }
+
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ResetSubmittedVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ResetSubmittedVacancyCommandHandler.cs
@@ -1,0 +1,86 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
+{
+    public class ResetSubmittedVacancyCommandHandler : IRequestHandler<ResetSubmittedVacancyCommand>
+    {
+        private readonly ILogger<ResetSubmittedVacancyCommandHandler> _logger;
+        private readonly IVacancyRepository _vacancyRepository;
+        private readonly IVacancyReviewQuery _vacancyReviewQuery;
+        private readonly IVacancyReviewRepository _vacancyReviewRepository;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IMessaging _messaging;
+        public ResetSubmittedVacancyCommandHandler(
+            IVacancyRepository vacancyRepository,
+            IVacancyReviewQuery vacancyReviewQuery,
+            IVacancyReviewRepository vacancyReviewRepository,
+            ITimeProvider timeProvider,
+            IMessaging messaging,
+            ILogger<ResetSubmittedVacancyCommandHandler> logger)
+        {
+            _logger = logger;
+            _vacancyRepository = vacancyRepository;
+            _vacancyReviewQuery = vacancyReviewQuery;
+            _vacancyReviewRepository = vacancyReviewRepository;
+            _timeProvider = timeProvider;
+            _messaging = messaging;
+        }
+        public async Task Handle(ResetSubmittedVacancyCommand message, CancellationToken cancellationToken)
+        {
+            var vacancy = await _vacancyRepository.GetVacancyAsync(message.VacancyId);
+            if (vacancy.Status != VacancyStatus.Submitted)
+            {
+                _logger.LogInformation($"No reviews will be updated for the vacancy {vacancy.VacancyReference} as it is in status {vacancy.Status}");
+                return;
+            }
+
+            var review = await _vacancyReviewQuery.GetLatestReviewByReferenceAsync(vacancy.VacancyReference.GetValueOrDefault());
+
+            if (review == null || review.Status == ReviewStatus.Closed)
+            {
+                _logger.LogInformation($"No active reviews found for vacancy {vacancy.VacancyReference}");
+                return;
+            }
+
+            if (review.Status == ReviewStatus.UnderReview)
+            {
+                _logger.LogInformation($"The vacancy will not be updated {vacancy.VacancyReference} as it is being reviewed {review.Id}.");
+                return;
+            }
+            else if (review.IsPending)
+            {
+                await ClosePendingReview(review);
+                await UpdateVacancyStatusToDraft(vacancy);
+                await _messaging.PublishEvent(
+                    new VacancyReviewWithdrawnEvent(vacancy.Id, vacancy.VacancyReference.GetValueOrDefault(), review.Id));
+            }
+        }
+
+        private Task UpdateVacancyStatusToDraft(Vacancy vacancy)
+        {
+            _logger.LogInformation($"Resetting vacancy {vacancy.VacancyReference} to Draft status.");
+            vacancy.Status = VacancyStatus.Draft;
+            vacancy.SubmittedDate = null;
+            vacancy.SubmittedByUser = null;
+            return _vacancyRepository.UpdateAsync(vacancy);
+        }
+
+        private Task ClosePendingReview(VacancyReview review)
+        {
+            _logger.LogInformation($"Closing pending review {review.Id} as the provider is blocked");
+            review.ManualOutcome = ManualQaOutcome.Withdrawn;
+            review.Status = ReviewStatus.Closed;
+            review.ClosedDate = _timeProvider.Now;
+            return _vacancyReviewRepository.UpdateAsync(review);
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/TransferProviderVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/TransferProviderVacancyCommandHandler.cs
@@ -1,0 +1,59 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
+{
+    public class TransferProviderVacancyCommandHandler : IRequestHandler<TransferProviderVacancyCommand>
+    {
+        private readonly IVacancyRepository _vacancyRepository;
+        private readonly ILogger<TransferProviderVacancyCommandHandler> _logger;
+        private readonly IMessaging _messaging;
+        public TransferProviderVacancyCommandHandler(
+            IVacancyRepository vacancyRepository,
+            IMessaging messaging,
+            ILogger<TransferProviderVacancyCommandHandler> logger)
+        {
+            _logger = logger;
+            _messaging = messaging;
+            _vacancyRepository = vacancyRepository;
+        }
+        
+        public async Task Handle(TransferProviderVacancyCommand message, CancellationToken cancellationToken)
+        {
+            var vacancy = await _vacancyRepository.GetVacancyAsync(message.VacancyId);
+            if (vacancy.OwnerType == OwnerType.Employer)
+            {
+                _logger.LogInformation($"Cannot transfer vacancy {vacancy.VacancyReference} as it is owned by {vacancy.OwnerType}.");
+                return;
+            }
+
+            _logger.LogInformation($"Transferring the vacancy {vacancy.VacancyReference} to the employer as the provider {vacancy.TrainingProvider.Ukprn} is blocked");
+
+            vacancy.TransferInfo = new TransferInfo()
+            {
+                Ukprn = vacancy.TrainingProvider.Ukprn.GetValueOrDefault(),
+                ProviderName = vacancy.TrainingProvider.Name,
+                LegalEntityName = vacancy.LegalEntityName,
+                TransferredByUser = message.TransferredByUser,
+                TransferredDate = message.TransferredDate,
+                Reason = message.Reason
+            };
+            vacancy.OwnerType = OwnerType.Employer;
+
+            await _vacancyRepository.UpdateAsync(vacancy);
+
+            await _messaging.PublishEvent(new VacancyTransferredEvent
+            {
+                VacancyId = vacancy.Id,
+                VacancyReference = vacancy.VacancyReference.GetValueOrDefault()
+            });
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/CloseVacancyCommand.cs
@@ -7,8 +7,15 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class CloseVacancyCommand : ICommand, IRequest
     {
-        public Guid VacancyId { get; set; }
-        public VacancyUser User { get; internal set; }
-        public ClosureReason ClosureReason { get; set; }
+        public Guid VacancyId { get; }
+        public VacancyUser User { get; }
+        public ClosureReason ClosureReason { get; }
+
+        public CloseVacancyCommand(Guid vacancyId, VacancyUser user, ClosureReason closureReason)
+        {
+            VacancyId = vacancyId;
+            User = user;
+            ClosureReason = closureReason;
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/ResetSubmittedVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/ResetSubmittedVacancyCommand.cs
@@ -1,0 +1,16 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Commands
+{
+    public class ResetSubmittedVacancyCommand : ICommand, IRequest
+    {
+        public Guid VacancyId { get; }
+
+        public ResetSubmittedVacancyCommand(Guid vacancyId)
+        {
+            VacancyId = vacancyId;
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/TransferProviderVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/TransferProviderVacancyCommand.cs
@@ -1,0 +1,23 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Commands
+{
+    public class TransferProviderVacancyCommand : ICommand, IRequest
+    {
+        public Guid VacancyId { get; set; }
+        public VacancyUser TransferredByUser { get; internal set; }
+        public DateTime TransferredDate { get; internal set; }
+        public TransferReason Reason { get; internal set; }
+
+        public TransferProviderVacancyCommand(Guid vacancyId, VacancyUser user, DateTime transferredDate, TransferReason reason)
+        {
+            VacancyId = vacancyId;
+            TransferredByUser = user;
+            TransferredDate = transferredDate;
+            Reason = reason;
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/IVacancyService.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Threading.Tasks;
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Services
 {
     public interface IVacancyService
     {
         Task CloseExpiredVacancy(Guid vacancyId);
-        Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason);
         Task PerformRulesCheckAsync(Guid reviewId);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyReviewTransferService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyReviewTransferService.cs
@@ -26,22 +26,19 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
         {
             var review = await _vacancyReviewQuery.GetLatestReviewByReferenceAsync(vacancyReference);
 
-            if (review.Status != ReviewStatus.Closed)
+            if (review.IsPending)
             {
-                if (review.Status == ReviewStatus.New || review.Status == ReviewStatus.PendingReview)
-                {
-                    review.ManualOutcome = review.VacancySnapshot.OwnerType == OwnerType.Provider && transferReason == TransferReason.BlockedByQa
-                                            ? ManualQaOutcome.Withdrawn
-                                            : ManualQaOutcome.Transferred;
-                    review.Status = ReviewStatus.Closed;
-                    review.ClosedDate = _timeProvider.Now;
+                review.ManualOutcome = review.VacancySnapshot.OwnerType == OwnerType.Provider && transferReason == TransferReason.BlockedByQa
+                                        ? ManualQaOutcome.Withdrawn
+                                        : ManualQaOutcome.Transferred;
+                review.Status = ReviewStatus.Closed;
+                review.ClosedDate = _timeProvider.Now;
 
-                    await _vacancyReviewRepository.UpdateAsync(review);
-                }
-                else if (review.Status == ReviewStatus.UnderReview)
-                {
-                    _logger.LogWarning($"Latest review for vacancy {review.VacancyReference} that has been transferred is currently being reviewed.");
-                }
+                await _vacancyReviewRepository.UpdateAsync(review);
+            }
+            else if (review.Status == ReviewStatus.UnderReview)
+            {
+                _logger.LogWarning($"Latest review for vacancy {review.VacancyReference} that has been transferred is currently being reviewed.");
             }
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyService.cs
@@ -40,11 +40,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
             var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyId);
             vacancy.ClosureReason = ClosureReason.Auto;
 
-            await CloseVacancyAsync(vacancy);
-        }
-
-        private async Task CloseVacancyAsync(Vacancy vacancy)
-        {
             vacancy.ClosedDate = _timeProvider.Now;
             vacancy.Status = VacancyStatus.Closed;
 
@@ -55,18 +50,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
                 VacancyReference = vacancy.VacancyReference.Value,
                 VacancyId = vacancy.Id
             });
-        }
-
-        public async Task CloseVacancyImmediately(Guid vacancyId, VacancyUser user, ClosureReason closureReason)
-        {
-            _logger.LogInformation("Closing vacancy {vacancyId} by user {userEmail}.", vacancyId, user.Email);
-
-            var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyId);
-
-            vacancy.ClosedByUser = user;
-            vacancy.ClosureReason = closureReason;
-
-            await CloseVacancyAsync(vacancy);
         }
 
         public async Task PerformRulesCheckAsync(Guid reviewId)

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Events/VacancyReviewWithdrawnEvent.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Events/VacancyReviewWithdrawnEvent.cs
@@ -1,0 +1,23 @@
+using System;
+using Esfa.Recruit.Vacancies.Client.Domain.Events.Interfaces;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using MediatR;
+
+namespace Esfa.Recruit.Vacancies.Client.Domain.Events
+{
+    public class VacancyReviewWithdrawnEvent : EventBase, INotification, IVacancyEvent, IVacancyReviewEvent
+    {
+        public Guid VacancyId { get; }
+
+        public long VacancyReference { get;}
+
+        public Guid ReviewId { get; }
+
+        public VacancyReviewWithdrawnEvent(Guid vacancyId, long vacancyReference, Guid reviewId)
+        {
+            VacancyId = vacancyId;
+            VacancyReference = vacancyReference;
+            ReviewId = reviewId;
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -233,16 +233,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _reportRepository.IncrementReportDownloadCountAsync(reportId);
         }
 
-        public async Task CloseVacancyAsync(Guid vacancyId, VacancyUser user)
+        public Task CloseVacancyAsync(Guid vacancyId, VacancyUser user)
         {
-            var command = new CloseVacancyCommand
-            {
-                VacancyId = vacancyId,
-                User = user,
-                ClosureReason = ClosureReason.WithdrawnByQa
-            };
-
-            await _messaging.SendCommandAsync(command);
+            return _messaging.SendCommandAsync(new CloseVacancyCommand(vacancyId, user, ClosureReason.WithdrawnByQa));
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -350,16 +350,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             await _messaging.SendCommandAsync(command);
         }
 
-        public async Task CloseVacancyAsync(Guid vacancyId, VacancyUser user, ClosureReason reason)
+        public Task CloseVacancyAsync(Guid vacancyId, VacancyUser user, ClosureReason reason)
         {
-            var command = new CloseVacancyCommand
-            {
-                VacancyId = vacancyId,
-                User = user,
-                ClosureReason = reason
-            };
-
-            await _messaging.SendCommandAsync(command);
+            return _messaging.SendCommandAsync(new CloseVacancyCommand(vacancyId, user, reason));
         }
 
         public async Task CloseExpiredVacancies()

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateEmployerDashboardOnChange.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateEmployerDashboardOnChange.cs
@@ -23,7 +23,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                                             INotificationHandler<ApplicationReviewedEvent>,
                                             INotificationHandler<SetupEmployerEvent>,
                                             INotificationHandler<VacancyReferredEvent>,
-                                            INotificationHandler<VacancyTransferredEvent>
+                                            INotificationHandler<VacancyTransferredEvent>,
+                                            INotificationHandler<VacancyReviewWithdrawnEvent>
     {
         private readonly IEmployerDashboardProjectionService _dashboardService;
         private readonly IVacancyRepository _vacancyRepository;
@@ -105,6 +106,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
 
             _logger.LogInformation("Handling {eventType} for accountId: {employerAccountId} and vacancyReference: {vacancyReference}", notification.GetType().Name, vacancy.EmployerAccountId, notification.VacancyReference);
             await _dashboardService.ReBuildDashboardAsync(vacancy.EmployerAccountId);
+        }
+
+        public Task Handle(VacancyReviewWithdrawnEvent notification, CancellationToken cancellationToken)
+        {
+            return Handle(notification);
         }
 
         private Task Handle(IEmployerEvent notification)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateProviderDashboardOnChangeEventHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateProviderDashboardOnChangeEventHandler.cs
@@ -23,7 +23,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                                             INotificationHandler<ApplicationReviewedEvent>,
                                             INotificationHandler<SetupProviderEvent>,
                                             INotificationHandler<VacancyReferredEvent>,
-                                            INotificationHandler<VacancyTransferredEvent>
+                                            INotificationHandler<VacancyTransferredEvent>,
+                                            INotificationHandler<VacancyReviewWithdrawnEvent>
     {
         private readonly IProviderDashboardProjectionService _dashboardService;
         private readonly IVacancyRepository _vacancyRepository;
@@ -105,6 +106,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
 
             _logger.LogInformation("Handling {eventType} for ukprn: {ukprn} and vacancyReference: {vacancyReference}", notification.GetType().Name, vacancy.TrainingProvider.Ukprn.Value, notification.VacancyReference);
             await _dashboardService.ReBuildDashboardAsync(vacancy.TrainingProvider.Ukprn.GetValueOrDefault());
+        }
+
+        public Task Handle(VacancyReviewWithdrawnEvent notification, CancellationToken cancellationToken)
+        {
+            return Handle(notification);
         }
 
         private Task Handle(IProviderEvent notification)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateQaDashboardOnReview.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/UpdateQaDashboardOnReview.cs
@@ -9,7 +9,8 @@ using Microsoft.Extensions.Logging;
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
 {
     public class UpdateQaDashboardOnReview : INotificationHandler<VacancyReviewApprovedEvent>,
-                                             INotificationHandler<VacancyReviewReferredEvent>
+                                             INotificationHandler<VacancyReviewReferredEvent>,
+                                             INotificationHandler<VacancyReviewWithdrawnEvent>
     {
         private readonly ILogger<UpdateQaDashboardOnReview> _logger;
         private readonly IQaDashboardProjectionService _qaDashboardService;
@@ -31,6 +32,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
         }
 
         public Task Handle(VacancyReviewReferredEvent notification, CancellationToken cancellationToken)
+        {
+            return Handle(notification);
+        }
+
+        public Task Handle(VacancyReviewWithdrawnEvent notification, CancellationToken cancellationToken)
         {
             return Handle(notification);
         }


### PR DESCRIPTION
Broken down the update of vacancy in three commands
- Apply transfer
- Reset submitted vacancy to draft
- Close live vacancy

I have refactored close vacancy command to update the vacancy and raise the event. This command can potentially be reused from all the cases where we need to close vacancies. Also this is the first step to get rid of VacancyService which is very ambiguous by name. 