### PR TITLE
ER-1489 - wage and pay validations. Employer.Web

### DIFF
--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -32,9 +32,12 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         public async Task<IActionResult> VacancyPreview(VacancyRouteModel vrm)
         {
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(vrm);
+            AddSoftValidationErrorsToModelState(viewModel);
             SetSectionStates(viewModel);
-            viewModel.IncompleteSectionCount = GetSectionStateCount(viewModel);
-            viewModel.IncompleteSectionText = "section".ToQuantity(viewModel.IncompleteSectionCount, ShowQuantityAs.None);
+            SetSectionCount(viewModel);
+
+            viewModel.HideValidationSummary = true;
+            
             return View(viewModel);
         }
 
@@ -60,9 +63,10 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             }
 
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);
+            viewModel.SoftValidationErrors = null;
             SetSectionStates(viewModel);
-            viewModel.IncompleteSectionCount = GetSectionStateCount(viewModel);
-            viewModel.IncompleteSectionText = "section".ToQuantity(viewModel.IncompleteSectionCount, ShowQuantityAs.None);
+            SetSectionCount(viewModel);
+
             return View(ViewNames.VacancyPreview, viewModel);
         }
 
@@ -72,8 +76,8 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             viewModel.ShortDescriptionSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.ShortDescription }, true, vm => vm.ShortDescription);
             viewModel.ClosingDateSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.ClosingDate }, true, vm => vm.ClosingDate);
             viewModel.WorkingWeekSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.WorkingWeek }, true, vm => vm.HoursPerWeek, vm => vm.WorkingWeekDescription);
-            viewModel.WageTextSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.Wage }, true, vm => vm.HasWage, vm => vm.PossibleStartDate);
-            viewModel.ExpectedDurationSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.ExpectedDuration }, true, vm => vm.HasWage, vm => vm.ExpectedDuration);
+            viewModel.WageTextSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.Wage }, true, vm => vm.HasWage, vm => vm.WageText);
+            viewModel.ExpectedDurationSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.ExpectedDuration }, true, vm => vm.ExpectedDuration);
             viewModel.PossibleStartDateSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.PossibleStartDate }, true, vm => vm.PossibleStartDate);
             viewModel.TrainingLevelSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.TrainingLevel }, true, vm => vm.HasProgramme, vm => vm.TrainingLevel);
             viewModel.NumberOfPositionsSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.NumberOfPositions }, true, vm => vm.NumberOfPositions);
@@ -207,6 +211,23 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             return reviewFieldIndicators != null && reviewFieldIndicators.Any(reviewFieldIndicator =>
                        vm.Review.FieldIndicators.Select(r => r.ReviewFieldIdentifier)
                            .Contains(reviewFieldIndicator));
+        }
+
+        private void SetSectionCount(VacancyPreviewViewModel viewModel)
+        {
+            viewModel.IncompleteSectionCount = GetSectionStateCount(viewModel);
+            viewModel.IncompleteSectionText = "section".ToQuantity(viewModel.IncompleteSectionCount, ShowQuantityAs.None);
+        }
+
+        private void AddSoftValidationErrorsToModelState(VacancyPreviewViewModel viewModel)
+        {
+            if (!viewModel.SoftValidationErrors.HasErrors)
+                return;
+
+            foreach (var error in viewModel.SoftValidationErrors.Errors)
+            {
+                ModelState.AddModelError(error.PropertyName, error.ErrorMessage);
+            }
         }
     }
 }

--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             SetSectionStates(viewModel);
             SetSectionCount(viewModel);
 
-            viewModel.HideValidationSummary = true;
+            viewModel.CanHideValidationSummary = true;
             
             return View(viewModel);
         }

--- a/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -13,6 +13,8 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;
+using SFA.DAS.VacancyServices.Wage;
+using WageType = Esfa.Recruit.Vacancies.Client.Domain.Entities.WageType;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
 {
@@ -44,11 +46,11 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
                 FixedWageYearlyAmount = vacancy.Wage?.FixedWageYearlyAmount?.AsMoney(),
                 WageAdditionalInformation = vacancy.Wage?.WageAdditionalInformation,
                 MinimumWageStartFrom = wagePeriod.ValidFrom.ToMonthNameYearString(),
-                NationalMinimumWageLowerBound = wagePeriod.NationalMinimumWageLowerBound.ToString("C"),
-                NationalMinimumWageUpperBound = wagePeriod.NationalMinimumWageUpperBound.ToString("C"),
-                NationalMinimumWageYearly = GetMinimumWageYearlyText(WageType.NationalMinimumWage, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
-                ApprenticeshipMinimumWage = wagePeriod.ApprenticeshipMinimumWage.ToString("C"),
-                ApprenticeshipMinimumWageYearly = GetMinimumWageYearlyText(WageType.NationalMinimumWageForApprentices, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
+                NationalMinimumWageLowerBoundHourly = wagePeriod.NationalMinimumWageLowerBound.ToString("C"),
+                NationalMinimumWageUpperBoundHourly = wagePeriod.NationalMinimumWageUpperBound.ToString("C"),
+                NationalMinimumWageYearly = GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType.NationalMinimum, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
+                ApprenticeshipMinimumWageHourly = wagePeriod.ApprenticeshipMinimumWage.ToString("C"),
+                ApprenticeshipMinimumWageYearly = GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType.ApprenticeshipMinimum, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
                 WeeklyHours = vacancy.Wage.WeeklyHours.Value,
                 PageInfo = Utility.GetPartOnePageInfo(vacancy)
             };
@@ -91,15 +93,13 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators.Part1
             );
         }
 
-        private string GetMinimumWageYearlyText(WageType wageType, decimal? weeklyHours, DateTime startDate)
+        private string GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType wageType, decimal? weeklyHours, DateTime startDate)
         {
-            var wage = new Wage
+            return WagePresenter.GetDisplayText(wageType, WageUnit.Annually, new WageDetails
             {
-                WageType = wageType,
-                WeeklyHours = weeklyHours
-            };
-
-            return wage.ToText(startDate);
+                HoursPerWeek = weeklyHours,
+                StartDate = startDate
+            }).AsWholeMoneyAmount();
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, WageEditModel> DefineMappings()

--- a/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -20,7 +20,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 {
     public class VacancyPreviewOrchestrator : EntityValidatingOrchestrator<Vacancy, VacancyPreviewViewModel>
     {
-        private const VacancyRuleSet ValidationRules = VacancyRuleSet.All;
+        private const VacancyRuleSet SubmitValidationRules = VacancyRuleSet.All;
         private const VacancyRuleSet SoftValidationRules = VacancyRuleSet.MinimumWage;
 
         private readonly IEmployerVacancyClient _client;
@@ -91,14 +91,16 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
             return await ValidateAndExecute(
                 vacancy,
-                v =>
-                {
-                    var result = _vacancyClient.Validate(v, ValidationRules);
-                    FlattenErrors(result.Errors);
-                    return result;
-                },
+                v => ValidateVacancy(v, SubmitValidationRules),
                 v => SubmitActionAsync(v, user)
                 );
+        }
+
+        private EntityValidationResult ValidateVacancy(Vacancy vacancy, VacancyRuleSet rules)
+        {
+            var result = _vacancyClient.Validate(vacancy, rules);
+            FlattenErrors(result.Errors);
+            return result;
         }
 
         private async Task<SubmitVacancyResponse> SubmitActionAsync(Vacancy vacancy, VacancyUser user)
@@ -130,8 +132,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
         private EntityValidationResult GetSoftValidationErrors(Vacancy vacancy)
         {
-            var result = _vacancyClient.Validate(vacancy, SoftValidationRules);
-            FlattenErrors(result.Errors);
+            var result = ValidateVacancy(vacancy, SoftValidationRules);
             MapValidationPropertiesToViewModel(result);
             return result;
         }

--- a/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/Part1/Wage/WageViewModel.cs
@@ -16,10 +16,10 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.Part1.Wage
         public string WageAdditionalInformation { get; set; }
 
         public string MinimumWageStartFrom { get; set; }
-        public string NationalMinimumWageLowerBound { get; set; }
-        public string NationalMinimumWageUpperBound { get; set; }
+        public string NationalMinimumWageLowerBoundHourly { get; set; }
+        public string NationalMinimumWageUpperBoundHourly { get; set; }
         public string NationalMinimumWageYearly { get; set; }
-        public string ApprenticeshipMinimumWage { get; set; }
+        public string ApprenticeshipMinimumWageHourly { get; set; }
         public string ApprenticeshipMinimumWageYearly { get; set; }
         public decimal WeeklyHours { get; set; }
 

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Esfa.Recruit.Shared.Web.Mappers;
 using Esfa.Recruit.Shared.Web.ViewModels;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
@@ -32,7 +33,10 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
         public VacancyPreviewSectionState WageTextSectionState { get; internal set; }
         public VacancyPreviewSectionState DescriptionsSectionState { get; internal set; }
         public VacancyPreviewSectionState WorkingWeekSectionState { get; internal set; }
-        
+
+        public EntityValidationResult SoftValidationErrors { get; internal set; }
+        public bool HideValidationSummary { get; internal set; }
+
         public bool HasWage { get; internal set; }
         public bool HasProgramme { get; internal set; }
 
@@ -58,7 +62,10 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
         public bool HasIncompleteOptionalSections => HasIncompleteThingsToConsiderSection
                                                     || HasIncompleteEmployerWebsiteUrlSection
                                                     || HasIncompleteContactSection;
-        public bool ShowIncompleteSections => (HasIncompleteMandatorySections || HasIncompleteOptionalSections) && !Review.HasBeenReviewed;
+
+        public bool HasSoftValidationErrors => SoftValidationErrors?.HasErrors == true;
+
+        public bool ShowIncompleteSections => ((HasIncompleteMandatorySections || HasIncompleteOptionalSections) && !Review.HasBeenReviewed) || HasSoftValidationErrors;
         public ReviewSummaryViewModel Review { get; set; } = new ReviewSummaryViewModel();
         public string SubmitButtonText => Review.HasBeenReviewed ? "Resubmit vacancy" : "Submit vacancy";
         public bool ApplicationInstructionsRequiresEdit => IsEditRequired(FieldIdentifiers.ApplicationInstructions);
@@ -95,6 +102,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
         public int IncompleteSectionCount { get; set; }
         public string IncompleteSectionText { get; set; }
         public ProgrammeLevel Level { get; set; }
+
         public IList<string> OrderedFieldNames => new List<string>
         {
             nameof(ShortDescription),

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
@@ -35,7 +35,7 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
         public VacancyPreviewSectionState WorkingWeekSectionState { get; internal set; }
 
         public EntityValidationResult SoftValidationErrors { get; internal set; }
-        public bool HideValidationSummary { get; internal set; }
+        public bool CanHideValidationSummary { get; internal set; }
 
         public bool HasWage { get; internal set; }
         public bool HasProgramme { get; internal set; }

--- a/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
+++ b/src/Employer/Employer.Web/Views/Part1/Wage/Wage.cshtml
@@ -31,7 +31,7 @@
                         <div id="wage-type-national-minimum-wage-panel" class="govuk-radios__conditional govuk-radios__conditional--hidden">
                             <div class="govuk-form-group">
                                 <p class="govuk-body">
-                                    <span class="govuk-hint">As of @Model.MinimumWageStartFrom, National Minimum Wage is set at an hourly rate from @Model.NationalMinimumWageLowerBound to @Model.NationalMinimumWageUpperBound depending on the candidates age.<br><br>
+                                    <span class="govuk-hint">As of @Model.MinimumWageStartFrom, National Minimum Wage is set at an hourly rate from @Model.NationalMinimumWageLowerBoundHourly to @Model.NationalMinimumWageUpperBoundHourly depending on the candidates age.<br><br>
                                         On the vacancy this will be displayed as a yearly figure of @Model.NationalMinimumWageYearly</span>
                                 </p>
                             </div>
@@ -45,7 +45,7 @@
                             <div class="govuk-form-group">
                                 <p class="govuk-body">
                                     <span class="govuk-hint">
-                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWage.<br><br>
+                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWageHourly.<br><br>
                                         On the vacancy this will be displayed as a yearly figure of @Model.ApprenticeshipMinimumWageYearly
                                     </span>
                                 </p>
@@ -59,16 +59,15 @@
                         <div id="custom-wage-fixed-panel" class="govuk-radios__conditional govuk-radios__conditional--hidden">
                             <fieldset class="govuk-fieldset">
                                 <div esfa-validation-marker-for="FixedWageYearlyAmount" class="govuk-form-group">
-                                    <span esfa-validation-message-for="FixedWageYearlyAmount" class="govuk-error-message"></span>
                                     <label asp-for="FixedWageYearlyAmount" class="govuk-visually-hidden">Yearly wage</label>
                                     <p class="govuk-body govuk-hint">
                                         This must be more than the <a href="@externalLinks.Value.NationalMinimumWageRates" rel="noopener" target="_blank">National Minimum Wage for apprentices.</a>
                                     </p>
-
                                     <p class="govuk-body govuk-hint">
-                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWage, Based on working hours of @Model.WeeklyHours hours per week, you will need to set a yearly figure of at least 
+                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWageHourly, Based on working hours of @Model.WeeklyHours hours per week, you will need to set a yearly figure of at least
                                         <span class="govuk-!-font-weight-bold">@Model.ApprenticeshipMinimumWageYearly</span>
                                     </p>
+                                    <span esfa-validation-message-for="FixedWageYearlyAmount" class="govuk-error-message"></span>
                                     <input asp-for="FixedWageYearlyAmount" class="govuk-input govuk-!-width-one-quarter" type="text">
                                     <span class="govuk-body">yearly</span>
                                 </div>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -43,7 +43,7 @@
             </p>
         </div>
 
-        <partial asp-hide="@Model.HideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
+        <partial asp-hide="@Model.CanHideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
         <div class="info-summary__header-bar" asp-show="@Model.HasIncompleteMandatorySections">
             <h2 class="govuk-heading-m">@Model.IncompleteSectionCount required @Model.IncompleteSectionText to complete</h2>
         </div>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -43,7 +43,7 @@
             </p>
         </div>
 
-        <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
+        <partial asp-hide="@Model.HideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
         <div class="info-summary__header-bar" asp-show="@Model.HasIncompleteMandatorySections">
             <h2 class="govuk-heading-m">@Model.IncompleteSectionCount required @Model.IncompleteSectionText to complete</h2>
         </div>
@@ -51,6 +51,19 @@
             <h2 class="govuk-heading-m">You have completed all required sections</h2>
         </div>
         <div asp-show="@Model.ShowIncompleteSections" class="info-summary govuk-!-margin-top-0" role="alert">
+            <div asp-show="Model.HasSoftValidationErrors">
+                <p class="govuk-body">
+                    Sections you will need to update:
+                </p>
+                <ul class=" govuk-list govuk-error-summary__list govuk-!-margin-bottom-4">
+                    @foreach (var softError in Model.SoftValidationErrors.Errors.OrderBy(x => Model.OrderedFieldNames.IndexOf(x.PropertyName)))
+                    {
+                        var softErrorVm = new ErrorListItemViewModel(softError.PropertyName, softError.ErrorMessage);
+                        <partial name="@RecruitPartialNames.ErrorListItem" model="@softErrorVm" />
+                    }
+                </ul>
+            </div>
+
             <div asp-show="@Model.HasIncompleteMandatorySections">
                 <p class="govuk-body">Sections you will need to complete:</p>
                 <ul class="govuk-list">

--- a/src/Provider/Provider.Web/Orchestrators/Part1/WageOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/Part1/WageOrchestrator.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Logging;
 using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
+using SFA.DAS.VacancyServices.Wage;
+using WageType = Esfa.Recruit.Vacancies.Client.Domain.Entities.WageType;
 
 namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
 {
@@ -47,11 +49,11 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
                 FixedWageYearlyAmount = vacancy.Wage?.FixedWageYearlyAmount?.AsMoney(),
                 WageAdditionalInformation = vacancy.Wage?.WageAdditionalInformation,
                 MinimumWageStartFrom = wagePeriod.ValidFrom.ToMonthNameYearString(),
-                NationalMinimumWageLowerBound = wagePeriod.NationalMinimumWageLowerBound.ToString("C"),
-                NationalMinimumWageUpperBound = wagePeriod.NationalMinimumWageUpperBound.ToString("C"),
-                NationalMinimumWageYearly = GetMinimumWageYearlyText(WageType.NationalMinimumWage, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
-                ApprenticeshipMinimumWage = wagePeriod.ApprenticeshipMinimumWage.ToString("C"),
-                ApprenticeshipMinimumWageYearly = GetMinimumWageYearlyText(WageType.NationalMinimumWageForApprentices, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
+                NationalMinimumWageLowerBoundHourly = wagePeriod.NationalMinimumWageLowerBound.ToString("C"),
+                NationalMinimumWageUpperBoundHourly = wagePeriod.NationalMinimumWageUpperBound.ToString("C"),
+                NationalMinimumWageYearly = GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType.NationalMinimum, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
+                ApprenticeshipMinimumWageHourly = wagePeriod.ApprenticeshipMinimumWage.ToString("C"),
+                ApprenticeshipMinimumWageYearly = GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType.ApprenticeshipMinimum, vacancy.Wage?.WeeklyHours, vacancy.StartDate.Value),
                 WeeklyHours = vacancy.Wage.WeeklyHours.Value,
                 PageInfo = Utility.GetPartOnePageInfo(vacancy)
             };
@@ -94,15 +96,13 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators.Part1
             );
         }
 
-        private string GetMinimumWageYearlyText(WageType wageType, decimal? weeklyHours, DateTime startDate)
+        private string GetMinimumWageYearlyText(SFA.DAS.VacancyServices.Wage.WageType wageType, decimal? weeklyHours, DateTime startDate)
         {
-            var wage = new Wage
+            return WagePresenter.GetDisplayText(wageType, WageUnit.Annually, new WageDetails
             {
-                WageType = wageType,
-                WeeklyHours = weeklyHours
-            };
-
-            return wage.ToText(startDate);
+                HoursPerWeek = weeklyHours,
+                StartDate = startDate
+            }).AsWholeMoneyAmount();
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, WageEditModel> DefineMappings()

--- a/src/Provider/Provider.Web/ViewModels/Part1/Wage/WageViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Wage/WageViewModel.cs
@@ -16,10 +16,10 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Wage
         public string WageAdditionalInformation { get; set; }
 
         public string MinimumWageStartFrom { get; set; }
-        public string NationalMinimumWageLowerBound { get; set; }
-        public string NationalMinimumWageUpperBound { get; set; }
+        public string NationalMinimumWageLowerBoundHourly { get; set; }
+        public string NationalMinimumWageUpperBoundHourly { get; set; }
         public string NationalMinimumWageYearly { get; set; }
-        public string ApprenticeshipMinimumWage { get; set; }
+        public string ApprenticeshipMinimumWageHourly { get; set; }
         public string ApprenticeshipMinimumWageYearly { get; set; }
         public decimal WeeklyHours { get; set; }
 

--- a/src/Provider/Provider.Web/Views/Part1/Wage/Wage.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Wage/Wage.cshtml
@@ -27,7 +27,7 @@
                             <div class="govuk-form-group">
                                 <p class="govuk-body">
                                     <span class="govuk-hint">
-                                        As of @Model.MinimumWageStartFrom, National Minimum Wage is set at an hourly rate from @Model.NationalMinimumWageLowerBound to @Model.NationalMinimumWageUpperBound depending on the candidates age.<br><br>
+                                        As of @Model.MinimumWageStartFrom, National Minimum Wage is set at an hourly rate from @Model.NationalMinimumWageLowerBoundHourly to @Model.NationalMinimumWageUpperBoundHourly depending on the candidates age.<br><br>
                                         On the vacancy this will be displayed as a yearly figure of @Model.NationalMinimumWageYearly
                                     </span>
                                 </p>
@@ -41,7 +41,7 @@
                             <div class="govuk-form-group">
                                 <p class="govuk-body">
                                     <span class="govuk-hint">
-                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWage.<br><br>
+                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWageHourly.<br><br>
                                         On the vacancy this will be displayed as a yearly figure of @Model.ApprenticeshipMinimumWageYearly
                                     </span>
                                 </p>
@@ -54,15 +54,15 @@
                         <div id="custom-wage-fixed-panel" class="govuk-radios__conditional govuk-radios__conditional--hidden">
                             <fieldset class="govuk-fieldset">
                                 <div esfa-validation-marker-for="FixedWageYearlyAmount" class="govuk-form-group">
-                                    <span esfa-validation-message-for="FixedWageYearlyAmount" class="govuk-error-message"></span>
                                     <label asp-for="FixedWageYearlyAmount" class="govuk-visually-hidden">Yearly wage</label>
                                     <p class="govuk-body govuk-hint">
                                         This must be more than the <a href="@externalLinks.Value.NationalMinimumWageRates" rel="noopener" target="_blank">National Minimum Wage for apprentices.</a>
                                     </p>
                                     <p class="govuk-body govuk-hint">
-                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWage, Based on working hours of @Model.WeeklyHours hours per week, you will need to set a yearly figure of at least
+                                        As of @Model.MinimumWageStartFrom, National Minimum Wage for apprentices is set at an hourly rate of @Model.ApprenticeshipMinimumWageHourly, Based on working hours of @Model.WeeklyHours hours per week, you will need to set a yearly figure of at least
                                         <span class="govuk-!-font-weight-bold">@Model.ApprenticeshipMinimumWageYearly</span>
                                     </p>
+                                    <span esfa-validation-message-for="FixedWageYearlyAmount" class="govuk-error-message"></span>
                                     <input asp-for="FixedWageYearlyAmount" class="govuk-input govuk-!-width-one-quarter" type="text">
                                     <span class="govuk-body">yearly</span>
                                 </div>

--- a/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
+++ b/src/Shared/Recruit.Shared.Web/Extensions/StringExtensions.cs
@@ -13,12 +13,7 @@ namespace Esfa.Recruit.Shared.Web.Extensions
         {
             return value.Replace("/", string.Empty);
         }
-        public static string AsWholeMoneyAmount(this string value)
-        {
-            return value.Replace(".00", "");
-        }
-
-
+        
         public static string AsPostcode(this string postcode)
         {
             if (postcode?.Length > incodeLength)

--- a/src/Shared/Recruit.Shared.Web/Extensions/WageExtensions.cs
+++ b/src/Shared/Recruit.Shared.Web/Extensions/WageExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using SFA.DAS.VacancyServices.Wage;
 using WageType = Esfa.Recruit.Vacancies.Client.Domain.Entities.WageType;
 

--- a/src/Shared/Recruit.Shared.Web/ViewModels/ErrorListItemViewModel.cs
+++ b/src/Shared/Recruit.Shared.Web/ViewModels/ErrorListItemViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Esfa.Recruit.Shared.Web.ViewModels
+{
+    public class ErrorListItemViewModel
+    {
+        public ErrorListItemViewModel(string elementId, string message)
+        {
+            ElementId = elementId;
+            Message = message;
+        }
+
+        public string ElementId { get; }
+        public string Message {get; }
+    }
+}

--- a/src/Shared/Recruit.Shared.Web/Views/RecruitPartialNames.cs
+++ b/src/Shared/Recruit.Shared.Web/Views/RecruitPartialNames.cs
@@ -12,5 +12,6 @@ namespace Esfa.Recruit.Shared.Web.Views
         public const string ValidationSummary = "_ValidationSummaryPartial";
         public const string ApplyThroughExternalApplicationSiteVacancyAnalytics = "_ApplyThroughExternalApplicationSiteVacancyAnalyticsSummaryPartial";
         public const string ApplyThroughFaaVacancyAnalytics = "_ApplyThroughFaaVacancyAnalyticsSummaryPartial";
+        public const string ErrorListItem = "_ErrorListItemPartial";
     }
 }

--- a/src/Shared/Recruit.Shared.Web/Views/Shared/_ErrorListItemPartial.cshtml
+++ b/src/Shared/Recruit.Shared.Web/Views/Shared/_ErrorListItemPartial.cshtml
@@ -1,0 +1,13 @@
+﻿@model ErrorListItemViewModel
+
+<li>
+    @if (!string.IsNullOrEmpty(Model.ElementId))
+    {
+        <a href="#error-message-@Model.ElementId" data-focuses="error-message-@Model.ElementId" class="summary-link">@Model.Message</a>
+    }
+    else
+    {
+        <span>@Model.Message</span>
+    }
+</li>
+          

--- a/src/Shared/Recruit.Shared.Web/Views/Shared/_ValidationSummaryPartial.cshtml
+++ b/src/Shared/Recruit.Shared.Web/Views/Shared/_ValidationSummaryPartial.cshtml
@@ -10,20 +10,11 @@
     <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
             @foreach (var stateItem in Model.ModelState.Where(msi => msi.Value.ValidationState == ModelValidationState.Invalid)
-                                                        .OrderBy(x => Model.OrderedFieldNames.IndexOf(x.Key)))
+                                                       .OrderBy(x => Model.OrderedFieldNames.IndexOf(x.Key)))
             {
-                var elementName = ViewData.TemplateInfo.GetFullHtmlFieldName(stateItem.Key) ?? stateItem.Key;
-                var firstErrorPerField = stateItem.Value.Errors.FirstOrDefault()?.ErrorMessage;
-            <li>
-                @if (!string.IsNullOrEmpty(stateItem.Key))
-                {
-                <a href="#error-message-@elementName" data-focuses="error-message-@elementName" class="summary-link">@firstErrorPerField</a>
-                }
-                else
-                {
-                <span>@firstErrorPerField</span>
-                }
-            </li>
+                var errorVm = new ErrorListItemViewModel(ViewData.TemplateInfo.GetFullHtmlFieldName(stateItem.Key) ?? stateItem.Key,
+                    stateItem.Value.Errors.FirstOrDefault()?.ErrorMessage);
+                <partial name="@RecruitPartialNames.ErrorListItem" model="@errorVm" />
             }
         </ul>
     </div>

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/StringExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string AsWholeMoneyAmount(this string value)
+        {
+            return value.Replace(".00", "");
+        }
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/FixedWageAmountValidation.cs
@@ -63,7 +63,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.
 
             result.HasErrors.Should().BeTrue();
             result.Errors.Should().HaveCount(1);
-            result.Errors[0].PropertyName.Should().Be(string.Empty);
+            result.Errors[0].PropertyName.Should().Be($"{nameof(Wage)}.{nameof(Wage.FixedWageYearlyAmount)}" );
             result.Errors[0].ErrorCode.Should().Be("49");
             result.Errors[0].RuleId.Should().Be((long)VacancyRuleSet.MinimumWage);
         }


### PR DESCRIPTION
Added the concept of `Soft Validations`  these get run on the GET of the vacancy preview.

Refactored `_ValidationSummaryPartial.cshtml ` to pull out the generation of the error list into a separate partial `_ErrorListItemPartial.cshtml` so we can reuse when building the soft validations summary.

Refactored `WageOrchestrator.GetMinimumWageYearlyText` so directly uses `WagePresenter` without having to create a temporary `Wage`object.

