### PR TITLE
ER-1384 provider blocked employer notification

### DIFF
--- a/src/Communication/Communication.Core/CommunicationProcessor.cs
+++ b/src/Communication/Communication.Core/CommunicationProcessor.cs
@@ -72,6 +72,8 @@ namespace Communication.Core
                 dataItems.AddRange(entityDataItems);
             }
 
+            dataItems.AddRange(request.DataItems);
+
             return dataItems;
         }
 

--- a/src/Communication/Communication.Types/CommunicationRequest.cs
+++ b/src/Communication/Communication.Types/CommunicationRequest.cs
@@ -10,12 +10,12 @@ namespace Communication.Types
         public DateTime RequestDateTime { get; set; }
         public string ParticipantsResolverName { get; set; }
         public string TemplateProviderName { get; set; }
-        public List<Entity> Entities { get; set; }
+        public List<Entity> Entities { get; set; } = new List<Entity>();
+        public List<CommunicationDataItem> DataItems { get; set; } = new List<CommunicationDataItem>();
 
         public CommunicationRequest()
         {
             RequestDateTime = DateTime.UtcNow;
-            Entities = new List<Entity>();
         }
 
         public CommunicationRequest(string requestType, string participantsResolverName, string templateProviderName) : this()

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenEmployerOwnedLiveVacancies.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenEmployerOwnedLiveVacancies.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Communication.Types;
+using Esfa.Recruit.Vacancies.Client.Application.Communications;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers.Provider.ProviderBlockedDomainEventHandlerTests
+{
+    public class GivenEmployerOwnedLiveVacancies : ProviderBlockedDomainEventHandlerTestBase
+    {
+        [Fact]
+        public async Task ShouldNotifyEmployersAboutLiveVacancy()
+        {
+            var employerAccount1 = "EmployerAccount1";
+            var employerAccount2 = "EmployerAccount2";
+            var employerAccount3 = "EmployerAccount3";
+
+            var ukprn = 1234;
+            var data = new ProviderBlockedEvent()
+            {
+                Ukprn = ukprn,
+                ProviderName = "provider name",
+                BlockedDate = DateTime.Now,
+                QaVacancyUser = new VacancyUser()
+            };
+
+            var vacancies = GetVacancies(OwnerType.Employer, employerAccount1, 1, VacancyStatus.Live)
+                .Concat(GetVacancies(OwnerType.Employer, employerAccount2, 1, VacancyStatus.Live))
+                .Concat(GetVacancies(OwnerType.Employer, employerAccount3, 1, VacancyStatus.Draft));
+
+            var sut = GetSut(GetEmptyProviderProfile(employerAccount1), vacancies);
+            var payload = JsonConvert.SerializeObject(data);
+            await sut.HandleAsync(payload);
+            
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies 
+                )), Times.Exactly(2));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount1) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount2) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenEmployersWithPermissionsOnly.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenEmployersWithPermissionsOnly.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Communication.Types;
+using Esfa.Recruit.Vacancies.Client.Application.Communications;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers.Provider.ProviderBlockedDomainEventHandlerTests
+{
+    public class GivenEmployersWithPermissionsOnly : ProviderBlockedDomainEventHandlerTestBase
+    {
+        [Fact]
+        public async Task ShouldNotifyEmployersAboutRevokedPermission()
+        {
+            var employerAccount1 = "EmployerAccount1";
+            var employerAccount2 = "EmployerAccount2";
+            var employerAccount3 = "EmployerAccount3";
+
+            var ukprn = 1234;
+            var data = new ProviderBlockedEvent()
+            {
+                Ukprn = ukprn,
+                ProviderName = "provider name",
+                BlockedDate = DateTime.Now,
+                QaVacancyUser = new VacancyUser()
+            };
+
+            var vacancies = GetVacancies(OwnerType.Employer, employerAccount1, 1, VacancyStatus.Live);
+            var info = GetEmptyProviderProfile(employerAccount1, employerAccount2, employerAccount3);
+            var sut = GetSut(info, vacancies);
+            var payload = JsonConvert.SerializeObject(data);
+            await sut.HandleAsync(payload);
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly
+                )), Times.Exactly(2));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount2) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount3) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount1)
+                )), Times.Never);
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenProviderOwnedVacancies.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/GivenProviderOwnedVacancies.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Communication.Types;
+using Esfa.Recruit.Vacancies.Client.Application.Communications;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers.Provider.ProviderBlockedDomainEventHandlerTests
+{
+    public class GivenProviderOwnedVacancies : ProviderBlockedDomainEventHandlerTestBase
+    {
+        [Fact]
+        public async Task MustNotifyEmployersWithTransferCount()
+        {
+            var employerAccount1 = "EmployerAccount1";
+            var employerAccount2 = "EmployerAccount2";
+            var employerAccount3 = "EmployerAccount3";
+
+            var ukprn = 1234;
+            var data = new ProviderBlockedEvent()
+            {
+                Ukprn = ukprn,
+                ProviderName = "provider name",
+                BlockedDate = DateTime.Now,
+                QaVacancyUser = new VacancyUser()
+            };
+
+            var payload = JsonConvert.SerializeObject(data);
+            var vacancies = GetVacancies(OwnerType.Provider, employerAccount1, 2, VacancyStatus.Live)
+                .Concat(GetVacancies(OwnerType.Provider, employerAccount2, 1, VacancyStatus.Draft))
+                .Concat(GetVacancies(OwnerType.Employer, employerAccount3, 1, VacancyStatus.Draft));
+                
+            var sut = GetSut(GetEmptyProviderProfile(), vacancies);
+            await sut.HandleAsync(payload);
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies
+                )), Times.Exactly(2));
+
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Any(d => d.Key == CommunicationConstants.DataItemKeys.Employer.VacanciesTransferredCount && d.Value == "2") && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount1) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Any(d => d.Key == CommunicationConstants.DataItemKeys.Employer.VacanciesTransferredCount && d.Value == "1") && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == employerAccount2) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == ukprn)
+                )));
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/HandleAsyncTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/HandleAsyncTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Communication.Types;
+using Esfa.Recruit.Vacancies.Client.Application.Communications;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Models;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers.Provider.ProviderBlockedDomainEventHandlerTests
+{
+    public class HandleAsyncTests : ProviderBlockedDomainEventHandlerTestBase
+    {
+        private string _employerAccount1 = "EmployerAccount1";
+        private string _employerAccount2 = "EmployerAccount2";
+        private string _employerAccount3 = "EmployerAccount3";
+        private string _legalEntity1 = "LegalEntity1";
+        private string _legalEntity2 = "LegalEntity2";
+        private long _ukprn = 1234;
+        private readonly IEnumerable<ProviderVacancySummary> vacancies;
+        private readonly DateTime _blockedDate = DateTime.Now;
+
+        public HandleAsyncTests()
+        {
+            var data = new ProviderBlockedEvent()
+            {
+                Ukprn = _ukprn,
+                ProviderName = "provider name",
+                BlockedDate = _blockedDate,
+                QaVacancyUser = new VacancyUser()
+            };
+
+            vacancies = GetVacancies(OwnerType.Provider, _employerAccount1, 1, VacancyStatus.Live)
+                .Concat(GetVacancies(OwnerType.Employer, _employerAccount2, 1, VacancyStatus.Live));
+            var info = GetProviderProfile();
+            var sut = GetSut(info, vacancies);
+            var payload = JsonConvert.SerializeObject(data);
+            sut.HandleAsync(payload).Wait();
+        }
+
+        [Fact]
+        public void ShouldNotifyEmployersAboutRevokedPermission()
+        {            
+            MockMessaging.Verify(q => q.PublishEvent(It.Is<ProviderBlockedOnLegalEntityEvent>(p => 
+                p.Ukprn == _ukprn && 
+                p.EmployerAccountId == _employerAccount1 && 
+                p.AccountLegalEntityPublicHashedId == _legalEntity1
+            )));
+
+            MockMessaging.Verify(q => q.PublishEvent(It.Is<ProviderBlockedOnLegalEntityEvent>(p => 
+                p.Ukprn == _ukprn && 
+                p.EmployerAccountId == _employerAccount1 && 
+                p.AccountLegalEntityPublicHashedId == _legalEntity2
+            )));
+
+            MockMessaging.Verify(q => q.PublishEvent(It.IsAny<ProviderBlockedOnLegalEntityEvent>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ShouldRaiseEventsToUpdateVacancies()
+        {
+            MockMessaging.Verify(m => m.PublishEvent(It.Is<ProviderBlockedOnVacancyEvent>(v => 
+                v.Ukprn == _ukprn && 
+                v.VacancyId == vacancies.Single().Id && 
+                v.BlockedDate == _blockedDate
+            )));
+
+            MockMessaging.Verify(m => m.PublishEvent(It.IsAny<ProviderBlockedOnVacancyEvent>()), Times.Once);
+        }
+
+        [Fact]
+        public void ShouldNotifyProvider()
+        {
+            MockCommunicationQueueService.Verify(c => c.AddMessageAsync(It.Is<CommunicationRequest>(r => 
+                r.RequestType == CommunicationConstants.RequestType.ProviderBlockedProviderNotification && 
+                r.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.ProviderParticipantsResolverName && 
+                r.Entities.Count == 2 && 
+                r.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == _ukprn) && 
+                r.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig && e.EntityId == null)
+            )));
+            
+            MockCommunicationQueueService.Verify(c => c.AddMessageAsync(It.Is<CommunicationRequest>(r => 
+                r.RequestType == CommunicationConstants.RequestType.ProviderBlockedProviderNotification)), Times.Once);
+        }
+
+        [Fact]
+        public void ShouldNotifyEmployerAboutTransfer()
+        {
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies
+            )), Times.Once);
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Any(d => d.Key == CommunicationConstants.DataItemKeys.Employer.VacanciesTransferredCount && d.Value == "1") && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == _employerAccount1) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == _ukprn)
+                )));
+        }
+
+        [Fact]
+        public void ShouldNotifyEmployerAboutLiveVacancies()
+        {
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies
+            )), Times.Once);
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count() == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == _employerAccount2) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == _ukprn) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig && e.EntityId == null)
+            )));
+        }
+
+        [Fact]
+        public void ShouldNotifyEmployerAboutRevokedPermissions()
+        {
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly
+            )), Times.Once);
+
+            MockCommunicationQueueService.Verify(q => q.AddMessageAsync(It.Is<CommunicationRequest>(c => 
+                c.RequestType == CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly &&
+                c.ParticipantsResolverName == CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName && 
+                c.TemplateProviderName == CommunicationConstants.ServiceName && 
+                c.DataItems.Count() == 0 && 
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Employer && e.EntityId.ToString() == _employerAccount3) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.Provider && (long)e.EntityId == _ukprn) &&
+                c.Entities.Any(e => e.EntityType == CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig && e.EntityId == null)
+            )));
+        }
+
+        protected ProviderEditVacancyInfo GetProviderProfile()
+        {
+            return new ProviderEditVacancyInfo()
+            {
+                Employers = new EmployerInfo[] 
+                { 
+                    new EmployerInfo 
+                    {
+                        EmployerAccountId = _employerAccount1,
+                        LegalEntities = new List<LegalEntity>() 
+                        {
+                            new LegalEntity() { LegalEntityId = 1, AccountLegalEntityPublicHashedId = _legalEntity1 },
+                            new LegalEntity() { LegalEntityId = 2, AccountLegalEntityPublicHashedId = _legalEntity2 }
+                        }
+                    },
+                    new EmployerInfo { EmployerAccountId = _employerAccount3 } 
+                }
+            };
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/ProviderBlockedDomainEventHandlerTestBase.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandlerTests/ProviderBlockedDomainEventHandlerTestBase.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Models;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
+using Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers.Provider.ProviderBlockedDomainEventHandlerTests
+{
+    public abstract class ProviderBlockedDomainEventHandlerTestBase
+    {
+        protected readonly Mock<ICommunicationQueueService> MockCommunicationQueueService = new Mock<ICommunicationQueueService>();
+        protected readonly Mock<IMessaging> MockMessaging = new Mock<IMessaging>();
+
+        protected ProviderBlockedDomainEventHandler GetSut(ProviderEditVacancyInfo providerInfo, IEnumerable<ProviderVacancySummary> vacancies)
+        {
+            var mockQueryStoreReader = new Mock<IQueryStoreReader>();
+            mockQueryStoreReader.Setup(q => q.GetProviderVacancyDataAsync(It.IsAny<long>())).ReturnsAsync(providerInfo);
+
+            var mockVacancyQuery = new Mock<IVacancyQuery>();
+            mockVacancyQuery.Setup(v => v.GetVacanciesAssociatedToProvider(It.IsAny<long>())).ReturnsAsync(vacancies);
+
+            var mockLogger = new Mock<ILogger<ProviderBlockedDomainEventHandler>>();
+            return new ProviderBlockedDomainEventHandler(
+                mockQueryStoreReader.Object, mockVacancyQuery.Object, MockMessaging.Object, 
+                MockCommunicationQueueService.Object, mockLogger.Object);
+        }
+
+        protected ProviderEditVacancyInfo GetEmptyProviderProfile(params string[] employerAccountIds)
+        {
+            return new ProviderEditVacancyInfo()
+            {
+                Employers = employerAccountIds.Select(e => new EmployerInfo { EmployerAccountId = e })
+            };
+        }
+
+        private int referenceNumber = 1000;
+        protected List<ProviderVacancySummary> GetVacancies(OwnerType owner, string employerId, int count, VacancyStatus status)
+        {
+            var vacancies = new List<ProviderVacancySummary>();
+            for(var i = 1; i <= count; i++)
+            {
+                vacancies.Add(
+                    new ProviderVacancySummary 
+                    {
+                        Id = Guid.NewGuid(),
+                        VacancyOwner = owner,
+                        EmployerAccountId = employerId,
+                        VacancyReference = ++referenceNumber,
+                        Status = status
+                    }
+                );
+            }
+            return vacancies;
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/VacancyReferredDomainEventHandlerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/DomainEvents/Handlers/VacancyReferredDomainEventHandlerTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace Esfa.Recruit.UnitTests.Jobs.DomainEventHandlers
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.DomainEvents.Handlers
 {
     public class VacancyReferredDomainEventHandlerTests
     {

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
@@ -20,7 +20,7 @@ using SFA.DAS.ProviderRelationships.Messages.Events;
 using SFA.DAS.ProviderRelationships.Types.Models;
 using Xunit;
 
-namespace Esfa.Recruit.UnitTests.Jobs.ExternalSystemEventHandlers
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.ExternalSystemEventHandlers
 {
     public class UpdatedPermissionsExternalSystemEventHandlerTests
     {

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/Jobs/TransferVacanciesFromProviderJobTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/Jobs/TransferVacanciesFromProviderJobTests.cs
@@ -6,11 +6,10 @@ using Esfa.Recruit.Vacancies.Client.Application.Queues;
 using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
-using Esfa.Recruit.Vacancies.Jobs;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.UnitTests.Jobs
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.Jobs
 {
     public class TransferVacanciesFromProviderJobTests
     {

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/Jobs/TransferVacancyToLegalEntityJobTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/Jobs/TransferVacancyToLegalEntityJobTests.cs
@@ -4,11 +4,10 @@ using Esfa.Recruit.Vacancies.Client.Application.Commands;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
-using Esfa.Recruit.Vacancies.Jobs;
 using Moq;
 using Xunit;
 
-namespace Esfa.Recruit.UnitTests.Jobs
+namespace Esfa.Recruit.Vacancies.Jobs.Tests.Jobs
 {
     public class TransferVacancyToLegalEntityJobTests
     {

--- a/src/Jobs/Recruit.Vacancies.Jobs.Tests/Recruit.Vacancies.Jobs.Tests.csproj
+++ b/src/Jobs/Recruit.Vacancies.Jobs.Tests/Recruit.Vacancies.Jobs.Tests.csproj
@@ -10,6 +10,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="AutoFixture" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ServiceCollectionExtensions.cs
@@ -118,14 +118,16 @@ namespace Esfa.Recruit.Vacancies.Jobs
             services.AddTransient<ICommunicationProcessor, CommunicationProcessor>();
             services.AddTransient<ICommunicationService, CommunicationService>();
 
-            services.AddTransient<IEntityDataItemProvider, VacancyDataEntityPlugin>();
             services.AddTransient<IParticipantResolver, VacancyParticipantsResolverPlugin>();
             services.AddTransient<IParticipantResolver, ProviderParticipantsResolverPlugin>();
+            services.AddTransient<IParticipantResolver, EmployerParticipantsResolverPlugin>();
             services.AddTransient<IUserPreferencesProvider, UserPreferencesProviderPlugin>();
             services.AddTransient<ITemplateIdProvider, TemplateIdProviderPlugin>();
+            services.AddTransient<IEntityDataItemProvider, VacancyDataEntityPlugin>();
             services.AddTransient<IEntityDataItemProvider, ApprenticeshipServiceUrlDataEntityPlugin>();
             services.AddTransient<IEntityDataItemProvider, ApprenticeshipServiceConfigDataEntityPlugin>();
             services.AddTransient<IEntityDataItemProvider, ProviderDataEntityPlugin>();
+            services.AddTransient<IEntityDataItemProvider, EmployerDataEntityPlugin>();
 
             services.Configure<CommunicationsConfiguration>(configuration.GetSection("CommunicationsConfiguration"));
         }

--- a/src/QA/QA.Web/Views/BlockedOrganisations/ConsentForProviderBlocking.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ConsentForProviderBlocking.cshtml
@@ -2,6 +2,7 @@
 @model ConsentForProviderBlockingViewModel;
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState }' asp-show="@ViewData.ModelState.IsValid == false" />
         <h1 class="govuk-heading-xl">Remove @Model.Name from the recruitment service</h1>
         <p class="govuk-body">Removing a training provider will do the following:</p>
         <ul class="govuk-list govuk-list--bullet">

--- a/src/QA/QA.Web/Views/BlockedOrganisations/FindTrainingProvider.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/FindTrainingProvider.cshtml
@@ -4,6 +4,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        <partial name="@PartialNames.ValidationSummary" model='new ValidationSummaryViewModel { ModelState = ViewData.ModelState }' asp-show="@ViewData.ModelState.IsValid == false" />
         <h1 class="govuk-heading-xl">Which training provider would you like to remove?</h1>
         <p class="govuk-body">Removing a training provider will prevent them from using the recruitment service.</p>
         <form asp-route="@RouteNames.BlockProvider_Find_Post">

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationConstants.cs
@@ -12,6 +12,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
         {
             public const string ProviderParticipantsResolverName = nameof(ProviderParticipantsResolverName);
             public const string VacancyParticipantsResolverName = nameof(VacancyParticipantsResolverName);
+            public const string EmployerParticipantsResolverName = nameof(EmployerParticipantsResolverName);
         }
 
         public static class EntityTypes
@@ -19,6 +20,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             public const string Vacancy = nameof(Vacancy);
             public const string ApprenticeshipServiceUrl = nameof(ApprenticeshipServiceUrl);
             public const string Provider = nameof(Provider);
+            public const string Employer = nameof(Employer);
             public const string ApprenticeshipServiceConfig = nameof(ApprenticeshipServiceConfig);
         }
 
@@ -27,7 +29,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             public const string VacancyRejected = nameof(VacancyRejected);
             public const string ApplicationSubmitted = nameof(ApplicationSubmitted);
             public const string VacancyWithdrawnByQa = nameof(VacancyWithdrawnByQa);
-            public const string ProviderBlockedProvider = nameof(ProviderBlockedProvider);
+            public const string ProviderBlockedProviderNotification = nameof(ProviderBlockedProviderNotification);
+            public const string ProviderBlockedEmployerNotificationForTransferredVacancies = nameof(ProviderBlockedEmployerNotificationForTransferredVacancies);
+            public const string ProviderBlockedEmployerNotificationForLiveVacancies = nameof(ProviderBlockedEmployerNotificationForLiveVacancies);
+            public const string ProviderBlockedEmployerNotificationForPermissionOnly = nameof(ProviderBlockedEmployerNotificationForPermissionOnly);
         }
 
         public static class DataItemKeys
@@ -36,7 +41,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             {
                 public const string VacancyReference = "vacancy-reference";
                 public const string VacancyTitle = "vacancy-title";
-                public const string EmployerName = "employer-name";
+                public const string EmployerName = "employer-name";                
             }
 
             public static class ApprenticeshipService
@@ -49,6 +54,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             {
                 public const string ProviderName = "provider-name";
             }
+
+            public static class Employer
+            {
+                public const string EmployerAccountId = nameof(EmployerAccountId);
+                public const string VacanciesTransferredCount = "vacancies-transferred-count";
+            }
         }
 
         public static class TemplateIds
@@ -56,8 +67,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             public const string VacancyRejected = "RecruitV2_VacancyRejected";
             public const string ApplicationSubmittedImmediate = "RecruitV2_NewApplicationImmediate";
             public const string VacancyWithdrawnByQa = "RecruitV2_VacancyWithdrawnByQa";
-            public const string ProviderBlockedEmployer = "RecruitV2_ProviderBlocked_Employer";
-            public const string ProviderBlockedProvider = "RecruitV2_ProviderBlocked_Provider";
+            public const string ProviderBlockedProviderNotification = "RecruitV2_ProviderBlocked_ProviderNotification";
+            public const string ProviderBlockedEmployerNotificationForTransferredVacancies = "RecruitV2_ProviderBlocked_EmployerNotification_ForTransferredVacancies";
+            public const string ProviderBlockedEmployerNotificationForLiveVacancies = "RecruitV2_ProviderBlocked_EmployerNotification_ForLiveVacancies";
+            public const string ProviderBlockedEmployerNotificationForPermissionsOnly = "RecruitV2_ProviderBlocked_EmployerNotification_ForPermissionsOnly";
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/EntityDataItemProviderPlugins/EmployerDataEntityPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/EntityDataItemProviderPlugins/EmployerDataEntityPlugin.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Communication.Types;
+using Communication.Types.Interfaces;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Communications.EntityDataItemProviderPlugins
+{
+    public class EmployerDataEntityPlugin : IEntityDataItemProvider
+    {
+        public string EntityType  => CommunicationConstants.EntityTypes.Employer;
+
+        public Task<IEnumerable<CommunicationDataItem>> GetDataItemsAsync(object entityId)
+        {
+            return Task.FromResult(Enumerable.Empty<CommunicationDataItem>());
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/ParticipantResolverPlugins/EmployerParticipantsResolverPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/ParticipantResolverPlugins/EmployerParticipantsResolverPlugin.cs
@@ -9,13 +9,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Communications.ParticipantResolverPlugins
 {
-    public class ProviderParticipantsResolverPlugin : IParticipantResolver
+    public class EmployerParticipantsResolverPlugin : IParticipantResolver
     {
-        private readonly IUserRepository _userRepository;
-        private readonly ILogger<ProviderParticipantsResolverPlugin> _logger;
-        public string ParticipantResolverName => CommunicationConstants.ParticipantResolverNames.ProviderParticipantsResolverName;
+        public string ParticipantResolverName => CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName;
 
-        public ProviderParticipantsResolverPlugin(IUserRepository userRepository, ILogger<ProviderParticipantsResolverPlugin> logger)
+        private readonly IUserRepository _userRepository;
+        private readonly ILogger<EmployerParticipantsResolverPlugin> _logger;
+        public EmployerParticipantsResolverPlugin(IUserRepository userRepository, ILogger<EmployerParticipantsResolverPlugin> logger)
         {
             _userRepository = userRepository;
             _logger = logger;
@@ -24,12 +24,12 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications.ParticipantRe
         public async Task<IEnumerable<CommunicationUser>> GetParticipantsAsync(CommunicationRequest request)
         {
             _logger.LogInformation($"Resolving participants for RequestType: '{request.RequestType}'");
-            var entityId = request.Entities.Single(e => e.EntityType == CommunicationConstants.EntityTypes.Provider).EntityId.ToString();
-            if(long.TryParse(entityId, out var ukprn) == false)
+            var employerAccountId = request.Entities.Single(e => e.EntityType == CommunicationConstants.EntityTypes.Employer).EntityId.ToString();
+            if(string.IsNullOrWhiteSpace(employerAccountId))
             {
                 return Array.Empty<CommunicationUser>();
             }
-            var users = await _userRepository.GetProviderUsersAsync(ukprn);
+            var users = await _userRepository.GetEmployerUsersAsync(employerAccountId);
             return ParticipantResolverPluginHelper.ConvertToCommunicationUsers(users, null);
         }
     }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/ParticipantResolverPlugins/VacancyParticipantsResolverPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/ParticipantResolverPlugins/VacancyParticipantsResolverPlugin.cs
@@ -46,7 +46,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications.ParticipantRe
             }
             else
             {
-                users = await _userRepository.GetProviderUsers(vacancy.TrainingProvider.Ukprn.GetValueOrDefault());
+                users = await _userRepository.GetProviderUsersAsync(vacancy.TrainingProvider.Ukprn.GetValueOrDefault());
             }
             return ParticipantResolverPluginHelper.ConvertToCommunicationUsers(users, vacancy.SubmittedByUser.UserId);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/TemplateIdProviderPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/TemplateIdProviderPlugin.cs
@@ -24,8 +24,17 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
                 case CommunicationConstants.RequestType.VacancyWithdrawnByQa:
                     templateId = CommunicationConstants.TemplateIds.VacancyWithdrawnByQa;
                     break;
-                case CommunicationConstants.RequestType.ProviderBlockedProvider:
-                    templateId = CommunicationConstants.TemplateIds.ProviderBlockedProvider;
+                case CommunicationConstants.RequestType.ProviderBlockedProviderNotification:
+                    templateId = CommunicationConstants.TemplateIds.ProviderBlockedProviderNotification;
+                    break;
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies:
+                    templateId = CommunicationConstants.TemplateIds.ProviderBlockedEmployerNotificationForTransferredVacancies;
+                    break;
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies:
+                    templateId = CommunicationConstants.TemplateIds.ProviderBlockedEmployerNotificationForLiveVacancies;
+                    break;
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly:
+                    templateId = CommunicationConstants.TemplateIds.ProviderBlockedEmployerNotificationForPermissionsOnly;
                     break;
                 default:
                     throw new NotImplementedException($"Template for request type {message.RequestType} is not defined.");

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/UserPreferencesProviderPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/UserPreferencesProviderPlugin.cs
@@ -34,9 +34,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
                     SetPreferencesForApplicationSubmittedNotification(ref userPref, userPreference);
                     return userPref;
                 case CommunicationConstants.RequestType.VacancyWithdrawnByQa:
-                    SetPreferencesForMandatoryOrganisationEmailNotification(ref userPref);
-                    return userPref;
-                case CommunicationConstants.RequestType.ProviderBlockedProvider:
+                case CommunicationConstants.RequestType.ProviderBlockedProviderNotification:
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies:
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies:
+                case CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly:
                     SetPreferencesForMandatoryOrganisationEmailNotification(ref userPref);
                     return userPref;
                 default:

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Models/ProviderVacancySummary.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Models/ProviderVacancySummary.cs
@@ -8,6 +8,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Models
         public Guid Id { get; set; }
         public OwnerType VacancyOwner { get; set; }
         public string EmployerAccountId { get; set; }
-        public long VacancyReference { get; internal set; }
+        public long VacancyReference { get; set; }
+        public VacancyStatus Status { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IUserRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IUserRepository.cs
@@ -9,6 +9,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
         Task<User> GetAsync(string idamsUserId);
         Task UpsertUserAsync(User user);
         Task<List<User>> GetEmployerUsersAsync(string accountId);
-        Task<List<User>> GetProviderUsers(long ukprn);
+        Task<List<User>> GetProviderUsersAsync(long ukprn);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbUserRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbUserRepository.cs
@@ -47,13 +47,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
                 new Context(nameof(GetEmployerUsersAsync)));
         }
 
-        public Task<List<User>> GetProviderUsers(long ukprn)
+        public Task<List<User>> GetProviderUsersAsync(long ukprn)
         {
             var filter = Builders<User>.Filter.Eq(u => u.Ukprn, ukprn);
             var collection = GetCollection<User>();
             return RetryPolicy.ExecuteAsync(_ => 
                 collection.Find(filter).ToListAsync(),
-                new Context(nameof(GetProviderUsers)));
+                new Context(nameof(GetProviderUsersAsync)));
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
@@ -220,7 +220,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
                     {
                         Id = x.Id,
                         VacancyOwner = x.OwnerType,
-                        VacancyReference = x.VacancyReference.GetValueOrDefault()
+                        VacancyReference = x.VacancyReference.GetValueOrDefault(),
+                        Status = x.Status,
+                        EmployerAccountId = x.EmployerAccountId
                     })
                     .ToListAsync(),
                 new Context(nameof(GetVacanciesAssociatedToProvider)));

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ParticipantResolverPluginTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Communications/ParticipantResolverPluginTests.cs
@@ -31,7 +31,7 @@ namespace UnitTests.Vacancies.Client.Application.Communications
         public ParticipantResolverPluginTests()
         {
             _mockUserRepository.Setup(u => u.GetEmployerUsersAsync(It.IsAny<string>())).ReturnsAsync(new List<User> {GetUser(OwnerType.Employer), GetUser(OwnerType.Employer), GetUser(OwnerType.Employer)});
-            _mockUserRepository.Setup(u => u.GetProviderUsers(It.IsAny<long>())).ReturnsAsync(new List<User> {GetUser(OwnerType.Provider), GetPrimaryUser(OwnerType.Provider)});
+            _mockUserRepository.Setup(u => u.GetProviderUsersAsync(It.IsAny<long>())).ReturnsAsync(new List<User> {GetUser(OwnerType.Provider), GetPrimaryUser(OwnerType.Provider)});
         }
 
         [Fact]

--- a/src/Shared/UnitTests/Vacancies.Client/Application/Communications/TemplateIdProviderPluginTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/Communications/TemplateIdProviderPluginTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Vacancies.Client.Application.Communications
         [Theory]
         [InlineData(RequestType.VacancyRejected, DeliveryFrequency.Default, TemplateIds.VacancyRejected)]
         [InlineData(RequestType.ApplicationSubmitted, DeliveryFrequency.Immediate, TemplateIds.ApplicationSubmittedImmediate)]
-        [InlineData(RequestType.ProviderBlockedProvider, DeliveryFrequency.Immediate, TemplateIds.ProviderBlockedProvider)]
+        [InlineData(RequestType.ProviderBlockedProviderNotification, DeliveryFrequency.Immediate, TemplateIds.ProviderBlockedProviderNotification)]
         [InlineData(RequestType.ApplicationSubmitted, DeliveryFrequency.Daily, "")]
         public async Task ReturnRespectiveTemplateId(string requestType, DeliveryFrequency frequency, string expectedTemplateId)
         {


### PR DESCRIPTION
Introduced data items to CommunicationRequest to allow populate certain calculated values (which cannot be derived later by Entity Data Item Providers) when the request is being created.

Also introduced couple of participant providers, one for employer and one for provider. These will fetch all the users for respective organisation. 

Three different templates were required for employer notification, I have created a method for each type of communication request and added unit tests.


