### PR TITLE
ER-1482 send vacancy closed notification on review approval +semver: …

### DIFF
--- a/src/Communication/Communication.Core/Communication.Core.csproj
+++ b/src/Communication/Communication.Core/Communication.Core.csproj
@@ -24,9 +24,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
 
     <ProjectReference Include="..\Communication.Types\Communication.Types.csproj" />
-    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Communication/Communication.UnitTests/Communication.UnitTests.csproj
+++ b/src/Communication/Communication.UnitTests/Communication.UnitTests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Communication.Core\Communication.Core.csproj" />
+    <ProjectReference Include="..\..\Shared\Recruit.Vacancies.Client\Recruit.Vacancies.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/Provider/ProviderBlockedDomainEventHandler.cs
@@ -146,17 +146,8 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
 
             foreach(var employerAccountGroup in employerAccountsWithTransfers)
             {
-                var communicationRequest = new CommunicationRequest(
-                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies, 
-                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
-                    CommunicationConstants.ServiceName);
                 var noOfVacancies = employerAccountGroup.Count();
-                var text = "vacancy".ToQuantity(noOfVacancies) + (noOfVacancies == 1 ? " has been transferred" : " have been transferred");
-                communicationRequest.DataItems.Add(new CommunicationDataItem(CommunicationConstants.DataItemKeys.Employer.VacanciesTransferredCountText, text));
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountGroup.Key);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
-
+                var communicationRequest = CommunicationRequestFactory.GetProviderBlockedEmployerNotificationForTransferredVacanciesRequest(ukprn, employerAccountGroup.Key, noOfVacancies);
                 tasks.Add(_communicationQueueService.AddMessageAsync(communicationRequest));
             }
             return tasks;
@@ -170,14 +161,8 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
 
             foreach(var employerAccountId in employerAccountWithLiveVacancies)
             {
-                var communicationRequest = new CommunicationRequest(
-                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies, 
-                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
-                    CommunicationConstants.ServiceName);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountId);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
-
+                var communicationRequest = CommunicationRequestFactory.GetProviderBlockedEmployerNotificationForLiveVacanciesRequest(ukprn, employerAccountId);
+                
                 tasks.Add(_communicationQueueService.AddMessageAsync(communicationRequest));
             }
 
@@ -192,13 +177,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.Provider
 
             foreach(var employerAccountId in employerIdsWithPermissionOnly)
             {
-                var communicationRequest = new CommunicationRequest(
-                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly, 
-                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
-                    CommunicationConstants.ServiceName);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountId);
-                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
+                var communicationRequest = CommunicationRequestFactory.GetProviderBlockedEmployerNotificationForPermissionOnlyRequest(ukprn, employerAccountId);
 
                 tasks.Add(_communicationQueueService.AddMessageAsync(communicationRequest));
             }

--- a/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/VacancyReview/VacancyReviewApprovedHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/DomainEvents/Handlers/VacancyReview/VacancyReviewApprovedHandler.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
 using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;
 
@@ -9,12 +11,13 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.VacancyReview
     public class VacancyReviewApprovedHandler : DomainEventHandler, IDomainEventHandler<VacancyReviewApprovedEvent>
     {
         private readonly ILogger<VacancyReviewApprovedHandler> _logger;
-        private readonly IJobsVacancyClient _client;
+        private readonly IMessaging _messaging;
 
-        public VacancyReviewApprovedHandler(ILogger<VacancyReviewApprovedHandler> logger, IJobsVacancyClient client) : base(logger)
+        public VacancyReviewApprovedHandler(ILogger<VacancyReviewApprovedHandler> logger, IMessaging messaging) 
+            : base(logger)
         {
             _logger = logger;
-            _client = client;
+            _messaging = messaging;
         }
 
         public async Task HandleAsync(string eventPayload)
@@ -25,7 +28,10 @@ namespace Esfa.Recruit.Vacancies.Jobs.DomainEvents.Handlers.VacancyReview
             {
                 _logger.LogInformation($"Processing {nameof(VacancyReviewApprovedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
                 
-                await _client.ApproveVacancy(@event.VacancyReference);
+                await _messaging.SendCommandAsync(new ApproveVacancyCommand
+                {
+                    VacancyReference = @event.VacancyReference
+                });
 
                 _logger.LogInformation($"Finished Processing {nameof(VacancyReviewApprovedEvent)} for review: {{ReviewId}} vacancy: {{VacancyReference}}", @event.ReviewId, @event.VacancyReference);
             }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationRequestFactory.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Communications/CommunicationRequestFactory.cs
@@ -1,0 +1,45 @@
+using Communication.Types;
+using Humanizer;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Communications
+{
+    public static class CommunicationRequestFactory
+    {
+        public static CommunicationRequest GetProviderBlockedEmployerNotificationForLiveVacanciesRequest(long ukprn, string employerAccountId)
+        {
+            var communicationRequest = new CommunicationRequest(
+                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForLiveVacancies, 
+                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
+                    CommunicationConstants.ServiceName);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountId);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
+            return communicationRequest;
+        }
+        public static CommunicationRequest GetProviderBlockedEmployerNotificationForPermissionOnlyRequest(long ukprn, string employerAccountId)
+        {
+            var communicationRequest = new CommunicationRequest(
+                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForPermissionOnly, 
+                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
+                    CommunicationConstants.ServiceName);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountId);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
+            return communicationRequest;
+        }
+        public static CommunicationRequest GetProviderBlockedEmployerNotificationForTransferredVacanciesRequest(long ukprn, string employerAccountId, int noOfVacancies)
+        {
+            var communicationRequest = new CommunicationRequest(
+                    CommunicationConstants.RequestType.ProviderBlockedEmployerNotificationForTransferredVacancies, 
+                    CommunicationConstants.ParticipantResolverNames.EmployerParticipantsResolverName, 
+                    CommunicationConstants.ServiceName);
+                var text = "vacancy".ToQuantity(noOfVacancies) + (noOfVacancies == 1 ? " has been transferred" : " have been transferred");
+                communicationRequest.DataItems.Add(new CommunicationDataItem(CommunicationConstants.DataItemKeys.Employer.VacanciesTransferredCountText, text));
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Provider, ukprn);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.Employer, employerAccountId);
+                communicationRequest.AddEntity(CommunicationConstants.EntityTypes.ApprenticeshipServiceConfig, null);
+
+            return communicationRequest;
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IJobsVacancyClient.cs
@@ -14,7 +14,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task CreateVacancyReview(long vacancyReference);
         Task CloseExpiredVacancies();
         Task EnsureVacancyIsGeocodedAsync(Guid vacancyId);
-        Task ApproveVacancy(long vacancyReference);
         Task UpdateBankHolidaysAsync();
         Task ReferVacancyAsync(long vacancyReference);
         Task CreateApplicationReviewAsync(Domain.Entities.Application application);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IQaVacancyClient.cs
@@ -13,7 +13,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<QaDashboard> GetDashboardAsync();
         Task<Vacancy> GetVacancyAsync(long vacancyReference);
         Task<IApprenticeshipProgramme> GetApprenticeshipProgrammeAsync(string programmeId);
-        Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> automatedQaRuleOutcomeIds);
         Task<VacancyReview> GetVacancyReviewAsync(Guid reviewId);
         Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> automatedQaRuleOutcomeIds);
         Task<Qualifications> GetCandidateQualificationsAsync();

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/QaVacancyClient.cs
@@ -56,11 +56,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             _reportRepository = reportRepository;
         }
 
-        public Task ApproveVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> selectedAutomatedQaRuleOutcomeIds)
-        {
-            return _messaging.SendCommandAsync(new ApproveVacancyReviewCommand(reviewId, manualQaComment, manualQaFieldIndicators, selectedAutomatedQaRuleOutcomeIds));
-        }
-
         public Task ReferVacancyReviewAsync(Guid reviewId, string manualQaComment, List<ManualQaFieldIndicator> manualQaFieldIndicators, List<Guid> selectedAutomatedQaRuleOutcomeIds)
         {
             return _messaging.SendCommandAsync(new ReferVacancyReviewCommand(reviewId, manualQaComment, manualQaFieldIndicators, selectedAutomatedQaRuleOutcomeIds));

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -379,14 +379,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             await _messaging.SendCommandAsync(command);
         }
 
-        public async Task ApproveVacancy(long vacancyReference)
-        {
-            await _messaging.SendCommandAsync(new ApproveVacancyCommand
-            {
-                VacancyReference = vacancyReference
-            });
-        }
-
         public Task ReferVacancyAsync(long vacancyReference)
         {
             return _messaging.SendCommandAsync(new ReferVacancyCommand

--- a/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
+++ b/src/Shared/Recruit.Vacancies.Client/Recruit.Vacancies.Client.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="SFA.DAS.Providers.Api.Client" Version="0.11.98" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
+    <PackageReference Include="Humanizer.Core.uk" Version="2.6.2" />
     <ProjectReference Include="..\..\Communication\Communication.Types\Communication.Types.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…patch

A new requirement was added to the story. When a review is approved for the vacancy that has blocked provider, the vacancy is closed instead of making it to live. The requirement is to also notify employer about the closed vacancy. 

I found that the Communication.Core had dependency on Recuirt.Vacancies.Client which is weird as any of the Communication projects should not have dependency on any of the recruit projects. I have removed this and refactored code/tests accordingly. 

Since I had to create similar communication request, I moved this to a factory class. 

Also I have removed some of the Client class methods as part of cleanup. 