### PR TITLE
ER-1518 Implements house keeping job for query store collection +semv…

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
@@ -1,4 +1,5 @@
 {
     "_id" : "RecruitWebJobsSystem",
-    "disabledJobs" : ["VacancyAnalyticsSummaryGeneratorJob"]
+    "disabledJobs" : ["VacancyAnalyticsSummaryGeneratorJob"],
+    "queryStoreDocumentsStaleAfterDays" : 90
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTriggerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTriggerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
+using Esfa.Recruit.Vacancies.Jobs.Configuration;
+using Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.UnitTests.Triggers.QueueTriggers
+{
+    public class DeleteStaleQueryStoreDocumentsQueueTriggerTests
+    {
+        private const int Days = 90;
+        private readonly Mock<ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger>> _loggerMock = new Mock<ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger>>();
+        private readonly RecruitWebJobsSystemConfiguration _jobsConfig = new RecruitWebJobsSystemConfiguration() { QueryStoreDocumentsStaleAfterDays = Days };
+        private readonly Mock<ITimeProvider> _timeProviderMock = new Mock<ITimeProvider>();
+        private readonly Mock<IQueryStoreHouseKeepingService> _queryStoreHouseKeepingServiceMock = new Mock<IQueryStoreHouseKeepingService>();
+
+        [Fact]
+        public async Task GivenDateInTheMessage_ThenUseThatDate()
+        {
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(new List<QueryProjectionBase>());
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.DeleteStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), It.IsAny<IEnumerable<string>>())).ReturnsAsync(0);
+            var sut = new DeleteStaleQueryStoreDocumentsQueueTrigger(_loggerMock.Object, _jobsConfig, _timeProviderMock.Object, _queryStoreHouseKeepingServiceMock.Object);
+            var message = new DeleteStaleQueryStoreDocumentsQueueMessage() { CreatedByScheduleDate = DateTime.Today };
+            await sut.DeleteStaleQueryStoreDocumentsAsync(JsonConvert.SerializeObject(message), null);
+            _queryStoreHouseKeepingServiceMock.Verify(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), DateTime.Today.AddDays(Days * -1)), Times.Exactly(5));
+            _timeProviderMock.Verify(t => t.Today, Times.Never);
+        }
+
+        [Fact]
+        public async Task GivenNoDateInTheMessage_ThenUseTodaysDate()
+        {
+            var targetDate = DateTime.Today.AddDays(-1);
+            _timeProviderMock.Setup(t => t.Today).Returns(targetDate);
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(new List<QueryProjectionBase>());
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.DeleteStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), It.IsAny<IEnumerable<string>>())).ReturnsAsync(0);
+            var sut = new DeleteStaleQueryStoreDocumentsQueueTrigger(_loggerMock.Object, _jobsConfig, _timeProviderMock.Object, _queryStoreHouseKeepingServiceMock.Object);
+            await sut.DeleteStaleQueryStoreDocumentsAsync("{}", null);
+            _queryStoreHouseKeepingServiceMock.Verify(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), targetDate.AddDays(Days * -1)), Times.Exactly(5));
+            _timeProviderMock.VerifyGet(t => t.Today);
+        }
+
+        [Fact]
+        public async Task GivenStaleDocumentsExist_ThenDeleteStaleDocuments()
+        {
+            var viewType = "ClosedVacancy";
+            var testId = Guid.NewGuid().ToString();
+            _timeProviderMock.Setup(t => t.Today).Returns(DateTime.Today);
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(viewType, It.IsAny<DateTime>())).ReturnsAsync(new List<QueryProjectionBase>() { new ClosedVacancy(){ Id = testId}} );
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsNotIn(new [] {viewType}), It.IsAny<DateTime>())).ReturnsAsync(new List<QueryProjectionBase>());
+            _queryStoreHouseKeepingServiceMock.Setup(s => s.DeleteStaleDocumentsAsync<QueryProjectionBase>(viewType, It.IsAny<IEnumerable<string>>())).ReturnsAsync(1);
+            var sut = new DeleteStaleQueryStoreDocumentsQueueTrigger(_loggerMock.Object, _jobsConfig, _timeProviderMock.Object, _queryStoreHouseKeepingServiceMock.Object);
+            await sut.DeleteStaleQueryStoreDocumentsAsync("", null);
+            _queryStoreHouseKeepingServiceMock.Verify(s => s.GetStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), DateTime.Today.AddDays(Days * -1)), Times.Exactly(5));
+            _queryStoreHouseKeepingServiceMock.Verify(s => s.DeleteStaleDocumentsAsync<QueryProjectionBase>(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()));
+        }
+
+
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Configuration/RecruitWebJobsSystemConfiguration.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Configuration/RecruitWebJobsSystemConfiguration.cs
@@ -5,6 +5,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.Configuration
     public class RecruitWebJobsSystemConfiguration
     {
         public string Id { get; set; }
-        public IList<string> DisabledJobs { get; set; }
+        public IList<string> DisabledJobs { get; set; } = new List<string>();
+        public int QueryStoreDocumentsStaleAfterDays { get; set; }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Schedules.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Schedules.cs
@@ -9,5 +9,6 @@
         internal const string EveryFiveMinutes = "*/5 * * * *";
         internal const string EveryFifteenMinutes = "*/15 * * * *";
         internal const string Hourly = "0 0 */1 * * *";
+        internal const string WeeklyFourAmSunday = "0 4 * * SUN";
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTrigger.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Employer;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Provider;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
+using Esfa.Recruit.Vacancies.Jobs.Configuration;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers
+{
+    public class DeleteStaleQueryStoreDocumentsQueueTrigger
+    {
+        private readonly ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger> _logger;
+        private readonly RecruitWebJobsSystemConfiguration _jobsConfig;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IQueryStoreHouseKeepingService _queryStoreHouseKeepingService;
+        private string JobName => GetType().Name;
+
+        public DeleteStaleQueryStoreDocumentsQueueTrigger(ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger> logger, 
+            RecruitWebJobsSystemConfiguration jobsConfig,
+            ITimeProvider timeProvider,
+            IQueryStoreHouseKeepingService queryStoreHouseKeepingService)
+        {
+            _logger = logger;
+            _jobsConfig = jobsConfig;
+            _timeProvider = timeProvider;
+            _queryStoreHouseKeepingService = queryStoreHouseKeepingService;
+        }
+
+        public async Task DeleteStaleQueryStoreDocumentsAsync([QueueTrigger(QueueNames.DeleteStaleQueryStoreDocumentsQueueName, Connection = "QueueStorage")] string message, TextWriter log)
+        {
+            try
+            {
+                if (_jobsConfig.DisabledJobs.Contains(JobName))
+                {
+                    _logger.LogDebug($"{JobName} is disabled, skipping ...");
+                    return;
+                }
+
+                var payload = JsonConvert.DeserializeObject<DeleteStaleQueryStoreDocumentsQueueMessage>(message);
+
+                var targetDate = payload?.CreatedByScheduleDate ?? _timeProvider.Today;
+
+                var deleteReportsCreatedBeforeDate = targetDate.AddDays(_jobsConfig.QueryStoreDocumentsStaleAfterDays * -1);
+                
+                _logger.LogInformation($"Begining to delete query store stale documents that have not been updated since {deleteReportsCreatedBeforeDate.ToShortDateString()}");
+
+                var documentTypesToDelete = new [] 
+                {
+                    nameof(EditVacancyInfo), 
+                    nameof(ProviderEditVacancyInfo),
+                    nameof(EmployerDashboard),
+                    nameof(ProviderDashboard),
+                    nameof(ClosedVacancy)
+                };
+
+                foreach (var viewType in documentTypesToDelete)
+                {
+                    var staleDocuments = await _queryStoreHouseKeepingService.GetStaleDocumentsAsync<QueryProjectionBase>(viewType, deleteReportsCreatedBeforeDate);
+                    _logger.LogInformation($"Found {staleDocuments.Count} query store documents for type {viewType} updated before {deleteReportsCreatedBeforeDate}");
+                    if (staleDocuments.Any())
+                    {
+                        var deletedCount = await _queryStoreHouseKeepingService.DeleteStaleDocumentsAsync<QueryProjectionBase>(viewType, staleDocuments.Select(s => s.Id));
+                        _logger.LogInformation($"Deleted {deletedCount} query store documents for type {viewType} updated before {deleteReportsCreatedBeforeDate}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to run {JobName}");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/TimerTriggers/DeleteStaleQueryStoreDocumentsTimeTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/TimerTriggers/DeleteStaleQueryStoreDocumentsTimeTrigger.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Queues;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Jobs;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Triggers.TimerTriggers
+{
+    public class DeleteStaleQueryStoreDocumentsTimeTrigger
+    {
+        private readonly ILogger<DeleteStaleQueryStoreDocumentsTimeTrigger> _logger;
+        private readonly IRecruitQueueService _queue;
+        private readonly ITimeProvider _timeProvider;
+
+        public DeleteStaleQueryStoreDocumentsTimeTrigger(ILogger<DeleteStaleQueryStoreDocumentsTimeTrigger> logger, IRecruitQueueService queue, ITimeProvider timeProvider)
+        {
+            _logger = logger;
+            _queue = queue;
+            _timeProvider = timeProvider;
+        }
+
+        public Task DeleteReportsAsync([TimerTrigger(Schedules.WeeklyFourAmSunday)] TimerInfo timerInfo, TextWriter log)
+        {
+            _logger.LogInformation($"Timer trigger {this.GetType().Name} fired");
+
+            var message = new DeleteStaleQueryStoreDocumentsQueueMessage
+            {
+                CreatedByScheduleDate = _timeProvider.Now
+            };
+
+            return _queue.AddMessageAsync(message);
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/DeleteStaleQueryStoreDocumentsQueueMessage.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/DeleteStaleQueryStoreDocumentsQueueMessage.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Queues.Messages
+{
+    public class DeleteStaleQueryStoreDocumentsQueueMessage
+    {
+        public DateTime? CreatedByScheduleDate { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreHouseKeepingService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreHouseKeepingService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
+
+namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
+{
+    public interface IQueryStoreHouseKeepingService
+    {
+        Task<List<T>> GetStaleDocumentsAsync<T>(string typeName, DateTime documentsNotAccessedSinceDate) where T : QueryProjectionBase;
+
+        Task<long> DeleteStaleDocumentsAsync<T>(string typeName, IEnumerable<string> documentIds) where T : QueryProjectionBase;
+
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/QueryProjectionBase.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/QueryProjectionBase.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections
 {
-    public abstract class QueryProjectionBase
+    public class QueryProjectionBase
     {
-        protected QueryProjectionBase(string viewType)
+        public QueryProjectionBase(string viewType)
         {
             ViewType = viewType;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
@@ -24,5 +24,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue
         public const string VacancyStatusQueueName = "vacancy-status-queue";
         public const string UpdateBankHolidaysQueueName = "update-bank-holidays-queue";
         public const string UpdateEmployerUserAccountQueueName = "update-employer-user-account-queue";
+        public const string DeleteStaleQueryStoreDocumentsQueueName = "delete-stale-query-store-documents-queue";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/RecruitStorageQueueService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/RecruitStorageQueueService.cs
@@ -23,7 +23,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue
             { typeof(UpdateQaDashboardQueueMessage), QueueNames.UpdateQaDashboardQueueName },
             { typeof(VacancyAnalyticsQueueMessage), QueueNames.GenerateVacancyAnalyticsQueueName },
             { typeof(VacancyStatusQueueMessage), QueueNames.VacancyStatusQueueName },
-            { typeof(UpdateEmployerUserAccountQueueMessage), QueueNames.UpdateEmployerUserAccountQueueName }
+            { typeof(UpdateEmployerUserAccountQueueMessage), QueueNames.UpdateEmployerUserAccountQueueName },
+            { typeof(DeleteStaleQueryStoreDocumentsQueueMessage), QueueNames.DeleteStaleQueryStoreDocumentsQueueName }
         };
 
         protected override string ConnectionString { get; }

--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -248,7 +248,10 @@ namespace Esfa.Recruit.Vacancies.Client.Ioc
             if (useTableStorageQueryStore)
                 services.AddTransient<IQueryStore, TableStorageQueryStore>();
             else
+            {
                 services.AddTransient<IQueryStore, MongoQueryStore>();
+                services.AddTransient<IQueryStoreHouseKeepingService, MongoQueryStore>();
+            }
         }
 
         private static void AddValidation(IServiceCollection services)


### PR DESCRIPTION
…er: minor

The timer trigger will raise message with a date time stamp, this will be used as the base date in the queue trigger. This will enable testing by dropping the message manually. Also there is a fall back to use today's date if the message doesn't have one. 

I had to convert based class to be non-abstract so I can query any view types. 

There are 5000+ EditVacancyInfo documents that qualify for deletion. I tested my code with 6000. I am using DeleteMany command, which only managed about 2500 after 3 attempts due to polly retry.  So it will require about 3 messages to begin with to clear the whole lot. But after that first run this should execute ideally. 



