### PR TITLE
ER-1427 - Ignoring withdrawn applications on dashboard count

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
@@ -22,13 +22,18 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 }
             },
             {
+                '$match': { 
+                    '$or': [
+                    { 'candidateApplicationReview.isWithdrawn': {'$exists' : false} }, 
+                    { 'candidateApplicationReview.isWithdrawn': false }] }
+            },
+            {
                 '$project': {
                     'vacancyGuid': '$_id',
                     'vacancyReference': 1,
                     'title': 1,
                     'status': 1,
                     'appStatus': '$candidateApplicationReview.status',
-                    'appIsWithdrawn': '$candidateApplicationReview.isWithdrawn',
                     'legalEntityId': 1,
                     'legalEntityName': 1,
                     'employerAccountId': 1,
@@ -77,36 +82,21 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                     'trainingProviderName': 1,
                     'isNew': {
                         '$cond': {
-                            'if': {
-                                '$and': [
-                                    {'$eq': [ '$appStatus', 'New']},
-                                    {'$eq': [ '$appIsWithdrawn', false]}
-                                ]
-                            },
+                            'if': {'$eq': [ '$appStatus', 'New']},
                             'then': 1,
                             'else': 0
                         }
                     },
                     'isSuccessful': {
                         '$cond': {
-                            'if': {
-                                '$and': [
-                                    {'$eq': [ '$appStatus', 'Successful']},
-                                    {'$eq': [ '$appIsWithdrawn', false]}
-                                ]
-                            },
+                            'if': {'$eq': [ '$appStatus', 'Successful']},
                             'then': 1,
                             'else': 0
                         }
                     },
                     'isUnsuccessful': {
                         '$cond': {
-                            'if': {
-                                '$and': [
-                                    {'$eq': [ '$appStatus', 'Unsuccessful']},
-                                    {'$eq': [ '$appIsWithdrawn', false]}
-                                ]
-                            },
+                            'if': {'$eq': [ '$appStatus', 'Unsuccessful']},
                             'then': 1,
                             'else': 0
                         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
@@ -1,176 +1,166 @@
-using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Mongo;
+using System.Linq;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummariesProvider
 {
     public static class VacancySummaryAggQueryBuilder
     {
-        private const string PathSpecifierFieldName = "path";
-        private const string PreserveNullAndEmptyArraysSpecifierFieldName = "preserveNullAndEmptyArrays";
-        private const string ApplicationReviewLookupAliasName = "candidateApplicationReview";
-        private static readonly BsonArray _newApplicationReviewStatusClause = new BsonArray { "$appStatus", ApplicationReviewStatus.New.ToString() };
-
-        private static readonly BsonArray _successfulApplicationReviewStatusClause = new BsonArray { "$appStatus", ApplicationReviewStatus.Successful.ToString() };
-
-        private static readonly BsonArray _unsuccessfulApplicationReviewStatusClause = new BsonArray { "$appStatus", ApplicationReviewStatus.Unsuccessful.ToString() };
-
-        private static readonly BsonDocument _lookupClause = new BsonDocument
-        {
+        private const string Pipeline = @"[
             {
-                "$lookup",
-                new BsonDocument
-                {
-                    { "from", MongoDbCollectionNames.ApplicationReviews },
-                    { "localField", "vacancyReference" },
-                    { "foreignField", "vacancyReference" },
-                    { "as", ApplicationReviewLookupAliasName }
+                '$lookup': {
+                    'from': 'applicationReviews',
+                    'localField': 'vacancyReference',
+                    'foreignField': 'vacancyReference',
+                    'as': 'candidateApplicationReview'
                 }
-            }
-        };
-        private static readonly BsonDocument _unwindClause = new BsonDocument
-        {
+            },
             {
-                "$unwind",
-                new BsonDocument().Add(PathSpecifierFieldName, $"${ApplicationReviewLookupAliasName}")
-                                .Add(PreserveNullAndEmptyArraysSpecifierFieldName, true)
-            }
-        };
-        private static readonly BsonDocument _projectionOneClause = new BsonDocument
-        {
-            {
-                "$project",
-                new BsonDocument
-                {
-                    { "vacancyGuid", "$_id" },
-                    { "vacancyReference", 1 },
-                    { "title", 1 },
-                    { "status", 1 },
-                    { "appStatus", $"${ApplicationReviewLookupAliasName}.status" },
-                    { "legalEntityId", 1 },
-                    { "legalEntityName", 1 },
-                    { "employerAccountId", 1 },
-                    { "employerName", 1 },
-                    { "ukprn", $"$trainingProvider.ukprn" },
-                    { "createdDate", 1 },
-                    { "closingDate", 1 },
-                    { "startDate", 1 },
-                    { "closedDate", 1 },
-                    { "closureReason", 1 },
-                    { "applicationMethod", 1 },
-                    { "programmeId", 1 },
-                    { "duration", "$wage.duration" },
-                    { "durationUnit", "$wage.durationUnit" },
-                    { "transferInfoUkprn", "$transferInfo.ukprn" },
-                    { "transferInfoProviderName", "$transferInfo.providerName" },
-                    { "transferInfoTransferredDate", "$transferInfo.transferredDate" },
-                    { "transferInfoReason", "$transferInfo.reason" },
-                    { "trainingProviderName", "$trainingProvider.name" }
+                '$unwind': {
+                    'path': '$candidateApplicationReview',
+                    'preserveNullAndEmptyArrays': true
                 }
-            }
-        };
-        private static readonly BsonDocument _projectionTwoClause = new BsonDocument
-        {
+            },
             {
-                "$project",
-                new BsonDocument
-                {
-                    { "vacancyGuid", 1 },
-                    { "vacancyReference", 1 },
-                    { "title", 1 },
-                    { "status", 1 },
-                    { "legalEntityId", 1 },
-                    { "legalEntityName", 1 },
-                    { "employerAccountId", 1 },
-                    { "employerName", 1 },
-                    { "ukprn", 1 },
-                    { "createdDate", 1 },
-                    { "closingDate", 1 },
-                    { "startDate", 1 },
-                    { "closedDate", 1 },
-                    { "closureReason", 1 },
-                    { "applicationMethod", 1 },
-                    { "programmeId", 1 },
-                    { "duration", 1 },
-                    { "durationUnit", 1 },
-                    { "transferInfoUkprn", 1 },
-                    { "transferInfoProviderName", 1 },
-                    { "transferInfoTransferredDate", 1 },
-                    { "transferInfoReason", 1 },
-                    { "trainingProviderName", 1 }
+                '$project': {
+                    'vacancyGuid': '$_id',
+                    'vacancyReference': 1,
+                    'title': 1,
+                    'status': 1,
+                    'appStatus': '$candidateApplicationReview.status',
+                    'appIsWithdrawn': '$candidateApplicationReview.isWithdrawn',
+                    'legalEntityId': 1,
+                    'legalEntityName': 1,
+                    'employerAccountId': 1,
+                    'employerName': 1,
+                    'ukprn': '$trainingProvider.ukprn',
+                    'createdDate': 1,
+                    'closingDate': 1,
+                    'startDate': 1,
+                    'closedDate': 1,
+                    'closureReason': 1,
+                    'applicationMethod': 1,
+                    'programmeId': 1,
+                    'duration': '$wage.duration',
+                    'durationUnit': '$wage.durationUnit',
+                    'transferInfoUkprn': '$transferInfo.ukprn',
+                    'transferInfoProviderName': '$transferInfo.providerName',
+                    'transferInfoTransferredDate': '$transferInfo.transferredDate',
+                    'transferInfoReason': '$transferInfo.reason',
+                    'trainingProviderName': '$trainingProvider.name'
                 }
-                .Add("isNew", new BsonDocument()
-                                .Add("$cond", new BsonDocument().Add("if", new BsonDocument().Add("$eq", _newApplicationReviewStatusClause))
-                                                                .Add("then", 1)
-                                                                .Add("else", 0)
-                                    )
-                    )
-                .Add("isSuccessful", new BsonDocument()
-                                        .Add("$cond", new BsonDocument().Add("if", new BsonDocument().Add("$eq", _successfulApplicationReviewStatusClause))
-                                                                        .Add("then", 1)
-                                                                        .Add("else", 0)
-                                            )
-                    )
-                .Add("isUnsuccessful", new BsonDocument()
-                                            .Add("$cond", new BsonDocument().Add("if", new BsonDocument().Add("$eq", _unsuccessfulApplicationReviewStatusClause))
-                                                                            .Add("then", 1)
-                                                                            .Add("else", 0)
-                                                )
-                    )
-            }
-        };
-        private static readonly BsonDocument _groupClause = new BsonDocument
-        {
+            },
             {
-                "$group",
-                new BsonDocument
-                {
-                    {
-                        "_id", new BsonDocument
-                        {
-                            { "vacancyGuid", "$vacancyGuid" },
-                            { "vacancyReference", "$vacancyReference" },
-                            { "title", "$title" },
-                            { "status", "$status" },
-                            { "legalEntityId", "$legalEntityId" },
-                            { "legalEntityName", "$legalEntityName" },
-                            { "employerAccountId", "$employerAccountId" },
-                            { "employerName", "$employerName" },
-                            { "ukprn", $"$ukprn" },
-                            { "createdDate", "$createdDate" },
-                            { "closingDate", "$closingDate" },
-                            { "startDate", "$startDate" },
-                            { "closedDate", "$closedDate" },
-                            { "closureReason", "$closureReason" },
-                            { "applicationMethod", "$applicationMethod" },
-                            { "programmeId", "$programmeId" },
-                            { "duration", "$duration" },
-                            { "durationUnit", "$durationUnit" },
-                            { "transferInfoUkprn", "$transferInfoUkprn" },
-                            { "transferInfoProviderName", "$transferInfoProviderName" },
-                            { "transferInfoTransferredDate", "$transferInfoTransferredDate" },
-                            { "transferInfoReason", "$transferInfoReason" },
-                            { "trainingProviderName", "$trainingProviderName" }
+                '$project': {
+                    'vacancyGuid': 1,
+                    'vacancyReference': 1,
+                    'title': 1,
+                    'status': 1,
+                    'legalEntityId': 1,
+                    'legalEntityName': 1,
+                    'employerAccountId': 1,
+                    'employerName': 1,
+                    'ukprn': 1,
+                    'createdDate': 1,
+                    'closingDate': 1,
+                    'startDate': 1,
+                    'closedDate': 1,
+                    'closureReason': 1,
+                    'applicationMethod': 1,
+                    'programmeId': 1,
+                    'duration': 1,
+                    'durationUnit': 1,
+                    'transferInfoUkprn': 1,
+                    'transferInfoProviderName': 1,
+                    'transferInfoTransferredDate': 1,
+                    'transferInfoReason': 1,
+                    'trainingProviderName': 1,
+                    'isNew': {
+                        '$cond': {
+                            'if': {
+                                '$and': [
+                                    {'$eq': [ '$appStatus', 'New']},
+                                    {'$eq': [ '$appIsWithdrawn', false]}
+                                ]
+                            },
+                            'then': 1,
+                            'else': 0
                         }
                     },
-                    { "noOfNewApplications", new BsonDocument().Add("$sum", "$isNew") },
-                    { "noOfSuccessfulApplications", new BsonDocument().Add("$sum", "$isSuccessful") },
-                    { "noOfUnsuccessfulApplications", new BsonDocument().Add("$sum", "$isUnsuccessful") }
+                    'isSuccessful': {
+                        '$cond': {
+                            'if': {
+                                '$and': [
+                                    {'$eq': [ '$appStatus', 'Successful']},
+                                    {'$eq': [ '$appIsWithdrawn', false]}
+                                ]
+                            },
+                            'then': 1,
+                            'else': 0
+                        }
+                    },
+                    'isUnsuccessful': {
+                        '$cond': {
+                            'if': {
+                                '$and': [
+                                    {'$eq': [ '$appStatus', 'Unsuccessful']},
+                                    {'$eq': [ '$appIsWithdrawn', false]}
+                                ]
+                            },
+                            'then': 1,
+                            'else': 0
+                        }
+                    }
+                }
+            },
+            {
+                '$group': {
+                    '_id': {
+                        'vacancyGuid': '$vacancyGuid',
+                        'vacancyReference': '$vacancyReference',
+                        'title': '$title',
+                        'status': '$status',
+                        'legalEntityId': '$legalEntityId',
+                        'legalEntityName': '$legalEntityName',
+                        'employerAccountId': '$employerAccountId',
+                        'employerName': '$employerName',
+                        'ukprn': '$ukprn',
+                        'createdDate': '$createdDate',
+                        'closingDate': '$closingDate',
+                        'startDate': '$startDate',
+                        'closedDate': '$closedDate',
+                        'closureReason': '$closureReason',
+                        'applicationMethod': '$applicationMethod',
+                        'programmeId': '$programmeId',
+                        'duration': '$duration',
+                        'durationUnit': '$durationUnit',
+                        'transferInfoUkprn': '$transferInfoUkprn',
+                        'transferInfoProviderName': '$transferInfoProviderName',
+                        'transferInfoTransferredDate': '$transferInfoTransferredDate',
+                        'transferInfoReason': '$transferInfoReason',
+                        'trainingProviderName': '$trainingProviderName'
+                    },
+                    'noOfNewApplications': {
+                        '$sum': '$isNew'
+                    },
+                    'noOfSuccessfulApplications': {
+                        '$sum': '$isSuccessful'
+                    },
+                    'noOfUnsuccessfulApplications': {
+                        '$sum': '$isUnsuccessful'
+                    }
                 }
             }
-        };
+        ]";
 
         public static BsonDocument[] GetAggregateQueryPipeline(BsonDocument vacanciesMatchClause)
         {
-            return new BsonDocument[]
-            {
-                vacanciesMatchClause,
-                _lookupClause,
-                _unwindClause,
-                _projectionOneClause,
-                _projectionTwoClause,
-                _groupClause
-            };
+            var pipeline = BsonSerializer.Deserialize<BsonArray>(Pipeline);
+            pipeline.Insert(0, vacanciesMatchClause);
+
+            var pipelineDefinition = pipeline.Values.Select(p => p.ToBsonDocument()).ToArray();
+
+            return pipelineDefinition;
         }
     }
 }


### PR DESCRIPTION
We're now ignoring withdrawn vacancies when calculating the count for New, Successful and Unsuccessful applications.

The bigger change is I've simplified `VacancySummaryAggQueryBuilder` so it just loads the entire aggregate pipeline from a string rather than composing it using a series of BsonDocuments and BsonArrays.  This makes it much easier (for me) to debug as you don't need to interpret it and can just cut-n-paste into RoboMongo.  Hope this refactor isn't too contentious. I took the same approach with the Provider reports.