### PR TITLE
ER-1490 wages and pay validations. Provider.Web

### DIFF
--- a/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyPreviewController.cs
@@ -14,7 +14,6 @@ using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Shared.Web.Mappers;
-using Humanizer;
 
 namespace Esfa.Recruit.Employer.Web.Controllers
 {
@@ -34,7 +33,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(vrm);
             AddSoftValidationErrorsToModelState(viewModel);
             SetSectionStates(viewModel);
-            SetSectionCount(viewModel);
 
             viewModel.CanHideValidationSummary = true;
             
@@ -65,7 +63,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             var viewModel = await _orchestrator.GetVacancyPreviewViewModelAsync(m);
             viewModel.SoftValidationErrors = null;
             SetSectionStates(viewModel);
-            SetSectionCount(viewModel);
 
             return View(ViewNames.VacancyPreview, viewModel);
         }
@@ -96,33 +93,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             viewModel.ProviderSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.Provider }, true, vm => vm.ProviderName);
             viewModel.TrainingSectionState = GetSectionState(viewModel, new[] { FieldIdentifiers.Training }, true, vm => vm.TrainingType, vm => vm.TrainingTitle);
             viewModel.DisabilityConfidentSectionState = GetSectionState(viewModel, new[]{ FieldIdentifiers.DisabilityConfident}, true, vm => vm.IsDisabilityConfident);
-        }
-
-        private int GetSectionStateCount(VacancyPreviewViewModel viewModel)
-        {
-            var count = 0;
-            if (CheckIfSectionIsIncomplete(viewModel.ShortDescriptionSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.SkillsSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.DescriptionsSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.QualificationsSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.EmployerDescriptionSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.ProviderSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.TrainingSectionState))
-                count++;
-            if (CheckIfSectionIsIncomplete(viewModel.ApplicationMethodSectionState))
-                count++;
-            return count;
-        }
-
-        private bool CheckIfSectionIsIncomplete(VacancyPreviewSectionState viewModelTitleSectionState)
-        {
-            return viewModelTitleSectionState == VacancyPreviewSectionState.Incomplete || viewModelTitleSectionState == VacancyPreviewSectionState.InvalidIncomplete;
         }
 
         private VacancyPreviewSectionState GetSectionState(VacancyPreviewViewModel vm, IEnumerable<string> reviewFieldIndicators, bool requiresAll, params Expression<Func<VacancyPreviewViewModel, object>>[] sectionProperties)
@@ -211,12 +181,6 @@ namespace Esfa.Recruit.Employer.Web.Controllers
             return reviewFieldIndicators != null && reviewFieldIndicators.Any(reviewFieldIndicator =>
                        vm.Review.FieldIndicators.Select(r => r.ReviewFieldIdentifier)
                            .Contains(reviewFieldIndicator));
-        }
-
-        private void SetSectionCount(VacancyPreviewViewModel viewModel)
-        {
-            viewModel.IncompleteSectionCount = GetSectionStateCount(viewModel);
-            viewModel.IncompleteSectionText = "section".ToQuantity(viewModel.IncompleteSectionCount, ShowQuantityAs.None);
         }
 
         private void AddSoftValidationErrorsToModelState(VacancyPreviewViewModel viewModel)

--- a/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
@@ -4,6 +4,7 @@ using Esfa.Recruit.Shared.Web.Mappers;
 using Esfa.Recruit.Shared.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Humanizer;
 
 namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
 {
@@ -99,8 +100,20 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyPreview
         {
             return Review.FieldIndicators.Any(f => f.ReviewFieldIdentifier == fieldIdentifier);
         }
-        public int IncompleteSectionCount { get; set; }
-        public string IncompleteSectionText { get; set; }
+
+        public int IncompleteRequiredSectionCount => new []
+                {
+                    ShortDescriptionSectionState,
+                    SkillsSectionState,
+                    DescriptionsSectionState,
+                    QualificationsSectionState,
+                    EmployerDescriptionSectionState,
+                    ProviderSectionState,
+                    TrainingSectionState,
+                    ApplicationMethodSectionState
+                }.Count(s => s == VacancyPreviewSectionState.Incomplete || s == VacancyPreviewSectionState.InvalidIncomplete);
+
+        public string IncompleteRequiredSectionText => "section".ToQuantity(IncompleteRequiredSectionCount, ShowQuantityAs.None);
         public ProgrammeLevel Level { get; set; }
 
         public IList<string> OrderedFieldNames => new List<string>

--- a/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -45,7 +45,7 @@
 
         <partial asp-hide="@Model.CanHideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }'/>
         <div class="info-summary__header-bar" asp-show="@Model.HasIncompleteMandatorySections">
-            <h2 class="govuk-heading-m">@Model.IncompleteSectionCount required @Model.IncompleteSectionText to complete</h2>
+            <h2 class="govuk-heading-m">@Model.IncompleteRequiredSectionCount required @Model.IncompleteRequiredSectionText to complete</h2>
         </div>
         <div class="info-summary__header-bar govuk-!-margin-bottom-6" asp-hide="@Model.HasIncompleteMandatorySections">
             <h2 class="govuk-heading-m">You have completed all required sections</h2>

--- a/src/Provider/Provider.Web/Controllers/VacancyPreviewController.cs
+++ b/src/Provider/Provider.Web/Controllers/VacancyPreviewController.cs
@@ -37,7 +37,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers
             AddSoftValidationErrorsToModelState(viewModel);
             SetSectionStates(viewModel);
 
-            viewModel.HideValidationSummary = true;
+            viewModel.CanHideValidationSummary = true;
 
             return View(viewModel);
         }

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -8,7 +8,6 @@ using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.VacancyPreview;
 using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.Services;
-using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
@@ -21,6 +20,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
     public class VacancyPreviewOrchestrator : EntityValidatingOrchestrator<Vacancy, VacancyPreviewViewModel>
     {
         private const VacancyRuleSet ValidationRules = VacancyRuleSet.All;
+        private const VacancyRuleSet SoftValidationRules = VacancyRuleSet.MinimumWage;
+
         private readonly IProviderVacancyClient _client;
         private readonly IRecruitVacancyClient _vacancyClient;
         private readonly DisplayVacancyViewModelMapper _vacancyDisplayMapper;
@@ -47,24 +48,27 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
         public async Task<VacancyPreviewViewModel> GetVacancyPreviewViewModelAsync(VacancyRouteModel vrm)
         {
-            //var vacancy = await Utility.GetAuthorisedVacancyForEditAsync(_client, _vacancyClient, vrm, RouteNames.Vacancy_Preview_Get);
             var vacancyTask = Utility.GetAuthorisedVacancyForEditAsync(_client, _vacancyClient, vrm, RouteNames.Vacancy_Preview_Get);
             var programmesTask = _vacancyClient.GetActiveApprenticeshipProgrammesAsync();
 
             await Task.WhenAll(vacancyTask, programmesTask);
 
-            var programme = programmesTask.Result.SingleOrDefault(p => p.Id == vacancyTask.Result.ProgrammeId);
+            var vacancy = vacancyTask.Result;
+            var programme = programmesTask.Result.SingleOrDefault(p => p.Id == vacancy.ProgrammeId);
             var vm = new VacancyPreviewViewModel();
-            await _vacancyDisplayMapper.MapFromVacancyAsync(vm, vacancyTask.Result);
+            await _vacancyDisplayMapper.MapFromVacancyAsync(vm, vacancy);
             
-            vm.HasProgramme = vacancyTask.Result.ProgrammeId != null;
-            vm.HasWage = vacancyTask.Result.Wage != null;
-            vm.CanShowReference = vacancyTask.Result.Status != VacancyStatus.Draft;
-            vm.CanShowDraftHeader = vacancyTask.Result.Status == VacancyStatus.Draft;
+            vm.HasProgramme = vacancy.ProgrammeId != null;
+            vm.HasWage = vacancy.Wage != null;
+            vm.CanShowReference = vacancy.Status != VacancyStatus.Draft;
+            vm.CanShowDraftHeader = vacancy.Status == VacancyStatus.Draft;
+            vm.SoftValidationErrors = GetSoftValidationErrors(vacancy);
+
             if (programme != null) vm.Level = programme.Level;
-            if (vacancyTask.Result.Status == VacancyStatus.Referred)
+
+            if (vacancy.Status == VacancyStatus.Referred)
             {
-                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancyTask.Result.VacancyReference.Value, 
+                vm.Review = await _reviewSummaryService.GetReviewSummaryViewModelAsync(vacancy.VacancyReference.Value, 
                     ReviewFieldMappingLookups.GetPreviewReviewFieldIndicators());
             }
             
@@ -85,7 +89,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
                 v =>
                 {
                     var result = _vacancyClient.Validate(v, ValidationRules);
-                    SyncErrorsAndModel(result.Errors);
+                    FlattenErrors(result.Errors);
                     return result;
                 },
                 v => SubmitActionAsync(v, user)
@@ -115,13 +119,21 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             return response;
         }
 
-        private void SyncErrorsAndModel(IList<EntityValidationError> errors)
+        private void FlattenErrors(IList<EntityValidationError> errors)
         {
-            //Flatten Qualification errors to its ViewModel parent instead. 'Qualifications[1].Grade' > 'Qualifications'
+            //Flatten Qualification errors to its ViewModel parent instead. 'Qualifications[1].Grade' becomes 'Qualifications'
             foreach (var error in errors.Where(e => e.PropertyName.StartsWith(nameof(Vacancy.Qualifications))))
             {
                 error.PropertyName = nameof(VacancyPreviewViewModel.Qualifications);
             }
+        }
+
+        private EntityValidationResult GetSoftValidationErrors(Vacancy vacancy)
+        {
+            var result = _vacancyClient.Validate(vacancy, SoftValidationRules);
+            FlattenErrors(result.Errors);
+            MapValidationPropertiesToViewModel(result);
+            return result;
         }
 
         protected override EntityToViewModelPropertyMappings<Vacancy, VacancyPreviewViewModel> DefineMappings()
@@ -131,6 +143,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             mappings.Add(e => e.ShortDescription, vm => vm.ShortDescription);
             mappings.Add(e => e.ClosingDate, vm => vm.ClosingDate);
             mappings.Add(e => e.Wage, vm => vm.HasWage);
+            mappings.Add(e => e.Wage.FixedWageYearlyAmount, vm => vm.WageText);
             mappings.Add(e => e.Wage.WeeklyHours, vm => vm.HoursPerWeek);
             mappings.Add(e => e.Wage.WorkingWeekDescription, vm => vm.WorkingWeekDescription);
             mappings.Add(e => e.Wage.WageType, vm => vm.WageText);

--- a/src/Provider/Provider.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/VacancyPreview/VacancyPreviewViewModel.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.VacancyPreview
         public VacancyPreviewSectionState WorkingWeekSectionState { get; internal set; }
 
         public EntityValidationResult SoftValidationErrors { get; internal set; }
-        public bool HideValidationSummary { get; internal set; }
+        public bool CanHideValidationSummary { get; internal set; }
 
         public bool HasWage { get; internal set; }
         public bool HasProgramme { get; internal set; }

--- a/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -42,7 +42,7 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <partial asp-hide="@Model.HideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }' />
+        <partial asp-hide="@Model.CanHideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }' />
         <div class="info-summary__header-bar" asp-show="@Model.HasIncompleteMandatorySections">
             <h2 class="govuk-heading-m">@Model.IncompleteRequiredSectionCount required @Model.IncompleteRequiredSectionText to complete</h2>
         </div>

--- a/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
+++ b/src/Provider/Provider.Web/Views/VacancyPreview/VacancyPreview.cshtml
@@ -42,14 +42,26 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }' />
+        <partial asp-hide="@Model.HideValidationSummary" name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState, OrderedFieldNames = Model.OrderedFieldNames }' />
         <div class="info-summary__header-bar" asp-show="@Model.HasIncompleteMandatorySections">
-            <h2 class="govuk-heading-m">@Model.IncompleteSectionCount required @Model.IncompleteSectionText to complete</h2>
+            <h2 class="govuk-heading-m">@Model.IncompleteRequiredSectionCount required @Model.IncompleteRequiredSectionText to complete</h2>
         </div>
         <div class="info-summary__header-bar govuk-!-margin-bottom-6" asp-hide="@Model.HasIncompleteMandatorySections">
             <h2 class="govuk-heading-m">You have completed all required sections</h2>
         </div>
         <div asp-show="@Model.ShowIncompleteSections" class="info-summary govuk-!-margin-top-0" role="alert">
+            <div asp-show="Model.HasSoftValidationErrors">
+                <p class="govuk-body">
+                    Sections you will need to update:
+                </p>
+                <ul class=" govuk-list govuk-error-summary__list govuk-!-margin-bottom-4">
+                    @foreach (var softError in Model.SoftValidationErrors.Errors.OrderBy(x => Model.OrderedFieldNames.IndexOf(x.PropertyName)))
+                    {
+                        var softErrorVm = new ErrorListItemViewModel(softError.PropertyName, softError.ErrorMessage);
+                        <partial name="@RecruitPartialNames.ErrorListItem" model="@softErrorVm" />
+                    }
+                </ul>
+            </div>
             <div asp-show="@Model.HasIncompleteMandatorySections">
                 <p class="govuk-body">Sections you will need to complete:</p>
                 <ul class="govuk-list">


### PR DESCRIPTION
Added the concept of 'soft validation errors' to Provider.Web. These get displayed on the GET of the vacancy preview.

I have also refactored the calculation of the Section Count (In Employer.Web and Provider.Web) to reduce the complexity of the vacancy preview controllers.