### PR TITLE
ER-1367 Removing Withdrawn as a possible ManualOutcome of vacancy in place of Blocked

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ResetSubmittedVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ResetSubmittedVacancyCommandHandler.cs
@@ -77,7 +77,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
         private Task ClosePendingReview(VacancyReview review)
         {
             _logger.LogInformation($"Closing pending review {review.Id} as the provider is blocked");
-            review.ManualOutcome = ManualQaOutcome.Withdrawn;
+            review.ManualOutcome = ManualQaOutcome.Blocked;
             review.Status = ReviewStatus.Closed;
             review.ClosedDate = _timeProvider.Now;
             return _vacancyReviewRepository.UpdateAsync(review);

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyReviewTransferService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/VacancyReviewTransferService.cs
@@ -28,8 +28,8 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services
 
             if (review.IsPending)
             {
-                review.ManualOutcome = review.VacancySnapshot.OwnerType == OwnerType.Provider && transferReason == TransferReason.BlockedByQa
-                                        ? ManualQaOutcome.Withdrawn
+                review.ManualOutcome = transferReason == TransferReason.BlockedByQa
+                                        ? ManualQaOutcome.Blocked
                                         : ManualQaOutcome.Transferred;
                 review.Status = ReviewStatus.Closed;
                 review.ClosedDate = _timeProvider.Now;

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ManualQaOutcome.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/ManualQaOutcome.cs
@@ -5,6 +5,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         Approved,
         Referred,
         Transferred,
-        Withdrawn
+        Blocked
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyReviewRepository.cs
@@ -28,7 +28,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
 
             var filter = filterBuilder.Eq(r => r.VacancyReference, vacancyReference) &
                         (filterBuilder.Exists(ManualOutcomeFieldName, false) |
-                        filterBuilder.Nin(ManualOutcomeFieldName, new string[] { ManualQaOutcome.Transferred.ToString(), ManualQaOutcome.Withdrawn.ToString() }));
+                        filterBuilder.Nin(ManualOutcomeFieldName, new string[] { ManualQaOutcome.Transferred.ToString(), ManualQaOutcome.Blocked.ToString() }));
             var results = await GetVacancyReviewsAsync(filter);
             return results.OrderByDescending(r => r.CreatedDate).FirstOrDefault();
         }


### PR DESCRIPTION

Given changing the enum value I will be running the following on TEST as part of deploying this:

`db.vacancyReviews.updateMany({"manualOutcome":"Withdrawn"}, { "$set": {"manualOutcome":"Blocked"}})`