### PR TITLE
ER-1384 Refactored ApprenticeshipService data entity provider to incl…

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Application/ApplicationSubmittedHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Application/ApplicationSubmittedHandler.cs
@@ -52,7 +52,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Application
             var commsRequest = new CommunicationRequest(
                 CommunicationConstants.RequestType.ApplicationSubmitted, CommunicationConstants.ServiceName, CommunicationConstants.ServiceName);
             commsRequest.AddEntity(CommunicationConstants.EntityTypes.Vacancy, vacancyReference);
-            commsRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceUrl, vacancyReference);
+            commsRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipService, vacancyReference);
             return commsRequest;
         }
 

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/VacancyReferredDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/VacancyReferredDomainEventHandler.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
             var commsRequest = new CommunicationRequest(
                 CommunicationConstants.RequestType.VacancyRejected, CommunicationConstants.ServiceName, CommunicationConstants.ServiceName);
             commsRequest.AddEntity(CommunicationConstants.EntityTypes.Vacancy, vacancyReference);
-            commsRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceUrl, vacancyReference);
+            commsRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipService, vacancyReference);
             return commsRequest;
         }
     }

--- a/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
@@ -117,11 +117,11 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddTransient<ICommunicationProcessor, CommunicationProcessor>();
             services.AddTransient<ICommunicationService, CommunicationService>();
 
-            services.AddTransient<IEntityDataItemProvider, VacancyPlugin>();
+            services.AddTransient<IEntityDataItemProvider, VacancyDataEntityPlugin>();
             services.AddTransient<IParticipantResolver, ParticipantResolverPlugin>();
             services.AddTransient<IUserPreferencesProvider, UserPreferencesProviderPlugin>();
             services.AddTransient<ITemplateIdProvider, TemplateIdProviderPlugin>();
-            services.AddTransient<IEntityDataItemProvider, ApprenticeshipServiceUrlPlugin>();
+            services.AddTransient<IEntityDataItemProvider, ApprenticeshipServiceDataEntityPlugin>();
 
             services.Configure<CommunicationsConfiguration>(configuration.GetSection("CommunicationsConfiguration"));
         }

--- a/src/Shared/Recruit.Shared.Web/Views/RecruitViewConstants.cs
+++ b/src/Shared/Recruit.Shared.Web/Views/RecruitViewConstants.cs
@@ -2,7 +2,7 @@ namespace Esfa.Recruit.Shared.Web.Views
 {
     public static class RecruitViewConstants
     {
-        public const string HelpdeskPhoneNumber = "08000 150 600";
+        public const string HelpdeskPhoneNumber = Esfa.Recruit.Vacancies.Client.Application.Constants.HelpdeskPhoneNumber;
         public const string HelpdeskPhoneCharges = "https://www.gov.uk/call-charges";
         public const string HelpdeskEmailAddress = "helpdesk@manage-apprenticeships.service.gov.uk";
         public const string VacancyServicesRAAEmailAddress = "VacancyServices.RAA@education.gov.uk";

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
@@ -6,10 +6,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
 
         public const string UserType = "VacancyServices.Recruit.User";
 
+        public const string HelpdeskPhoneNumber = "08000 150 600";
+
         public static class EntityTypes
         {
             public const string Vacancy = nameof(Vacancy);
-            public const string ApprenticeshipServiceUrl = nameof(ApprenticeshipServiceUrl);
+            public const string ApprenticeshipService = nameof(ApprenticeshipService);
         }
 
         public static class RequestType
@@ -31,6 +33,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             public static class ApprenticeshipService
             {
                 public const string ApprenticeshipServiceUrl = "apprenticeship-service-url";
+                public const string HelpdeskPhoneNumber = "helpdesk-number";
             }
         }
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
@@ -6,7 +6,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
 
         public const string UserType = "VacancyServices.Recruit.User";
 
-        public const string HelpdeskPhoneNumber = "08000 150 600";
+        public const string HelpdeskPhoneNumber = Esfa.Recruit.Vacancies.Client.Application.Constants.HelpdeskPhoneNumber;
 
         public static class EntityTypes
         {

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/EntityDataItemProviderPlugins/VacancyDataEntityPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/EntityDataItemProviderPlugins/VacancyDataEntityPlugin.cs
@@ -9,12 +9,12 @@ using static Esfa.Recruit.Vacancies.Client.Application.Communications.Communicat
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Communications.EntityDataItemProviderPlugins
 {
-    public class VacancyPlugin : IEntityDataItemProvider
+    public class VacancyDataEntityPlugin : IEntityDataItemProvider
     {
         private readonly IVacancyRepository _vacancyRepository;
         public string EntityType => CommunicationConstants.EntityTypes.Vacancy;
 
-        public VacancyPlugin(IVacancyRepository vacancyRepository)
+        public VacancyDataEntityPlugin(IVacancyRepository vacancyRepository)
         {
             _vacancyRepository = vacancyRepository;
         }
@@ -23,7 +23,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications.EntityDataIte
         {
             if(int.TryParse(entityId.ToString(), out var vacancyReference) == false)
             {
-                throw new InvalidEntityIdException(EntityType, nameof(VacancyPlugin));
+                throw new InvalidEntityIdException(EntityType, nameof(VacancyDataEntityPlugin));
             }
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(vacancyReference);

--- a/src/Shared/Recruit.Vacancies.Client/Application/Constants.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Constants.cs
@@ -1,0 +1,7 @@
+namespace Esfa.Recruit.Vacancies.Client.Application
+{
+    public static class Constants
+    {
+        public const string HelpdeskPhoneNumber = "08000 150 600";
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/EventHandlers/NotifyOnVacancyActionsEventHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/EventHandlers/NotifyOnVacancyActionsEventHandler.cs
@@ -5,11 +5,8 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
-using Communication.Types;
-using Esfa.Recruit.Vacancies.Client.Application.Communications;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.EventHandlers
 {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/VacancyClosedEventHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/EventHandlers/VacancyClosedEventHandler.cs
@@ -86,6 +86,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.EventHandlers
                 CommunicationConstants.ServiceName);
 
             communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Vacancy, vacancyReference);
+            communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipService, vacancyReference);
             return communicationRequest;
         }
 

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ApprenticeshipServiceUrlPluginTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ApprenticeshipServiceUrlPluginTests.cs
@@ -56,8 +56,8 @@ namespace UnitTests.Vacancies.Client.Application.Communications
 
             dataItems.Count().Should().Be(2);
 
-            dataItems.First(d => d.Key == DataItemKeys.ApprenticeshipService.ApprenticeshipServiceUrl).Value.Should().Be(expectedUrl);
-            dataItems.First(d => d.Key == DataItemKeys.ApprenticeshipService.HelpdeskPhoneNumber).Value.Should().Be(CommunicationConstants.HelpdeskPhoneNumber);
+            dataItems.Single(d => d.Key == DataItemKeys.ApprenticeshipService.ApprenticeshipServiceUrl).Value.Should().Be(expectedUrl);
+            dataItems.Single(d => d.Key == DataItemKeys.ApprenticeshipService.HelpdeskPhoneNumber).Value.Should().Be(CommunicationConstants.HelpdeskPhoneNumber);
         }
 
     }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ApprenticeshipServiceUrlPluginTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ApprenticeshipServiceUrlPluginTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using Esfa.Recruit.Client.Application.Communications;
+using Esfa.Recruit.Vacancies.Client.Application.Communications;
 using Esfa.Recruit.Vacancies.Client.Application.Communications.EntityDataItemProviderPlugins;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
@@ -13,7 +14,7 @@ using static Esfa.Recruit.Vacancies.Client.Application.Communications.Communicat
 
 namespace UnitTests.Vacancies.Client.Application.Communications
 {
-    public class ApprenticeshipServiceUrlPluginTests
+    public class ApprenticeshipServiceDataEntityPluginTests
     {
         private readonly Fixture _fixture = new Fixture();
         const string EmployerUrl = "https://www.google.com/";
@@ -22,9 +23,9 @@ namespace UnitTests.Vacancies.Client.Application.Communications
         private readonly Mock<IOptions<CommunicationsConfiguration>> _mockOptions = new Mock<IOptions<CommunicationsConfiguration>>();
         private readonly Mock<IVacancyRepository> _mockRepository = new Mock<IVacancyRepository>();
 
-        private ApprenticeshipServiceUrlPlugin GetSut() => new ApprenticeshipServiceUrlPlugin(_mockRepository.Object, _mockOptions.Object);
+        private ApprenticeshipServiceDataEntityPlugin GetSut() => new ApprenticeshipServiceDataEntityPlugin(_mockRepository.Object, _mockOptions.Object);
 
-        public ApprenticeshipServiceUrlPluginTests()
+        public ApprenticeshipServiceDataEntityPluginTests()
         {
             _mockOptions.Setup(m => m.Value).Returns(new CommunicationsConfiguration{EmployersApprenticeshipServiceUrl = EmployerUrl, ProvidersApprenticeshipServiceUrl = ProviderUrl});
         }
@@ -53,10 +54,10 @@ namespace UnitTests.Vacancies.Client.Application.Communications
 
             var dataItems = await sut.GetDataItemsAsync(_fixture.Create<long>());
 
-            dataItems.Count().Should().Be(1);
+            dataItems.Count().Should().Be(2);
 
-            dataItems.Single().Key.Should().Be(DataItemKeys.ApprenticeshipService.ApprenticeshipServiceUrl);
-            dataItems.Single().Value.Should().Be(expectedUrl);
+            dataItems.First(d => d.Key == DataItemKeys.ApprenticeshipService.ApprenticeshipServiceUrl).Value.Should().Be(expectedUrl);
+            dataItems.First(d => d.Key == DataItemKeys.ApprenticeshipService.HelpdeskPhoneNumber).Value.Should().Be(CommunicationConstants.HelpdeskPhoneNumber);
         }
 
     }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Communications/VacancyDataEntityPluginTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Communications/VacancyDataEntityPluginTests.cs
@@ -11,11 +11,11 @@ using static Esfa.Recruit.Vacancies.Client.Application.Communications.Communicat
 
 namespace UnitTests.Vacancies.Client.Application.Communications
 {
-    public class VacancyPluginTests
+    public class VacancyDataEntityPluginTests
     {
         private readonly Mock<IVacancyRepository> _mockRepository = new Mock<IVacancyRepository>();
         private readonly Fixture _fixture = new Fixture();
-        private VacancyPlugin GetSut() => new VacancyPlugin(_mockRepository.Object);
+        private VacancyDataEntityPlugin GetSut() => new VacancyDataEntityPlugin(_mockRepository.Object);
 
         [Theory]
         [InlineData(EmployerNameOption.TradingName)]


### PR DESCRIPTION
…ude helpdesk number

There was a specific data item entity provider `ApprenticeshipServiceUrl` to provider uri to either employer or provider. 

In my last PR, Chris suggested that the helpdesk number on the email template should be populated from the config. So I refactored `ApprenticeshipServiceUrl` provider to be more generic to include helpdesk phone number.

I found that the phone number was in a constant in shared web, which cannot be used in shared client, so I created another constant in the client. 

This phone number is required for the blocked communications as well so I wanted to get this refactoring checked in sooner. 
