### PR TITLE
Encoding service to use shared config

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -16,7 +16,9 @@
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
             "console": "internalConsole",
             "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "APPSETTING_ASPNETCORE_ENVIRONMENT": "Development",
+                "CUSTOMCONNSTR_ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;"
             },
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart"

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build-jobs",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceRoot}/Jobs/Recruit.Vacancies.Jobs/bin/Debug/netcoreapp2.1/Esfa.Recruit.Vacancies.Jobs.dll",
+            "program": "${workspaceRoot}/Jobs/Recruit.Vacancies.Jobs/bin/Debug/netcoreapp2.2/Esfa.Recruit.Vacancies.Jobs.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Jobs/Recruit.Vacancies.Jobs",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.json
@@ -103,6 +103,9 @@
         "SetNotificationPreferences": false
       }
     },
+    "ConfigurationStorageConnectionString": {
+      "type": "securestring"
+    },
     "LoggingRedisConnectionString": {
       "type": "securestring",
       "defaultValue": ""
@@ -984,6 +987,11 @@
           },
           "appServiceConnectionStrings": {
             "value": [
+              {
+                "name": "ConfigurationStorageConnectionString",
+                "connectionString": "[parameters('ConfigurationStorageConnectionString')]",
+                "type": "Custom"
+              },
               {
                 "name": "Redis",
                 "connectionString": "[parameters('LoggingRedisConnectionString')]",

--- a/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
+++ b/src/Employer/Esfa.Recruit.Azure.Resources/azuredeploy.parameters.json
@@ -78,6 +78,9 @@
         "SetNotificationPreferences": false
       }
     },
+    "ConfigurationStorageConnectionString": {
+      "value": ""
+    },
     "LoggingRedisConnectionString": {
       "value": ""
     },

--- a/src/Jobs/Recruit.Vacancies.Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventsHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventsHandler.cs
@@ -11,7 +11,6 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVa
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount;
 using Esfa.Recruit.Vacancies.Jobs.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NServiceBus;
 using SFA.DAS.Encoding;
 using SFA.DAS.ProviderRelationships.Messages.Events;
@@ -28,37 +27,24 @@ namespace Esfa.Recruit.Vacancies.Jobs.ExternalSystemEventHandlers
         private readonly RecruitWebJobsSystemConfiguration _jobsConfig;
         private readonly IVacancyQuery _vacancyQuery;
         private readonly IMessaging _messaging;
-        private readonly EncodingConfig _encodingConfig;
         private string ExternalSystemEventHandlerName => GetType().Name;
 
         public UpdatedPermissionsExternalSystemEventsHandler(ILogger<UpdatedPermissionsExternalSystemEventsHandler> logger, RecruitWebJobsSystemConfiguration jobsConfig,
                                                 IRecruitQueueService recruitQueueService,
                                                 IEmployerAccountProvider employerAccountProvider, IEncodingService encoder, IVacancyQuery vacancyQuery,
-                                                IMessaging messaging, EncodingConfig encodingConfig)
+                                                IMessaging messaging)
         {
             _logger = logger;
             _jobsConfig = jobsConfig;
             _recruitQueueService = recruitQueueService;
             _employerAccountProvider = employerAccountProvider;
-            //_encoder = encoder;
-            _encoder = new EncodingService(encodingConfig);
+            _encoder = encoder;
             _vacancyQuery = vacancyQuery;
             _messaging = messaging;
-            _encodingConfig = encodingConfig;
-        }
-
-        private void LogEncodingConfiguration()
-        {
-            foreach (var encoding in _encodingConfig.Encodings)
-            {
-                _logger.LogInformation($"Found Encoding Config: {encoding.EncodingType.ToString()}, with salt length {encoding.Salt.Length}, alphabet length {encoding.Alphabet.Length} and minHashLength {encoding.MinHashLength}");
-            }
         }
 
         public async Task Handle(UpdatedPermissionsEvent message, IMessageHandlerContext context)
         {
-            LogEncodingConfiguration();
-
             if (_jobsConfig.DisabledJobs.Contains(ExternalSystemEventHandlerName))
             {
                 _logger.LogDebug($"{ExternalSystemEventHandlerName} is disabled, skipping ...");

--- a/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -8,10 +8,12 @@ using Esfa.Recruit.Vacancies.Jobs.NServiceBus;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Queues;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
+[assembly: UserSecretsId("recruit-webjob")]
 
 namespace Esfa.Recruit.Vacancies.Jobs
 {

--- a/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -8,13 +8,11 @@ using Esfa.Recruit.Vacancies.Jobs.NServiceBus;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Queues;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
 using SFA.DAS.Configuration.AzureTableStorage;
-[assembly: UserSecretsId("recruit-webjob")]
 
 namespace Esfa.Recruit.Vacancies.Jobs
 {

--- a/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Program.cs
@@ -95,7 +95,8 @@ namespace Esfa.Recruit.Vacancies.Jobs
                             options.MaxPollingInterval = TimeSpan.FromSeconds(10);
                         });
 
-                        services.ConfigureJobServices(context.Configuration);
+                        var logger = NLog.LogManager.GetCurrentClassLogger();
+                        services.ConfigureJobServices(context.Configuration, logger);
 
                         services.AddDasNServiceBus(context.Configuration);
                     })

--- a/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <UserSecretsId>recruit-webjob</UserSecretsId>
     <RootNamespace>Esfa.Recruit.Vacancies.Jobs</RootNamespace>
@@ -15,14 +15,14 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.57" />

--- a/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Esfa.Recruit.Vacancies.Jobs</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AssemblyName>Esfa.Recruit.Vacancies.Jobs</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Recruit.Vacancies.Jobs.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.4.0" />
+    <PackageReference Include="SFA.DAS.Configuration" Version="3.0.77" />
+    <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.77" />
     <PackageReference Include="SFA.DAS.Encoding" Version="1.1.57" />
     <PackageReference Include="SFA.DAS.Http" Version="1.2.112" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />

--- a/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
@@ -29,16 +29,14 @@ using Communication.Types.Interfaces;
 using Esfa.Recruit.Vacancies.Client.Application.Communications;
 using Esfa.Recruit.Client.Application.Communications;
 using Esfa.Recruit.Vacancies.Client.Application.Communications.EntityDataItemProviderPlugins;
-using System;
 using System.Collections.Generic;
 using SFA.DAS.Encoding;
-using NLog;
 
 namespace Esfa.Recruit.Vacancies.Jobs
 {
     internal static class ServiceCollectionExtensions
     {
-        public static void ConfigureJobServices(this IServiceCollection services, IConfiguration configuration, NLog.Logger logger)
+        public static void ConfigureJobServices(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddSingleton<IApprenticeshipProgrammeApiClient, ApprenticeshipProgrammeApiClient>();
             services.AddScoped(x => new AccountsReader(x.GetService<ILogger<AccountsReader>>(), configuration.GetConnectionString("EmployerFinanceSqlDbConnectionString"), configuration.GetConnectionString("EmployerAccountsSqlDbConnectionString")));
@@ -102,7 +100,7 @@ namespace Esfa.Recruit.Vacancies.Jobs
 
             RegisterCommunicationsService(services, configuration);
             RegisterDasNotifications(services, configuration);
-            RegisterDasEncodingService(services, configuration, logger);
+            RegisterDasEncodingService(services, configuration);
         }
 
         private static void RegisterCommunicationsService(IServiceCollection services, IConfiguration configuration)
@@ -143,24 +141,12 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddTransient<INotificationsApi>(sp => new NotificationsApi(httpClient, notificationsConfig));
         }
 
-        private static void RegisterDasEncodingService(IServiceCollection services, IConfiguration configuration, NLog.Logger logger)
+        private static void RegisterDasEncodingService(IServiceCollection services, IConfiguration configuration)
         {
             var dasEncodingConfig = new EncodingConfig { Encodings = new List<Encoding>() };
             configuration.GetSection(nameof(dasEncodingConfig.Encodings)).Bind(dasEncodingConfig.Encodings);
             services.AddSingleton<EncodingConfig>(dasEncodingConfig);
-            //var name = nameof(EncodingConfig.Encodings);
-            //services.Configure()
-            //services.Configure<EncodingConfiguration>(configuration.GetSection("Encodings"));
             services.AddSingleton<IEncodingService, EncodingService>();
-            //LogOutConfigurationFound(logger, dasEncodingConfig);
-        }
-
-        private static void LogOutConfigurationFound(Logger logger, EncodingConfig dasEncodingConfig)
-        {
-            foreach (var encoding in dasEncodingConfig.Encodings)
-            {
-                logger.Log(NLog.LogLevel.Info, $"Found Encoding Config: {encoding.EncodingType.ToString()}, with salt length {encoding.Salt.Length}, alphabet length {encoding.Alphabet.Length} and minHashLength {encoding.MinHashLength}");
-            }
         }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/SpikeQueueTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/SpikeQueueTrigger.cs
@@ -6,6 +6,8 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummariesProv
 using Esfa.Recruit.Vacancies.Jobs.Configuration;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SFA.DAS.Encoding;
 
 #if DEBUG
 namespace Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers
@@ -15,14 +17,18 @@ namespace Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers
         private readonly ILogger<SpikeQueueTrigger> _logger;
         private readonly RecruitWebJobsSystemConfiguration _jobsConfig;
         private readonly IApplicationReviewQuery _query;
+        private readonly EncodingConfig _encodingConfig;
+        private readonly IEncodingService _encodingService;
 
         private string JobName => GetType().Name;
 
-        public SpikeQueueTrigger(ILogger<SpikeQueueTrigger> logger, RecruitWebJobsSystemConfiguration jobsConfig, IApplicationReviewQuery query)
+        public SpikeQueueTrigger(ILogger<SpikeQueueTrigger> logger, RecruitWebJobsSystemConfiguration jobsConfig, IApplicationReviewQuery query, EncodingConfig encodingConfig, IEncodingService encodingService)
         {
             _logger = logger;
             _jobsConfig = jobsConfig;
             _query = query;
+            _encodingConfig = encodingConfig;
+            _encodingService = encodingService;
         }
 
         public async Task SpikeAsync([QueueTrigger("test-queue", Connection = "QueueStorage")] string message, TextWriter log)

--- a/src/Jobs/Recruit.Vacancies.Jobs/appSettings.json
+++ b/src/Jobs/Recruit.Vacancies.Jobs/appSettings.json
@@ -26,6 +26,7 @@
   "ConnectionStrings": {
     "AzureWebJobsDashboard": "",
     "AzureWebJobsStorage": "",
+    "ConfigurationStorageConnectionString": "",
     "Redis": "",
     "MongoDb": "",
     "QueueStorage": "",
@@ -78,7 +79,5 @@
     "ClientSecret": "",
     "IdentifierUri": "",
     "Tenant": ""
-  },
-  "Encodings": [
-  ]
+  }
 }

--- a/src/Shared/UnitTests/Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
+++ b/src/Shared/UnitTests/Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
@@ -15,6 +15,7 @@ using Esfa.Recruit.Vacancies.Jobs.Configuration;
 using Esfa.Recruit.Vacancies.Jobs.ExternalSystemEventHandlers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using SFA.DAS.EAS.Account.Api.Types;
 using SFA.DAS.Encoding;
@@ -30,7 +31,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
         private const string UserFirstName = "John";
         private const string UserLastName = "Smith";
         private const long EmployerAccountId = 12345;
-        private const string EmployerAccountIdEncoded = "ABC123";
+        private const string EmployerAccountIdEncoded = "MYVGYG";//"ABC123";
         private const long AccountLegalEntityId = 1231;
         private const long AccountProviderId = 321;
         private const long AccountProviderLegalEntityId = 1223;
@@ -56,10 +57,36 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
             _mockEncoder = new Mock<IEncodingService>();
             _mockVacancyQuery = new Mock<IVacancyQuery>();
             _mockMessaging = new Mock<IMessaging>();
+            var mockEncodingConfig = new Mock<IOptions<EncodingConfig>>();
+            mockEncodingConfig.Setup(x => x.Value).Returns(new EncodingConfig
+            {
+                Encodings = new List<Encoding>()
+                {
+                    new Encoding
+                    {
+                        EncodingType = EncodingType.AccountId,
+                        Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+                        MinHashLength = 6,
+                        Salt = "zyxwvutsrqponm"
+                    }
+                }
+            });
 
             _sut = new UpdatedPermissionsExternalSystemEventsHandler(Mock.Of<ILogger<UpdatedPermissionsExternalSystemEventsHandler>>(), _jobsConfig,
                                                         _mockRecruitQueueService.Object, _mockEmployerAccountProvider.Object,
-                                                        _mockEncoder.Object, _mockVacancyQuery.Object, _mockMessaging.Object);
+                                                        _mockEncoder.Object, _mockVacancyQuery.Object, _mockMessaging.Object, new EncodingConfig
+            {
+                Encodings = new List<Encoding>()
+                {
+                    new Encoding
+                    {
+                        EncodingType = EncodingType.AccountId,
+                        Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456",
+                        MinHashLength = 6,
+                        Salt = "zyxwvutsrqponm"
+                    }
+                }
+            });
         }
 
         [Fact]
@@ -72,7 +99,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
             _mockRecruitQueueService.VerifyNoOtherCalls();
             _mockMessaging.VerifyNoOtherCalls();
             _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
+            //_mockEncoder.VerifyNoOtherCalls();
             _mockVacancyQuery.VerifyNoOtherCalls();
         }
 
@@ -85,7 +112,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
             _mockRecruitQueueService.VerifyNoOtherCalls();
             _mockMessaging.VerifyNoOtherCalls();
             _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
+            //_mockEncoder.VerifyNoOtherCalls();
             _mockVacancyQuery.VerifyNoOtherCalls();
         }
 
@@ -98,7 +125,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
             _mockRecruitQueueService.VerifyNoOtherCalls();
             _mockMessaging.VerifyNoOtherCalls();
             _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
+            //_mockEncoder.VerifyNoOtherCalls();
             _mockVacancyQuery.VerifyNoOtherCalls();
         }
 
@@ -111,7 +138,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
             _mockRecruitQueueService.VerifyNoOtherCalls();
             _mockMessaging.VerifyNoOtherCalls();
             _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
+            //_mockEncoder.VerifyNoOtherCalls();
             _mockVacancyQuery.VerifyNoOtherCalls();
         }
 
@@ -119,7 +146,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
         public async Task GivenNotExistingLegalEntityId_ThenExceptionIsThrown()
         {
             var grantedOperations = new HashSet<Operation> { Operation.CreateCohort };
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
+            //_mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
             _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
                                         .ReturnsAsync(_dummyLegalEntities);
 
@@ -127,7 +154,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
                             _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, DateTime.UtcNow), null));
 
             exception.Message.Should().Be($"Could not find matching Account Legal Entity Id {AccountLegalEntityId} for Employer Account {EmployerAccountId}");
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
+            //_mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
             _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
         }
 
@@ -141,7 +168,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
                                                             .Create();
 
             var grantedOperations = new HashSet<Operation> { Operation.CreateCohort };
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
+            //_mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
             _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
                                         .ReturnsAsync(_dummyLegalEntities.Append(matchingLegalEntityViewModel));
 
@@ -149,7 +176,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
 
             await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, DateTime.UtcNow), null);
 
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
+            //_mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
             _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
             _mockVacancyQuery.Verify(x => x.GetNoOfProviderOwnedVacanciesForLegalEntityAsync(Ukprn, RecruitLegalEntityId), Times.Once);
             _mockRecruitQueueService.VerifyNoOtherCalls();
@@ -174,7 +201,7 @@ namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
 
             await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, DateTime.UtcNow), null);
 
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
+            //_mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
             _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
             _mockVacancyQuery.Verify(x => x.GetNoOfProviderOwnedVacanciesForLegalEntityAsync(Ukprn, RecruitLegalEntityId), Times.Once);
             _mockRecruitQueueService.Verify(x => x.AddMessageAsync(It.IsAny<TransferVacanciesFromProviderQueueMessage>()), Times.Once);

--- a/src/Shared/UnitTests/UnitTests.csproj
+++ b/src/Shared/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Esfa.Recruit.Vacancies.Client.UnitTests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
I have run a simple test on TEST 2 where I have revoked a permission and a vacancy has been transferred.

- Upgraded webjobs to 2.2 to be able to use Das configuration (This seems to work without issues)
- If you have Encodings config in your webjobs secrets, please remove as we will now be using the DAS shared Encoding
- You will need to run the das-employer-config-updater tool with the environment set to `Development` - Mark has done this recently for provider relationships so he can help
- I will remove the Encodings config from the ARM template and Release definition after this piece goes out.
- If using Visual Studio, you may have to adjust your launchSettings.json for the webjobs project to use the environment variables as I have declared in the launch.json file in this PR