### PR TITLE
ER-1519 housekeeping on vacancies

### DIFF
--- a/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
+++ b/src/Data/CosmosDb/Console.RecruitSeedDataWriter/Data/RecruitWebJobsSystem.json
@@ -1,5 +1,7 @@
 {
     "_id" : "RecruitWebJobsSystem",
     "disabledJobs" : ["VacancyAnalyticsSummaryGeneratorJob"],
-    "queryStoreDocumentsStaleAfterDays" : 90
+    "queryStoreDocumentsStaleByDays" : 90,
+    "draftVacanciesStaleByDays" : 180,
+    "referredVacanciesStaleByDays" : 90
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTriggerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleQueryStoreDocumentsQueueTriggerTests.cs
@@ -19,7 +19,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.UnitTests.Triggers.QueueTriggers
     {
         private const int Days = 90;
         private readonly Mock<ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger>> _loggerMock = new Mock<ILogger<DeleteStaleQueryStoreDocumentsQueueTrigger>>();
-        private readonly RecruitWebJobsSystemConfiguration _jobsConfig = new RecruitWebJobsSystemConfiguration() { QueryStoreDocumentsStaleAfterDays = Days };
+        private readonly RecruitWebJobsSystemConfiguration _jobsConfig = new RecruitWebJobsSystemConfiguration() { QueryStoreDocumentsStaleByDays = Days };
         private readonly Mock<ITimeProvider> _timeProviderMock = new Mock<ITimeProvider>();
         private readonly Mock<IQueryStoreHouseKeepingService> _queryStoreHouseKeepingServiceMock = new Mock<IQueryStoreHouseKeepingService>();
 

--- a/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleVacanciesQueueTriggerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/Triggers/QueueTriggers/DeleteStaleVacanciesQueueTriggerTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Jobs.Configuration;
+using Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Jobs.UnitTests.Triggers.QueueTriggers
+{
+    public class DeleteStaleVacanciesQueueTriggerTests
+    {
+        private readonly Mock<ILogger<DeleteStaleVacanciesQueueTrigger>> _mockLogger = new Mock<ILogger<DeleteStaleVacanciesQueueTrigger>>(); 
+        private readonly RecruitWebJobsSystemConfiguration _config = new RecruitWebJobsSystemConfiguration(); 
+        private readonly Mock<ITimeProvider> _mockTimeProvider = new Mock<ITimeProvider>();
+        private readonly Mock<IVacancyQuery> _mockQuery = new Mock<IVacancyQuery>();
+        private readonly Mock<IMessaging> _mockMessaging = new Mock<IMessaging>();
+        private readonly DeleteStaleVacanciesQueueMessage _message = new DeleteStaleVacanciesQueueMessage();
+        private string GetMessage() => JsonConvert.SerializeObject(_message);
+        private DeleteStaleVacanciesQueueTrigger GetSut() => new DeleteStaleVacanciesQueueTrigger(_mockLogger.Object, _config, _mockTimeProvider.Object, _mockQuery.Object, _mockMessaging.Object);
+        
+        [Fact]
+        public async Task WhenConfigIsNotPopulated_ThenUseDefaultStaleByDays()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _mockTimeProvider.Setup(t => t.Today).Returns(executionDate);
+            var expectedDraftStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultDraftStaleByDays * -1);
+            var expectedReferredStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultReferredStaleByDays * -1);
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockQuery.Verify(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(expectedDraftStaleByDate));
+            _mockQuery.Verify(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(expectedReferredStaleByDate));
+        }
+
+        [Fact]
+        public async Task WhenStaleByDaysAreDefinedInTheConfig_ThenUseConfigStaleByDays()
+        {
+            _config.DraftVacanciesStaleByDays = 20;
+            _config.ReferredVacanciesStaleByDays = 10;
+            var executionDate = new DateTime(2019, 10, 8);
+            _mockTimeProvider.Setup(t => t.Today).Returns(executionDate);
+            var expectedDraftStaleByDate = executionDate.AddDays(_config.DraftVacanciesStaleByDays.Value * -1);
+            var expectedReferredStaleByDate = executionDate.AddDays(_config.ReferredVacanciesStaleByDays.Value * -1);
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockQuery.Verify(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(expectedDraftStaleByDate));
+            _mockQuery.Verify(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(expectedReferredStaleByDate));
+        }
+
+        [Fact]
+        public async Task WhenDateIsMissingInTheMessage_ThenUseTimeProviderDate()
+        {
+            _message.CreatedByScheduleDate = null;
+            var executionDate = new DateTime(2019, 10, 8);
+            _mockTimeProvider.Setup(t => t.Today).Returns(executionDate);
+
+            var expectedDraftStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultDraftStaleByDays * -1);
+            var expectedReferredStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultReferredStaleByDays * -1);
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockTimeProvider.Verify(t => t.Today);
+            _mockQuery.Verify(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(expectedDraftStaleByDate));
+            _mockQuery.Verify(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(expectedReferredStaleByDate));
+        }
+        
+        [Fact]
+        public async Task WhenDateIsDefinedInTheMessage_ThenUseMessageDate()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _message.CreatedByScheduleDate = executionDate;
+
+            var expectedDraftStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultDraftStaleByDays * -1);
+            var expectedReferredStaleByDate = executionDate.AddDays(DeleteStaleVacanciesQueueTrigger.DefaultReferredStaleByDays * -1);
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockTimeProvider.Verify(t => t.Today, Times.Never);
+            _mockQuery.Verify(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(expectedDraftStaleByDate));
+            _mockQuery.Verify(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(expectedReferredStaleByDate));
+        }
+
+        [Fact]
+        public async Task WhenDraftAndReferredVacanciesFound_RaiseDeleteCommandForAll()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _message.CreatedByScheduleDate = executionDate;
+            var fixture = new Fixture();
+            var draftVacancy = fixture.Create<VacancyIdentifier>();
+            var referredVacancy = fixture.Create<VacancyIdentifier>();
+            _mockQuery.Setup(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>())).ReturnsAsync(new [] { draftVacancy });
+            _mockQuery.Setup(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>())).ReturnsAsync(new [] { referredVacancy });
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.IsAny<ICommand>()), Times.Exactly(2));
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.Is<DeleteVacancyCommand>(d => d.VacancyId == draftVacancy.Id)));
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.Is<DeleteVacancyCommand>(d => d.VacancyId == referredVacancy.Id)));
+        }
+
+        [Fact]
+        public async Task WhenReferredVacanciesFound_RaiseDeleteCommand()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _message.CreatedByScheduleDate = executionDate;
+            var fixture = new Fixture();
+            var vacancies = new [] { fixture.Create<VacancyIdentifier>() };
+            _mockQuery
+                .Setup(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(Array.Empty<VacancyIdentifier>());
+            _mockQuery
+                .Setup(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(vacancies);
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.IsAny<ICommand>()), Times.Exactly(1));
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.Is<DeleteVacancyCommand>(d => d.VacancyId == vacancies.First().Id)));
+        }
+
+        [Fact]
+        public async Task WhenDraftVacanciesFound_RaiseDeleteCommand()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _message.CreatedByScheduleDate = executionDate;
+            var fixture = new Fixture();
+            var vacancies = new [] { fixture.Create<VacancyIdentifier>() };
+            _mockQuery
+                .Setup(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(vacancies);
+            _mockQuery
+                .Setup(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(Array.Empty<VacancyIdentifier>());
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.IsAny<ICommand>()), Times.Exactly(1));
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.Is<DeleteVacancyCommand>(d => d.VacancyId == vacancies.First().Id)));
+        }
+
+        [Fact]
+        public async Task WhenNoVacanciesFound_RaiseDeleteCommand()
+        {
+            var executionDate = new DateTime(2019, 10, 8);
+            _message.CreatedByScheduleDate = executionDate;
+            _mockQuery
+                .Setup(q => q.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(Array.Empty<VacancyIdentifier>());
+            _mockQuery
+                .Setup(q => q.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(It.IsAny<DateTime>()))
+                .ReturnsAsync(Array.Empty<VacancyIdentifier>());
+
+            var sut = GetSut();
+            await sut.DeleteStaleVacanciesAsync(GetMessage(), null);
+
+            _mockMessaging.Verify(m => m.SendCommandAsync(It.IsAny<DeleteVacancyCommand>()), Times.Never);
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Configuration/RecruitWebJobsSystemConfiguration.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Configuration/RecruitWebJobsSystemConfiguration.cs
@@ -6,6 +6,8 @@ namespace Esfa.Recruit.Vacancies.Jobs.Configuration
     {
         public string Id { get; set; }
         public IList<string> DisabledJobs { get; set; } = new List<string>();
-        public int QueryStoreDocumentsStaleAfterDays { get; set; }
+        public int? QueryStoreDocumentsStaleByDays { get; set; }
+        public int? DraftVacanciesStaleByDays { get; set; }
+        public int? ReferredVacanciesStaleByDays { get; set; }
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Schedules.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Schedules.cs
@@ -10,5 +10,6 @@
         internal const string EveryFifteenMinutes = "*/15 * * * *";
         internal const string Hourly = "0 0 */1 * * *";
         internal const string WeeklyFourAmSunday = "0 4 * * SUN";
+        internal const string WeeklySevenAmSunday = "0 7 * * SUN";
     }
 }

--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/DeleteStaleVacanciesQueueTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/DeleteStaleVacanciesQueueTrigger.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
+using Esfa.Recruit.Vacancies.Jobs.Configuration;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers
+{
+    public class DeleteStaleVacanciesQueueTrigger
+    {
+        public const int DefaultDraftStaleByDays = 180;
+        public const int DefaultReferredStaleByDays = 90;
+        private readonly ILogger<DeleteStaleVacanciesQueueTrigger> _logger;
+        private readonly RecruitWebJobsSystemConfiguration _jobsConfig;
+        private readonly ITimeProvider _timeProvider;
+        private readonly IVacancyQuery _vacancyQuery;
+        private readonly IMessaging _messaging;
+
+        private string JobName => GetType().Name;
+
+        public DeleteStaleVacanciesQueueTrigger(ILogger<DeleteStaleVacanciesQueueTrigger> logger, 
+            RecruitWebJobsSystemConfiguration jobsConfig,
+            ITimeProvider timeProvider,
+            IVacancyQuery vacancyQuery,
+            IMessaging messaging)
+        {
+            _logger = logger;
+            _jobsConfig = jobsConfig;
+            _timeProvider = timeProvider;
+            _vacancyQuery = vacancyQuery;
+            _messaging = messaging;
+        }
+
+        public async Task DeleteStaleVacanciesAsync([QueueTrigger(QueueNames.DeleteStaleVacanciesQueueName, Connection = "QueueStorage")] string message, TextWriter log)
+        {
+            try
+            {
+                if (_jobsConfig.DisabledJobs.Contains(JobName))
+                {
+                    _logger.LogDebug($"{JobName} is disabled, skipping ...");
+                    return;
+                }
+
+                var payload = JsonConvert.DeserializeObject<DeleteStaleVacanciesQueueMessage>(message);
+
+                var targetDate = payload?.CreatedByScheduleDate ?? _timeProvider.Today;
+
+                _logger.LogInformation($"Begining to delete vacancies that have not been updated since {targetDate.ToShortDateString()}");
+
+                var draftStaleByDate = targetDate.AddDays((_jobsConfig.DraftVacanciesStaleByDays ?? DefaultDraftStaleByDays) * -1);
+                var referredStaleByDate = targetDate.AddDays((_jobsConfig.ReferredVacanciesStaleByDays ?? DefaultReferredStaleByDays) * -1);
+
+                var staleDraftVacanciesTask = _vacancyQuery.GetDraftVacanciesCreatedBeforeAsync<VacancyIdentifier>(draftStaleByDate);
+                var staleReferredVacanciesTask = _vacancyQuery.GetReferredVacanciesSubmittedBeforeAsync<VacancyIdentifier>(referredStaleByDate);
+
+                await Task.WhenAll(staleDraftVacanciesTask, staleReferredVacanciesTask);
+
+                var staleVacancies = staleDraftVacanciesTask.Result.Concat(staleReferredVacanciesTask.Result);
+
+                _logger.LogInformation($"Found {staleDraftVacanciesTask.Result.Count()} {VacancyStatus.Draft} vacancies that have been created on or before {draftStaleByDate}");
+                _logger.LogInformation($"Found {staleReferredVacanciesTask.Result.Count()} {VacancyStatus.Referred} vacancies that have been submitted on or before {referredStaleByDate}");
+
+                await Task.WhenAll(GetDeleteVacancyTasks(staleVacancies));
+
+                _logger.LogInformation($"Finished deleting vacancies that have not been updated since {targetDate.ToShortDateString()}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to run {JobName}");
+                throw;
+            }
+        }
+
+        private List<Task> GetDeleteVacancyTasks(IEnumerable<VacancyIdentifier> vacancies)
+        {
+            var tasks = new List<Task>();
+
+            foreach(var v in vacancies) 
+            {
+                var cmd = new DeleteVacancyCommand() { VacancyId = v.Id };
+                tasks.Add(_messaging.SendCommandAsync(cmd));
+            }
+
+            return tasks;
+        }
+    }
+}

--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/TimerTriggers/DeleteStaleVacanciesTimeTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/TimerTriggers/DeleteStaleVacanciesTimeTrigger.cs
@@ -8,24 +8,24 @@ using Microsoft.Extensions.Logging;
 
 namespace Esfa.Recruit.Vacancies.Jobs.Triggers.TimerTriggers
 {
-    public class DeleteStaleQueryStoreDocumentsTimeTrigger
+    public class DeleteStaleVacanciesTimeTrigger
     {
-        private readonly ILogger<DeleteStaleQueryStoreDocumentsTimeTrigger> _logger;
+        private readonly ILogger<DeleteStaleVacanciesTimeTrigger> _logger;
         private readonly IRecruitQueueService _queue;
         private readonly ITimeProvider _timeProvider;
 
-        public DeleteStaleQueryStoreDocumentsTimeTrigger(ILogger<DeleteStaleQueryStoreDocumentsTimeTrigger> logger, IRecruitQueueService queue, ITimeProvider timeProvider)
+        public DeleteStaleVacanciesTimeTrigger(ILogger<DeleteStaleVacanciesTimeTrigger> logger, IRecruitQueueService queue, ITimeProvider timeProvider)
         {
             _logger = logger;
             _queue = queue;
             _timeProvider = timeProvider;
         }
 
-        public Task DeleteReportsAsync([TimerTrigger(Schedules.WeeklyFourAmSunday)] TimerInfo timerInfo, TextWriter log)
+        public Task DeleteStaleVacanciesAsync([TimerTrigger(Schedules.WeeklySevenAmSunday)] TimerInfo timerInfo, TextWriter log)
         {
             _logger.LogInformation($"Timer trigger {this.GetType().Name} fired");
 
-            var message = new DeleteStaleQueryStoreDocumentsQueueMessage
+            var message = new DeleteStaleVacanciesQueueMessage
             {
                 CreatedByScheduleDate = _timeProvider.Today
             };

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandler.cs
@@ -35,7 +35,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
             
             var vacancy = await _repository.GetVacancyAsync(message.VacancyId);
 
-            if (vacancy == null || vacancy.CanDelete == false)
+            if (vacancy == null)
+            {
+                _logger.LogWarning($"Unable to find vacancy {{vacancyId}} for deletion", message.VacancyId);
+                return;
+            }
+
+            if (vacancy.CanDelete == false)
             {
                 _logger.LogWarning($"Unable to delete vacancy {{vacancyId}} due to vacancy having a status of {vacancy?.Status}.", message.VacancyId);
                 return;
@@ -45,9 +51,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
             vacancy.IsDeleted = true;
             vacancy.DeletedDate = now;
-            vacancy.DeletedByUser = message.User;
             vacancy.LastUpdatedDate = now;
-            vacancy.LastUpdatedByUser = message.User;
+
+            if (message.User != null)
+            {
+                vacancy.DeletedByUser = message.User;
+                vacancy.LastUpdatedByUser = message.User;
+            }
 
             await _repository.UpdateAsync(vacancy);
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/DeleteStaleVacanciesQueueMessage.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/DeleteStaleVacanciesQueueMessage.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Queues.Messages
+{
+    public class DeleteStaleVacanciesQueueMessage
+    {
+        public DateTime? CreatedByScheduleDate { get; set; }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyQuery.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IVacancyQuery.cs
@@ -20,5 +20,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
         Task<IEnumerable<ProviderVacancySummary>> GetVacanciesAssociatedToProvider(long ukprn);
         Task<IEnumerable<Vacancy>> GetProviderOwnedVacanciesForLegalEntityAsync(long ukprn, long legalEntityId);
         Task<IEnumerable<Vacancy>> GetProviderOwnedVacanciesForEmployerWithoutLegalEntityAsync(long ukprn, string employerAccountId);
+        Task<IEnumerable<T>> GetDraftVacanciesCreatedBeforeAsync<T>(DateTime staleDate);
+        Task<IEnumerable<T>> GetReferredVacanciesSubmittedBeforeAsync<T>(DateTime staleDate);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbVacancyRepository.cs
@@ -110,7 +110,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
             var builder = Builders<T>.Filter;
             var filter = builder.Eq(ProviderUkprnFieldName, ukprn) &
                         builder.Eq(OwnerTypeFieldName, OwnerType.Provider.ToString()) &
-                        builder.Ne(IsDeletedFieldName, true);
+                        builder.Eq(IsDeletedFieldName, false);
 
             var collection = GetCollection<T>();
 
@@ -119,6 +119,40 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
                     .Project<T>(GetProjection<T>())
                     .ToListAsync(),
             new Context(nameof(GetVacanciesByProviderAccountAsync)));
+
+            return result;
+        }
+
+        public async Task<IEnumerable<T>> GetDraftVacanciesCreatedBeforeAsync<T>(DateTime staleByDate)
+        {
+            var builder = Builders<T>.Filter;
+            var filter = builder.Eq("status", VacancyStatus.Draft.ToString()) &
+                        builder.Lt("createdDate", staleByDate) &
+                        builder.Eq(IsDeletedFieldName, false);
+                        var collection = GetCollection<T>();
+
+            var result = await RetryPolicy.ExecuteAsync(_ =>
+                    collection.Find(filter)
+                    .Project<T>(GetProjection<T>())
+                    .ToListAsync(),
+            new Context(nameof(GetDraftVacanciesCreatedBeforeAsync)));
+
+            return result;
+        }
+
+        public async Task<IEnumerable<T>> GetReferredVacanciesSubmittedBeforeAsync<T>(DateTime staleByDate)
+        {
+            var builder = Builders<T>.Filter;
+            var filter = builder.Eq("status", VacancyStatus.Referred.ToString()) &
+                        builder.Lt("submittedDate", staleByDate) &
+                        builder.Eq(IsDeletedFieldName, false);
+                        var collection = GetCollection<T>();
+
+            var result = await RetryPolicy.ExecuteAsync(_ =>
+                    collection.Find(filter)
+                    .Project<T>(GetProjection<T>())
+                    .ToListAsync(),
+            new Context(nameof(GetReferredVacanciesSubmittedBeforeAsync)));
 
             return result;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/ProviderRelationship/ProviderRelationshipsService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/ProviderRelationship/ProviderRelationshipsService.cs
@@ -115,7 +115,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelation
 
                 if(!response.IsSuccessStatusCode)
                 {
-                    throw new Exception($"Failed to revoke provider {ukprn} permission for account legal entity {accountLegalEntityPublicHashedId} ");
+                    throw new Exception($"Failed to revoke provider {ukprn} permission for account legal entity {accountLegalEntityPublicHashedId} response code: {response.StatusCode}");
                 }
             }
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
@@ -32,7 +32,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
             }
             catch (Exception ex)
             {
-                _logger.LogInformation(ex, $"Failed to retrieve provider information for UKPRN: {ukprn}");
+                _logger.LogWarning(ex, $"Failed to retrieve provider information for UKPRN: {ukprn}");
                 return null;
             }
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
@@ -25,5 +25,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue
         public const string UpdateBankHolidaysQueueName = "update-bank-holidays-queue";
         public const string UpdateEmployerUserAccountQueueName = "update-employer-user-account-queue";
         public const string DeleteStaleQueryStoreDocumentsQueueName = "delete-stale-query-store-documents-queue";
+        public const string DeleteStaleVacanciesQueueName = "delete-stale-vacancies-queue";
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/DeleteVacancyCommandHandlerTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using Esfa.Recruit.Vacancies.Client.Application.CommandHandlers;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.CommandHandlers
+{
+    public class DeleteVacancyCommandHandlerTests
+    {
+        private readonly Mock<ILogger<DeleteVacancyCommandHandler>> _mockLogger = new Mock<ILogger<DeleteVacancyCommandHandler>>();
+        private readonly Mock<IVacancyRepository> _mockVacancyRepository = new Mock<IVacancyRepository>();
+        private readonly Mock<IMessaging> _mockMessaging = new Mock<IMessaging>();
+        private readonly Mock<ITimeProvider> _mockTimeProvider = new Mock<ITimeProvider>();
+
+        [Theory]
+        [InlineData(VacancyStatus.Live)]
+        [InlineData(VacancyStatus.Approved)]
+        [InlineData(VacancyStatus.Closed)]
+        [InlineData(VacancyStatus.Submitted)]
+        public async Task WhenVacancyIsNotInValidState_ShouldNotSetVacancyDeleted(VacancyStatus status)
+        {
+            var fixture = new Fixture();
+            var vacancy = fixture.Build<Vacancy>().With(v => v.Status, status).Create();
+            _mockVacancyRepository.Setup(r => r.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(vacancy);
+            var sut = GetSut();
+            await sut.Handle(fixture.Create<DeleteVacancyCommand>(), new CancellationToken());
+            _mockVacancyRepository.Verify(m => m.UpdateAsync(It.IsAny<Vacancy>()), Times.Never);
+            _mockMessaging.Verify(m => m.PublishEvent(It.IsAny<VacancyDeletedEvent>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenVacancyIsAlreadyDeleted_ShouldNotSetVacancyDeleted()
+        {
+            var fixture = new Fixture();
+            var vacancy = fixture.Build<Vacancy>().With(v => v.IsDeleted, true).Create();
+            _mockVacancyRepository.Setup(r => r.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(vacancy);
+            var sut = GetSut();
+            await sut.Handle(fixture.Create<DeleteVacancyCommand>(), new CancellationToken());
+            _mockVacancyRepository.Verify(m => m.UpdateAsync(It.IsAny<Vacancy>()), Times.Never);
+            _mockMessaging.Verify(m => m.PublishEvent(It.IsAny<VacancyDeletedEvent>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenVacancyIsNotFound_ShouldNotSetVacancyDeleted()
+        {
+            var fixture = new Fixture();
+            _mockVacancyRepository.Setup(r => r.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync((Vacancy)null);
+            var sut = GetSut();
+            await sut.Handle(fixture.Create<DeleteVacancyCommand>(), new CancellationToken());
+            _mockVacancyRepository.Verify(m => m.UpdateAsync(It.IsAny<Vacancy>()), Times.Never);
+            _mockMessaging.Verify(m => m.PublishEvent(It.IsAny<VacancyDeletedEvent>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenUserInformationIsMissing_SetVacancyDeletedWithoutUser()
+        {
+            var fixture = new Fixture();
+            var user = fixture.Create<VacancyUser>();
+            var vacancy = 
+                fixture.Build<Vacancy>()
+                    .With(v => v.IsDeleted, false)
+                    .With(v => v.LastUpdatedByUser, user)
+                    .Without(v => v.DeletedByUser).Create();
+            _mockVacancyRepository.Setup(r => r.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(vacancy);
+            var command = fixture.Build<DeleteVacancyCommand>().Without(v => v.User).Create();
+            var sut = GetSut();
+            await sut.Handle(command, new CancellationToken());
+            _mockVacancyRepository.Verify(m => m.UpdateAsync(It.Is<Vacancy>(v => v.DeletedByUser == null && v.LastUpdatedByUser == user)));
+            _mockMessaging.Verify(m => m.PublishEvent(It.IsAny<VacancyDeletedEvent>()));
+        }
+
+        [Fact]
+        public async Task WhenUserInformationIsAvailable_SetVacancyDeletedByUser()
+        {
+            var fixture = new Fixture();
+            var lastUpdatedByUser = fixture.Create<VacancyUser>();
+            var deletedByUser = fixture.Create<VacancyUser>();
+            var vacancy = 
+                fixture.Build<Vacancy>()
+                    .With(v => v.IsDeleted, false)
+                    .With(v => v.LastUpdatedByUser, lastUpdatedByUser).Create();
+            _mockVacancyRepository.Setup(r => r.GetVacancyAsync(It.IsAny<Guid>())).ReturnsAsync(vacancy);
+            var command = fixture.Build<DeleteVacancyCommand>().With(v => v.User, deletedByUser).Create();
+            var sut = GetSut();
+            await sut.Handle(command, new CancellationToken());
+            _mockVacancyRepository.Verify(m => m.UpdateAsync(It.Is<Vacancy>(v => v.DeletedByUser == deletedByUser && v.LastUpdatedByUser == deletedByUser)));
+            _mockMessaging.Verify(m => m.PublishEvent(It.IsAny<VacancyDeletedEvent>()));
+        }
+
+        private DeleteVacancyCommandHandler GetSut()
+        {
+            return new DeleteVacancyCommandHandler(
+                _mockLogger.Object, _mockVacancyRepository.Object, _mockMessaging.Object, _mockTimeProvider.Object);
+        }
+    }
+}


### PR DESCRIPTION
Continuing to use the configuration collection to allow configuring un-essential bits for the jobs. To fall back on missing configuration a default value based on the story is applied. 

Changed the DeleteVacancyCommandHandler to make the user optional as when we delete the vacancy via the job there is no associated user. 