### PR TITLE
ER-1406 - Added content for employer vacancies closed due to blocked provider

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -15,8 +15,6 @@ using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Shared.Web.Mappers;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyAnalytics;
 using Esfa.Recruit.Shared.Web.FeatureToggle;
-using Esfa.Recruit.Employer.Web.Configuration;
-using Esfa.Recruit.Shared.Web.Configuration;
 using Employer.Web.Configuration;
 using Esfa.Recruit.Shared.Web.Helpers;
 
@@ -27,14 +25,12 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
         private const VacancyRuleSet ValdationRules = VacancyRuleSet.ClosingDate | VacancyRuleSet.StartDate | VacancyRuleSet.TrainingProgramme | VacancyRuleSet.StartDateEndDate | VacancyRuleSet.TrainingExpiryDate | VacancyRuleSet.MinimumWage;
         private readonly DisplayVacancyViewModelMapper _vacancyDisplayMapper;
         private readonly IRecruitVacancyClient _client;
-        private readonly IFeature _featureToggle;
         private readonly EmployerRecruitSystemConfiguration _systemConfig;
 
-        public VacancyManageOrchestrator(ILogger<VacancyManageOrchestrator> logger, DisplayVacancyViewModelMapper vacancyDisplayMapper, IRecruitVacancyClient vacancyClient, IFeature featureToggle, EmployerRecruitSystemConfiguration systemConfig) : base(logger)
+        public VacancyManageOrchestrator(ILogger<VacancyManageOrchestrator> logger, DisplayVacancyViewModelMapper vacancyDisplayMapper, IRecruitVacancyClient vacancyClient, EmployerRecruitSystemConfiguration systemConfig) : base(logger)
         {
             _vacancyDisplayMapper = vacancyDisplayMapper;
             _client = vacancyClient;
-            _featureToggle = featureToggle;
             _systemConfig = systemConfig;
         }
 
@@ -63,6 +59,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             viewModel.TransferredOnDate = vacancy.TransferInfo?.TransferredDate.AsGdsDate();
             viewModel.CanShowEditVacancyLink = vacancy.CanExtendStartAndClosingDates;
             viewModel.CanShowCloseVacancyLink = vacancy.CanClose;
+            viewModel.IsClosedBlockedByQa = vacancy.Status == VacancyStatus.Closed && vacancy.ClosureReason == ClosureReason.BlockedByQa;
 
             if (vacancy.Status == VacancyStatus.Closed && vacancy.ClosureReason == ClosureReason.WithdrawnByQa)
             {

--- a/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
@@ -17,6 +17,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyManage
         public bool IsApplyThroughFaaVacancy { get; internal set; }
         public bool IsApplyThroughExternalApplicationSiteVacancy => !IsApplyThroughFaaVacancy;
         public bool IsWithdrawn => string.IsNullOrEmpty(WithdrawnDate) == false;
+        public bool IsClosedBlockedByQa { get; set; }
         public VacancyApplicationsViewModel Applications { get; internal set; }
         public bool HasApplications => Applications.Applications.Any();
         public bool HasNoApplications => Applications.Applications == null || Applications.Applications?.Any() == false;

--- a/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
@@ -9,16 +9,20 @@
         <h3 class="govuk-heading-xl govuk-!-margin-top-6 govuk-!-margin-bottom-6" id="vacancy-header">
             Manage vacancy
         </h3>
-
-        <p asp-show="@Model.IsTransferred" class="govuk-inset-text">This vacancy was created by 
-            <span class="govuk-!-font-weight-bold">@Model.TransferredProviderName</span> 
+        <p asp-show="@Model.IsTransferred" class="govuk-inset-text">
+            This vacancy was created by
+            <span class="govuk-!-font-weight-bold">@Model.TransferredProviderName</span>
             and transferred to your account on @Model.TransferredOnDate
         </p>
-    
+
         <p asp-show="@Model.IsWithdrawn" class="govuk-inset-text">
             This vacancy has issues and was closed on @Model.WithdrawnDate.
         </p>
-    
+
+        <p asp-show="@Model.IsClosedBlockedByQa" class="govuk-inset-text">
+            This vacancy was closed on @Model.ClosingDate because the training provider is no longer able to manage or recruit apprentices.
+        </p>
+
         <div asp-show="@Model.HasVacancyClosedInfoMessage" class="info-summary govuk-!-margin-bottom-0">
             <p class="govuk-body">@Model.VacancyClosedInfoMessage</p>
             <p class="govuk-body">The vacancy will be unpublished from the Find an apprenticeship service within the next hour.</p>

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
@@ -31,7 +31,9 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(eventData.VacancyId);
 
-            if (vacancy.OwnerType == Entities.OwnerType.Provider)
+            var isTransfer = vacancy.OwnerType == Entities.OwnerType.Provider;
+
+            if (isTransfer)
             {
                 await _messaging.SendCommandAsync(
                     new TransferProviderVacancyCommand(
@@ -49,7 +51,9 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             if (vacancy.Status == Entities.VacancyStatus.Live)
             {
-                await _messaging.SendCommandAsync(new CloseVacancyCommand(vacancy.Id, eventData.QaVacancyUser, Entities.ClosureReason.BlockedByQa));
+                var closureReason = isTransfer ? Entities.ClosureReason.TransferredByQa : Entities.ClosureReason.BlockedByQa;
+
+                await _messaging.SendCommandAsync(new CloseVacancyCommand(vacancy.Id, eventData.QaVacancyUser, closureReason));
             }
         }
     }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Vacancy/ProviderBlockedOnVacancyDomainEventHandler.cs
@@ -31,9 +31,9 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(eventData.VacancyId);
 
-            var isTransfer = vacancy.OwnerType == Entities.OwnerType.Provider;
+            var hasToBeTransferred = vacancy.OwnerType == Entities.OwnerType.Provider;
 
-            if (isTransfer)
+            if (hasToBeTransferred)
             {
                 await _messaging.SendCommandAsync(
                     new TransferProviderVacancyCommand(
@@ -51,7 +51,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Vacancy
 
             if (vacancy.Status == Entities.VacancyStatus.Live)
             {
-                var closureReason = isTransfer ? Entities.ClosureReason.TransferredByQa : Entities.ClosureReason.BlockedByQa;
+                var closureReason = hasToBeTransferred ? Entities.ClosureReason.TransferredByQa : Entities.ClosureReason.BlockedByQa;
 
                 await _messaging.SendCommandAsync(new CloseVacancyCommand(vacancy.Id, eventData.QaVacancyUser, closureReason));
             }

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApproveVacancyReviewCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApproveVacancyReviewCommandHandler.cs
@@ -88,7 +88,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
             }
             else
             {
-                return ClosureReason.BlockedByQa;
+                return ClosureReason.TransferredByQa;
             }
         }
 


### PR DESCRIPTION
Added some content to the Manage vacancy screen for closed vacancies.

Also added fix so:

> 1. if the vacancy to be closed is one where an employer has given permission (so the provider created it) then it is transferred to the employer. closure reason = transferred by QA
> 2. if the vacancy to be closed is NOT one where an employer has given permission (they created it themselves and chose the provider) then it is just closed. closure reason = blocked by QA
