### PR TITLE
ER-1492 Reinstated the cancel button on confirmation screen

### DIFF
--- a/src/QA/QA.Web/Views/BlockedOrganisations/ConfirmTrainingProviderBlocking.cshtml
+++ b/src/QA/QA.Web/Views/BlockedOrganisations/ConfirmTrainingProviderBlocking.cshtml
@@ -21,6 +21,7 @@
         <form asp-route="@RouteNames.BlockProvider_Confirm_Post">
             <input type="hidden" asp-for="Ukprn">
             <button type="submit" class="govuk-button">Confirm and continue</button>
+            <a asp-route="@RouteNames.BlockedOrganisations_Get" class="govuk-link das-button-link">Cancel</a>
         </form>
     </div>
 </div>


### PR DESCRIPTION
It now takes user back to the blocked organisation list page. 