### PR TITLE
ER-1345 - Dates validation. Provider.Web

### DIFF
--- a/src/Provider/Provider.Web/Controllers/Part1/DatesController.cs
+++ b/src/Provider/Provider.Web/Controllers/Part1/DatesController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Provider.Web.Configuration.Routing;
 using Esfa.Recruit.Provider.Web.Extensions;
@@ -5,6 +6,7 @@ using Esfa.Recruit.Provider.Web.Orchestrators.Part1;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.Part1.Dates;
 using Esfa.Recruit.Shared.Web.Extensions;
+using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Esfa.Recruit.Provider.Web.Controllers.Part1
@@ -39,6 +41,7 @@ namespace Esfa.Recruit.Provider.Web.Controllers.Part1
             if (!ModelState.IsValid)
             {
                 var vm = await _orchestrator.GetDatesViewModelAsync(m);
+                vm.CanShowTrainingErrorHint = response.Errors.Errors.Any(e => e.ErrorCode == ErrorCodes.TrainingExpiryDate);
                 vm.PageInfo.SetWizard(wizard);
                 return View(vm);
             }

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -20,7 +20,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
     public class VacancyPreviewOrchestrator : EntityValidatingOrchestrator<Vacancy, VacancyPreviewViewModel>
     {
         private const VacancyRuleSet SubmitValidationRules = VacancyRuleSet.All;
-        private const VacancyRuleSet SoftValidationRules = VacancyRuleSet.MinimumWage;
+        private const VacancyRuleSet SoftValidationRules = VacancyRuleSet.MinimumWage | VacancyRuleSet.TrainingExpiryDate;
 
         private readonly IProviderVacancyClient _client;
         private readonly IRecruitVacancyClient _vacancyClient;

--- a/src/Provider/Provider.Web/ViewModels/Part1/Dates/DatesViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/Part1/Dates/DatesViewModel.cs
@@ -59,5 +59,13 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.Part1.Dates
         public PartOnePageInfoViewModel PageInfo { get; set; }
 
         public int CurrentYear { get; set; }
+
+        public string TrainingDescription { get; set; }
+        public string TrainingEffectiveToDate { get; set; }
+        public bool HasTrainingEffectiveToDate => string.IsNullOrEmpty(TrainingEffectiveToDate) == false;
+
+        public bool CanShowTrainingErrorHint { get; set; }
+        public bool CanShowTrainingHint => HasTrainingEffectiveToDate && CanShowTrainingErrorHint == false;
+
     }
 }

--- a/src/Provider/Provider.Web/Views/Part1/Dates/Dates.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Dates/Dates.cshtml
@@ -50,27 +50,35 @@
             <div esfa-validation-marker-for="StartDate" class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-!-font-weight-bold">When do you expect the apprentice to start?<span class="govuk-visually-hidden"> (in numeric format DD MM YYYY)</span></legend>
-                    <span class="govuk-hint">For example, @exampleStartingDate.AsInputHintDisplayDate()</span>
 
                     <span esfa-validation-message-for="StartDate" class="govuk-error-message"></span>
 
+                    <p asp-show="@Model.CanShowTrainingHint" class="govuk-hint">
+                        The start date must be before the @Model.TrainingDescription closes to new starters on @Model.TrainingEffectiveToDate
+                    </p>
+
+                    <p asp-show="@Model.CanShowTrainingErrorHint" class="govuk-hint">
+                        You may want to <a asp-route="@RouteNames.Training_Get" asp-route-wizard="@Model.PageInfo.IsWizard" class="govuk-link">find different apprenticeship training</a>.
+                    </p>
+
+                    <span class="govuk-hint">For example, @exampleStartingDate.AsInputHintDisplayDate()</span>
                     <div class="govuk-date-input">
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="StartDay" class="govuk-label govuk-date-input__label">Day</label>
-                                <input asp-for="StartDay" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" min="1" max="31" >
+                                <input asp-for="StartDay" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" min="1" max="31">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="StartMonth" class="govuk-label govuk-date-input__label">Month</label>
-                                <input asp-for="StartMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" min="1" max="12" >
+                                <input asp-for="StartMonth" class="govuk-input govuk-date-input__input govuk-input--width-2" type="number" min="1" max="12">
                             </div>
                         </div>
                         <div class="govuk-date-input__item">
                             <div class="govuk-form-group">
                                 <label asp-for="StartYear" class="govuk-label govuk-date-input__label">Year</label>
-                                <input asp-for="StartYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number" min="@Model.CurrentYear" >
+                                <input asp-for="StartYear" class="govuk-input govuk-date-input__input govuk-input--width-4" type="number" min="@Model.CurrentYear">
                             </div>
                         </div>
                     </div>

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
@@ -2,6 +2,7 @@
 {
     public static class ErrorCodes
     {
+        public const string TrainingExpiryDate = "26";
         public const string TrainingProviderUkprnNotEmpty = "101";
         public const string TrainingProviderUkprnMustBeCorrectLength = "99";
         public const string TrainingProviderMustExist = "102";

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -69,10 +69,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
 
                 if (matchingProgramme.EffectiveTo != null && matchingProgramme.EffectiveTo < vacancy.StartDate)
                 {
-                    var failure = new ValidationFailure(string.Empty, $"The {matchingProgramme.Title} {matchingProgramme.ApprenticeshipType} is no longer available on the date selected. Choose other apprenticeship training or change the start date.")
+                    var message = $"The start date must be before {matchingProgramme.EffectiveTo.Value.AsGdsDate()} when the apprenticeship training closes to new starters.";
+                    var failure = new ValidationFailure(string.Empty, message)
                     {
-                        ErrorCode = "26",
-                        CustomState = VacancyRuleSet.TrainingExpiryDate
+                        ErrorCode = ErrorCodes.TrainingExpiryDate,
+                        CustomState = VacancyRuleSet.TrainingExpiryDate,
+                        PropertyName = nameof(Vacancy.StartDate)
                     };
                     context.AddFailure(failure);
                 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -621,7 +621,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
 
         private void TrainingExpiryDateValidation()
         {
-            When(x => x.ProgrammeId != null && !string.IsNullOrWhiteSpace(x.ProgrammeId) && x.StartDate.HasValue, () =>
+            When(x => !string.IsNullOrWhiteSpace(x.ProgrammeId) && x.StartDate.HasValue, () =>
             {
                 RuleFor(x => x)
                     .TrainingMustBeActiveForStartDate(_apprenticeshipProgrammesProvider)

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TrainingExpiryDateValidation.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/CrossField/TrainingExpiryDateValidation.cs
@@ -79,8 +79,8 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.VacancyValidation.
 
             result.HasErrors.Should().BeTrue();
             result.Errors.Should().HaveCount(1);
-            result.Errors[0].PropertyName.Should().Be(string.Empty);
-            result.Errors[0].ErrorCode.Should().Be("26");
+            result.Errors[0].PropertyName.Should().Be(nameof(Vacancy.StartDate));
+            result.Errors[0].ErrorCode.Should().Be(ErrorCodes.TrainingExpiryDate);
             result.Errors[0].RuleId.Should().Be((long)VacancyRuleSet.TrainingExpiryDate);
         }
     }


### PR DESCRIPTION
Added extra validation to the Dates page to handle expiring training programmes.  Also added this check to soft validations on vacancy preview.

There is also different content we show depending on whether the training has an expiry date or whether there is an error is displayed due to the training expiry date.