### PR TITLE
ER-1506 Fixed provider and employer notifications +semver: patch

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/UserPreferencesProviderPlugin.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/UserPreferencesProviderPlugin.cs
@@ -23,7 +23,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
             var userPref = new CommunicationUserPreference() { Channels = DeliveryChannelPreferences.None };
 
             var userPreference = await _repository.GetAsync(user.UserId);
-            if (userPreference == null) return userPref;
 
             switch (requestType)
             {
@@ -47,6 +46,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
 
         private static void SetPreferencesForVacancyRejectedNotification(ref CommunicationUserPreference userPref, UserNotificationPreferences userPreference)
         {
+            if (userPreference == null) return;
             if (userPreference.NotificationTypes.HasFlag(NotificationTypes.VacancyRejected))
             {
                 userPref.Channels = DeliveryChannelPreferences.EmailOnly;
@@ -57,6 +57,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Communications
 
         private static void SetPreferencesForApplicationSubmittedNotification(ref CommunicationUserPreference userPref, UserNotificationPreferences userPreference)
         {
+            if (userPreference == null) return;
             if (userPreference.NotificationTypes.HasFlag(NotificationTypes.ApplicationSubmitted))
             {
                 userPref.Channels = DeliveryChannelPreferences.EmailOnly;


### PR DESCRIPTION
In the user preference provider, there was a check if the user preference is not set then return "None" preferences. However in case of certain request types (high severity) we have to bypass user preferences, so even if they are not set, we still have to send the notification emails. 

I have updated the tests accordingly. 