### PR TITLE
ER-1446 Added check on vacancy owner in authorization

### DIFF
--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -189,7 +189,7 @@
             "type": "process",
             "args": [
                 "test",
-                "${workspaceFolder}/Jobs/Recruit.Vacancies.Jobs.Tests/Recruit.Vacancies.Jobs.Tests.csproj",
+                "${workspaceFolder}/Jobs/Recruit.Vacancies.Jobs.UnitTests/Recruit.Vacancies.Jobs.UnitTests.csproj",
                 "/p:GenerateFullPaths=true"
             ]
         }

--- a/src/Employer/Employer.Web/Utility.cs
+++ b/src/Employer/Employer.Web/Utility.cs
@@ -46,6 +46,8 @@ namespace Esfa.Recruit.Employer.Web
         {
             if (!vacancy.EmployerAccountId.Equals(employerAccountId, StringComparison.OrdinalIgnoreCase))
                 throw new AuthorisationException(string.Format(ExceptionMessages.VacancyUnauthorisedAccess, employerAccountId, vacancy.EmployerAccountId, vacancy.Title, vacancy.Id));
+            if (vacancy.OwnerType != OwnerType.Employer)
+                throw new AuthorisationException(string.Format(ExceptionMessages.UserIsNotTheOwner, OwnerType.Employer));
         }
 
         public static void CheckRouteIsValidForVacancy(Vacancy vacancy, string currentRouteName)

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -8,9 +8,11 @@ using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.VacancyPreview;
 using Esfa.Recruit.Shared.Web.Orchestrators;
 using Esfa.Recruit.Shared.Web.Services;
+using Esfa.Recruit.Vacancies.Client.Application.Commands;
 using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Exceptions;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Microsoft.Extensions.Logging;
 using ErrMsg = Esfa.Recruit.Shared.Web.ViewModels.ErrorMessages;
@@ -28,6 +30,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
         private readonly IReviewSummaryService _reviewSummaryService;
         private readonly ILegalEntityAgreementService _legalEntityAgreementService;
         private readonly ITrainingProviderAgreementService _trainingProviderAgreementService;
+        private readonly IMessaging _messaging;
 
         public VacancyPreviewOrchestrator(
             IProviderVacancyClient client,
@@ -36,7 +39,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             DisplayVacancyViewModelMapper vacancyDisplayMapper, 
             IReviewSummaryService reviewSummaryService,
             ILegalEntityAgreementService legalEntityAgreementService,
-            ITrainingProviderAgreementService trainingProviderAgreementService) : base(logger)
+            ITrainingProviderAgreementService trainingProviderAgreementService,
+            IMessaging messaging) : base(logger)
         {
             _client = client;
             _vacancyClient = vacancyClient;
@@ -44,6 +48,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             _reviewSummaryService = reviewSummaryService;
             _legalEntityAgreementService = legalEntityAgreementService;
             _trainingProviderAgreementService = trainingProviderAgreementService;
+            _messaging = messaging;
         }
 
         public async Task<VacancyPreviewViewModel> GetVacancyPreviewViewModelAsync(VacancyRouteModel vrm)
@@ -94,15 +99,12 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             return await ValidateAndExecute(
                 vacancy,
                 v => ValidateVacancy(v, SubmitValidationRules),
-                v => SubmitActionAsync(m, user)
+                v => SubmitActionAsync(vacancy, user)
                 );
         }
 
-        private async Task<SubmitVacancyResponse> SubmitActionAsync(SubmitEditModel submitEditModel, VacancyUser user)
+        private async Task<SubmitVacancyResponse> SubmitActionAsync(Vacancy vacancy, VacancyUser user)
         {
-            //Retrieve vacancy again in case it has changed
-            var vacancy = await Utility.GetAuthorisedVacancyAsync(_client, _vacancyClient, submitEditModel, RouteNames.Preview_Submit_Post);
-
             var hasLegalEntityAgreementTask = _legalEntityAgreementService.HasLegalEntityAgreementAsync(vacancy.EmployerAccountId, vacancy.LegalEntityId);
             var hasProviderAgreementTask = _trainingProviderAgreementService.HasAgreementAsync(vacancy.TrainingProvider.Ukprn.Value);
 
@@ -117,7 +119,9 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
             if (response.HasLegalEntityAgreement && response.HasProviderAgreement)
             {
-                await _client.SubmitVacancyAsync(vacancy.Id, user);
+                var command = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
+
+                await _messaging.SendCommandAsync(command);
                 response.IsSubmitted = true;
             }
             

--- a/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyPreviewOrchestrator.cs
@@ -94,12 +94,15 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             return await ValidateAndExecute(
                 vacancy,
                 v => ValidateVacancy(v, SubmitValidationRules),
-                v => SubmitActionAsync(v, user)
+                v => SubmitActionAsync(m, user)
                 );
         }
 
-        private async Task<SubmitVacancyResponse> SubmitActionAsync(Vacancy vacancy, VacancyUser user)
+        private async Task<SubmitVacancyResponse> SubmitActionAsync(SubmitEditModel submitEditModel, VacancyUser user)
         {
+            //Retrieve vacancy again in case it has changed
+            var vacancy = await Utility.GetAuthorisedVacancyAsync(_client, _vacancyClient, submitEditModel, RouteNames.Preview_Submit_Post);
+
             var hasLegalEntityAgreementTask = _legalEntityAgreementService.HasLegalEntityAgreementAsync(vacancy.EmployerAccountId, vacancy.LegalEntityId);
             var hasProviderAgreementTask = _trainingProviderAgreementService.HasAgreementAsync(vacancy.TrainingProvider.Ukprn.Value);
 

--- a/src/Provider/Provider.Web/Utility.cs
+++ b/src/Provider/Provider.Web/Utility.cs
@@ -44,7 +44,7 @@ namespace Esfa.Recruit.Provider.Web
 
         public static void CheckAuthorisedAccess(Vacancy vacancy, long ukprn)
         {
-            if (vacancy.TrainingProvider.Ukprn.Value != ukprn)
+            if (vacancy.TrainingProvider.Ukprn.Value != ukprn || vacancy.OwnerType != OwnerType.Provider)
                 throw new AuthorisationException(string.Format(ExceptionMessages.VacancyUnauthorisedAccessForProvider, ukprn, vacancy.TrainingProvider.Ukprn, vacancy.Title, vacancy.Id));
         }
 

--- a/src/Provider/Provider.Web/Utility.cs
+++ b/src/Provider/Provider.Web/Utility.cs
@@ -44,8 +44,10 @@ namespace Esfa.Recruit.Provider.Web
 
         public static void CheckAuthorisedAccess(Vacancy vacancy, long ukprn)
         {
-            if (vacancy.TrainingProvider.Ukprn.Value != ukprn || vacancy.OwnerType != OwnerType.Provider)
+            if (vacancy.TrainingProvider.Ukprn.Value != ukprn)
                 throw new AuthorisationException(string.Format(ExceptionMessages.VacancyUnauthorisedAccessForProvider, ukprn, vacancy.TrainingProvider.Ukprn, vacancy.Title, vacancy.Id));
+            if (vacancy.OwnerType != OwnerType.Provider)
+                throw new AuthorisationException(string.Format(ExceptionMessages.UserIsNotTheOwner, OwnerType.Provider));
         }
 
         public static void CheckRouteIsValidForVacancy(Vacancy vacancy, string currentRouteName, VacancyRouteModel vrm)

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/CloneVacancyOrchestratorTestBase.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/CloneVacancyOrchestratorTestBase.cs
@@ -26,7 +26,8 @@ namespace Esfa.Recruit.UnitTests.Provider.Web.Orchestrators.CloneVacancyOrchestr
             TrainingProvider = TrainingProvider,
             Status = VacancyStatus.Live,
             StartDate = SourceStartDate,
-            ClosingDate = SourceClosingDate
+            ClosingDate = SourceClosingDate,
+            OwnerType = OwnerType.Provider
         };
         internal VacancyRouteModel VRM => new VacancyRouteModel
         {

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/GetCloneableAuthorisedVacancyAsyncTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/GetCloneableAuthorisedVacancyAsyncTests.cs
@@ -18,8 +18,7 @@ namespace Esfa.Recruit.UnitTests.Provider.Web.Orchestrators.CloneVacancyOrchestr
 
         [Theory]
         [InlineData(VacancyStatus.Referred)]
-        [InlineData(VacancyStatus.Draft)]
-        public async Task WhenVacancyInInvalidState_ShouldThrowInvalidStateException(VacancyStatus status)
+        [InlineData(VacancyStatus.Draft)]         public async Task WhenVacancyInInvalidState_ShouldThrowInvalidStateException(VacancyStatus status)
         {
             var vacancy = SourceVacancy;
             vacancy.Status = status;

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/GetCloneableAuthorisedVacancyAsyncTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/CloneVacancyOrchestratorTest/GetCloneableAuthorisedVacancyAsyncTests.cs
@@ -18,7 +18,8 @@ namespace Esfa.Recruit.UnitTests.Provider.Web.Orchestrators.CloneVacancyOrchestr
 
         [Theory]
         [InlineData(VacancyStatus.Referred)]
-        [InlineData(VacancyStatus.Draft)]         public async Task WhenVacancyInInvalidState_ShouldThrowInvalidStateException(VacancyStatus status)
+        [InlineData(VacancyStatus.Draft)]
+        public async Task WhenVacancyInInvalidState_ShouldThrowInvalidStateException(VacancyStatus status)
         {
             var vacancy = SourceVacancy;
             vacancy.Status = status;

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/Part1/LegalEntityOrchestratorTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/Part1/LegalEntityOrchestratorTests.cs
@@ -72,7 +72,8 @@ namespace Esfa.Recruit.UnitTests.Provider.Web.Orchestrators.Part1
                 Wage = new Wage
                 {
                     WageType = WageType.NationalMinimumWage
-                }
+                },
+                OwnerType = OwnerType.Provider
             };
         }
     }

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/Part2/SkillOrchestratorTests.cs
@@ -196,7 +196,8 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.Orchestrators.Part2
                     Duration = 1,
                     WageType = WageType.NationalMinimumWage
                 },
-                StartDate = DateTime.Now
+                StartDate = DateTime.Now,
+                OwnerType = OwnerType.Provider
             };
         }
 

--- a/src/Provider/UnitTests/Provider.Web/UtilityTests/GetAuthorisedApplicationReviewAsyncTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/UtilityTests/GetAuthorisedApplicationReviewAsyncTests.cs
@@ -34,7 +34,8 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.UtilityTests
             new Vacancy()
             {
                 Id = _vacancyId,
-                TrainingProvider = new TrainingProvider { Ukprn = _applicationReviewUkprn }
+                TrainingProvider = new TrainingProvider { Ukprn = _applicationReviewUkprn },
+                OwnerType = OwnerType.Provider
             });
         }
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
@@ -18,7 +18,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
         public const string VacancyNotFoundExceptionMessageFormat = "Vacancy {0} not found";
         public const string InvalidStateExceptionMessageFormat = "Unable to submit vacancy {0} due to vacancy having a status of {1}.";
         public const string InvalidOwnerExceptionMessageFormat = "The vacancy {0} owner has changed from {1} to {2} and hence cannot be submitted.";
-        public const string MissingReferenceNumberExceptionMessageFormat = "Cannot submit vacancy {0} without a vacancy reference";
+        public const string MissingReferenceNumberExceptionMessageFormat = "Cannot submit vacancy {0} without a vacancy reference number";
         private readonly ILogger<SubmitVacancyCommandHandler> _logger;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly IMessaging _messaging;
@@ -54,8 +54,8 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
             if(vacancy.CanSubmit == false)
                 throw new InvalidOperationException(string.Format(InvalidStateExceptionMessageFormat, vacancy.Id, vacancy.Status));
 
-            if(vacancy.OwnerType != message.SubmittedFrom)
-                throw new InvalidOperationException(string.Format(InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmittedFrom, vacancy.OwnerType));
+            if(vacancy.OwnerType != message.SubmissionOwner)
+                throw new InvalidOperationException(string.Format(InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmissionOwner, vacancy.OwnerType));
 
             var now = _timeProvider.Now;
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandler.cs
@@ -15,6 +15,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 {
     public class SubmitVacancyCommandHandler : IRequestHandler<SubmitVacancyCommand>
     {
+        public const string VacancyNotFoundExceptionMessageFormat = "Vacancy {0} not found";
+        public const string InvalidStateExceptionMessageFormat = "Unable to submit vacancy {0} due to vacancy having a status of {1}.";
+        public const string InvalidOwnerExceptionMessageFormat = "The vacancy {0} owner has changed from {1} to {2} and hence cannot be submitted.";
+        public const string MissingReferenceNumberExceptionMessageFormat = "Cannot submit vacancy {0} without a vacancy reference";
         private readonly ILogger<SubmitVacancyCommandHandler> _logger;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly IMessaging _messaging;
@@ -41,14 +45,17 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
             var vacancy = await _vacancyRepository.GetVacancyAsync(message.VacancyId);
             
-            if (vacancy == null || vacancy.CanSubmit == false)
-            {
-                _logger.LogWarning($"Unable to submit vacancy {{vacancyId}} due to vacancy having a status of {vacancy?.Status}.", message.VacancyId);
-                return;
-            }
+            if (vacancy == null) 
+                throw new ArgumentException(string.Format(VacancyNotFoundExceptionMessageFormat, message.VacancyId));
 
             if (vacancy.VacancyReference.HasValue == false)
-                throw new Exception("Cannot submit vacancy without a vacancy reference");
+                throw new InvalidOperationException(string.Format(MissingReferenceNumberExceptionMessageFormat, vacancy.Id));
+
+            if(vacancy.CanSubmit == false)
+                throw new InvalidOperationException(string.Format(InvalidStateExceptionMessageFormat, vacancy.Id, vacancy.Status));
+
+            if(vacancy.OwnerType != message.SubmittedFrom)
+                throw new InvalidOperationException(string.Format(InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmittedFrom, vacancy.OwnerType));
 
             var now = _timeProvider.Now;
 

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
@@ -7,24 +7,24 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class SubmitVacancyCommand : ICommand, IRequest
     {
-        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, OwnerType submittedFrom)
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, OwnerType submissionOwner)
         {
             VacancyId = vacancyId;
             User = user;
-            SubmittedFrom = submittedFrom;
+            SubmissionOwner = submissionOwner;
         }
 
-        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, string employerDescription, OwnerType submittedFrom)
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, string employerDescription, OwnerType submissionOwner)
         {
             VacancyId = vacancyId;
             User = user;
             EmployerDescription = employerDescription;
-            SubmittedFrom = submittedFrom;
+            SubmissionOwner = submissionOwner;
         }
 
         public Guid VacancyId { get;}
         public VacancyUser User { get; }
         public string EmployerDescription { get; }
-        public OwnerType SubmittedFrom { get; }
+        public OwnerType SubmissionOwner { get; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Commands/SubmitVacancyCommand.cs
@@ -7,21 +7,24 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Commands
 {
     public class SubmitVacancyCommand : ICommand, IRequest
     {
-        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user)
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, OwnerType submittedFrom)
         {
             VacancyId = vacancyId;
             User = user;
+            SubmittedFrom = submittedFrom;
         }
 
-        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, string employerDescription)
+        public SubmitVacancyCommand(Guid vacancyId, VacancyUser user, string employerDescription, OwnerType submittedFrom)
         {
             VacancyId = vacancyId;
             User = user;
             EmployerDescription = employerDescription;
+            SubmittedFrom = submittedFrom;
         }
 
         public Guid VacancyId { get;}
         public VacancyUser User { get; }
         public string EmployerDescription { get; }
+        public OwnerType SubmittedFrom { get; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Exceptions/ExceptionMessages.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Exceptions/ExceptionMessages.cs
@@ -6,6 +6,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Exceptions
     {
         public const string VacancyUnauthorisedAccess = "The employer account '{0}' cannot access employer account '{1}' for vacancy '{2} ({3})'.";
         public const string VacancyUnauthorisedAccessForProvider = "The provider account '{0}' cannot access provider account '{1}' for vacancy '{2} ({3})'.";
+        public const string UserIsNotTheOwner = "The {0} user is not the owner of the vacancy";
         public const string VacancyWithReferenceNotFound = "Unable to find vacancy with reference: {0}.";
         public const string VacancyWithIdNotFound = "Unable to find vacancy with id: {0}.";
         public const string ApplicationReviewUnauthorisedAccess = "The employer account '{0}' cannot access employer account '{1}' application '{2}' for vacancy '{3}'.";

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IEmployerVacancyClient.cs
@@ -13,7 +13,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
     {
         Task<Guid> CreateVacancyAsync(string title, string employerAccountId, VacancyUser user);
         Task GenerateDashboard(string employerAccountId);
-        Task SubmitVacancyAsync(Guid vacancyId, string employerDescription, VacancyUser user);
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<EmployerDashboard> GetDashboardAsync(string employerAccountId, bool createIfNonExistent = false);
         Task<EditVacancyInfo> GetEditVacancyInfoAsync(string employerAccountId);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IProviderVacancyClient.cs
@@ -16,7 +16,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task SetupProviderAsync(long ukprn);
         Task<ProviderEditVacancyInfo> GetProviderEditVacancyInfoAsync(long ukprn);
         Task<EmployerInfo> GetProviderEmployerVacancyDataAsync(long ukprn, string employerAccountId);
-        Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user);
         Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user);
         Task<Guid> CreateProviderApplicationsReportAsync(long ukprn, DateTime fromDate, DateTime toDate, VacancyUser user, string reportName);
         Task<List<ReportSummary>> GetReportsForProviderAsync(long ukprn);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/ProviderVacancyClient.cs
@@ -64,13 +64,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _messaging.SendCommandAsync(command);
         }
 
-        public Task SubmitVacancyAsync(Guid vacancyId, VacancyUser user)
-        {
-            var command = new SubmitVacancyCommand(vacancyId, user);
-
-            return _messaging.SendCommandAsync(command);
-        }
-
         public async Task<Guid> CreateProviderApplicationsReportAsync(long ukprn, DateTime fromDate, DateTime toDate, VacancyUser user, string reportName)
         {
             var reportId = Guid.NewGuid();

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -167,13 +167,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return Guid.NewGuid();
         }
 
-        public Task SubmitVacancyAsync(Guid vacancyId, string employerDescription, VacancyUser user)
-        {
-            var command = new SubmitVacancyCommand(vacancyId, user, employerDescription);
-
-            return _messaging.SendCommandAsync(command);
-        }
-
         public Task DeleteVacancyAsync(Guid vacancyId, VacancyUser user)
         {
             var command = new DeleteVacancyCommand

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
@@ -151,7 +151,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
             var user = new VacancyUser();
             var now = DateTime.Now;
             var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
-            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmittedFrom, vacancy.OwnerType);
+            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmissionOwner, vacancy.OwnerType);
 
             var sut = GetSut(vacancy.Id, vacancy, now);
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Handle(message, new CancellationToken()));

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
@@ -30,6 +30,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
                 Status = VacancyStatus.Draft,
                 VacancyReference = 1234567890
             };
+            vacancy.OwnerType = OwnerType.Employer;
             var user = new VacancyUser();
             var now = DateTime.Now;
             var message = new SubmitVacancyCommand(vacancy.Id, user, expectedDescription, OwnerType.Employer);
@@ -57,6 +58,7 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
                 Status = VacancyStatus.Draft,
                 VacancyReference = 1234567890
             };
+            vacancy.OwnerType= OwnerType.Provider;
             var user = new VacancyUser();
             var now = DateTime.Now;
             var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);

--- a/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/CommandHandlers/SubmitVacancyCommandHandlerTests.cs
@@ -19,38 +19,123 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
     public class SubmitVacancyCommandHandlerTests
     {
         [Fact]
-        public async Task Handle_ShouldChangeEmployerDescriptionIfSpecifiedInCommand()
+        public async Task GivenEmployerDescription_ThenShouldUpdateVacancyWithThatDescripion()
         {
+            var expectedDescription = "updated description";
             var vacancy = new Vacancy
             {
                 Id = Guid.NewGuid(),
-                EmployerDescription = "initial description",
+                EmployerDescription = "old description",
                 IsDeleted = false,
                 Status = VacancyStatus.Draft,
                 VacancyReference = 1234567890
             };
-
             var user = new VacancyUser();
             var now = DateTime.Now;
+            var message = new SubmitVacancyCommand(vacancy.Id, user, expectedDescription, OwnerType.Employer);
 
-            var handler = GetSubmitVacancyCommandHandler(vacancy, now);
-
-            var message = new SubmitVacancyCommand(vacancy.Id, user, "updated description");
-
-            var cancel = new CancellationToken();
-            await handler.Handle(message, cancel);
+            var sut = GetSut(vacancy.Id, vacancy, now);
+            await sut.Handle(message, new CancellationToken());
 
             vacancy.Status.Should().Be(VacancyStatus.Submitted);
             vacancy.SubmittedDate.Should().Be(now);
             vacancy.SubmittedByUser.Should().Be(user);
             vacancy.LastUpdatedDate.Should().Be(now);
             vacancy.LastUpdatedByUser.Should().Be(user);
-
-            vacancy.EmployerDescription.Should().Be("updated description");
+            vacancy.EmployerDescription.Should().Be(expectedDescription);
         }
 
         [Fact]
-        public async Task Handle_ShouldNotChangeEmployerDescriptionIfNotSpecifiedInCommand()
+        public async Task ShouldNotChangeEmployerDescriptionIfNotSpecifiedInCommand()
+        {
+            var expectedDescription = "initial description";
+            var vacancy = new Vacancy
+            {
+                Id = Guid.NewGuid(),
+                EmployerDescription = expectedDescription,
+                IsDeleted = false,
+                Status = VacancyStatus.Draft,
+                VacancyReference = 1234567890
+            };
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+            var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
+
+            var sut = GetSut(vacancy.Id, vacancy, now);
+            await sut.Handle(message, new CancellationToken());
+
+            vacancy.Status.Should().Be(VacancyStatus.Submitted);
+            vacancy.SubmittedDate.Should().Be(now);
+            vacancy.SubmittedByUser.Should().Be(user);
+            vacancy.LastUpdatedDate.Should().Be(now);
+            vacancy.LastUpdatedByUser.Should().Be(user);
+            vacancy.EmployerDescription.Should().Be(expectedDescription);
+        }
+
+        [Fact]
+        public async Task WhenVacancyNotFound_ShouldRaiseException()
+        {
+            var id = Guid.NewGuid();
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.VacancyNotFoundExceptionMessageFormat, id);
+            var message = new SubmitVacancyCommand(id, user, OwnerType.Provider);
+
+            var sut = GetSut(id, null, now);
+            var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await sut.Handle(message, new CancellationToken()));
+
+            exception.Message.Should().Be(expectedExceptionMessage);
+        }
+
+        [Fact]
+        public async Task WhenStatusIsIncorrect_ShouldRaiseException()
+        {
+            var vacancy = new Vacancy
+            {
+                Id = Guid.NewGuid(),
+                EmployerDescription = "initial description",
+                IsDeleted = false,
+                Status = VacancyStatus.Live,
+                VacancyReference = 1234567890
+            };
+            vacancy.OwnerType = OwnerType.Employer;
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+            var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
+            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.InvalidStateExceptionMessageFormat, vacancy.Id, vacancy.Status);
+
+            var sut = GetSut(vacancy.Id, vacancy, now);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Handle(message, new CancellationToken()));
+
+            exception.Message.Should().Be(expectedExceptionMessage);
+        }
+
+        [Fact]
+        public async Task WhenReferenceNumberIsNotGenerated_ShouldRaiseException()
+        {
+            var vacancy = new Vacancy
+            {
+                Id = Guid.NewGuid(),
+                EmployerDescription = "initial description",
+                IsDeleted = false,
+                Status = VacancyStatus.Live,
+                VacancyReference = null
+            };
+            vacancy.OwnerType = OwnerType.Employer;
+            var user = new VacancyUser();
+            var now = DateTime.Now;
+            var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
+            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.MissingReferenceNumberExceptionMessageFormat, vacancy.Id);
+
+            var sut = GetSut(vacancy.Id, vacancy, now);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Handle(message, new CancellationToken()));
+
+            exception.Message.Should().Be(expectedExceptionMessage);
+        }
+
+
+        [Fact]
+        public async Task WhenOwnerHasChanged_ShouldRaiseException()
         {
             var vacancy = new Vacancy
             {
@@ -60,32 +145,24 @@ namespace Esfa.Recruit.UnitTests.Vacancies.Client.Application.CommandHandlers
                 Status = VacancyStatus.Draft,
                 VacancyReference = 1234567890
             };
-
+            vacancy.OwnerType = OwnerType.Employer;
             var user = new VacancyUser();
             var now = DateTime.Now;
+            var message = new SubmitVacancyCommand(vacancy.Id, user, OwnerType.Provider);
+            var expectedExceptionMessage = string.Format(SubmitVacancyCommandHandler.InvalidOwnerExceptionMessageFormat, vacancy.Id, message.SubmittedFrom, vacancy.OwnerType);
 
-            var handler = GetSubmitVacancyCommandHandler(vacancy, now);
+            var sut = GetSut(vacancy.Id, vacancy, now);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await sut.Handle(message, new CancellationToken()));
 
-            var message = new SubmitVacancyCommand(vacancy.Id, user);
-
-            var cancel = new CancellationToken();
-            await handler.Handle(message, cancel);
-
-            vacancy.Status.Should().Be(VacancyStatus.Submitted);
-            vacancy.SubmittedDate.Should().Be(now);
-            vacancy.SubmittedByUser.Should().Be(user);
-            vacancy.LastUpdatedDate.Should().Be(now);
-            vacancy.LastUpdatedByUser.Should().Be(user);
-
-            vacancy.EmployerDescription.Should().Be("initial description");
+            exception.Message.Should().Be(expectedExceptionMessage);
         }
 
-        public SubmitVacancyCommandHandler GetSubmitVacancyCommandHandler(Vacancy vacancy, DateTime now)
+        public SubmitVacancyCommandHandler GetSut(Guid id, Vacancy vacancy, DateTime now)
         {
             var mockLogger = new Mock<ILogger<SubmitVacancyCommandHandler>>();
 
             var mockRepository = new Mock<IVacancyRepository>();
-            mockRepository.Setup(r => r.GetVacancyAsync(vacancy.Id)).ReturnsAsync(vacancy);
+            mockRepository.Setup(r => r.GetVacancyAsync(id)).ReturnsAsync(vacancy);
 
             var mockMessaging = new Mock<IMessaging>();
 


### PR DESCRIPTION
I have added check on ownership in the authorization, this should prevent provider from accessing vacancies that have been transferred. 

A related edge case is where a provider submits the vacancy and at the same time the employer revokes the permissions, the vacancy manages to pass through validation and gets submitted. 

To stop this, I have changed command to include the requesting owner and comparing that in the handler with what is on the vacancy. The command will fail in case the owner has changed. 