### PR TITLE
CON-1085 Fix connection issues

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Ioc/ServiceCollectionExtensions.cs
@@ -96,7 +96,7 @@ namespace Esfa.Recruit.Vacancies.Client.Ioc
         private static void RegisterAccountApiClientDeps(IServiceCollection services)
         {
             services.AddSingleton<IAccountApiConfiguration>(kernal => kernal.GetService<IOptions<AccountApiConfiguration>>().Value);
-            services.AddTransient<IAccountApiClient, AccountApiClient>();
+            services.AddSingleton<IAccountApiClient, AccountApiClient>();
         }
 
         private static void RegisterServiceDeps(IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
Cause: 
To update the `AccountLegalEntityPublicHashedId` on all the existing vacancies, I was queuing each vacancy individually to be processed by a job that will fetch the Id from EAS API and update the vacancy.  The job uses the API client which was registered in the IOC as a transient. Which meant that each instance of the job was injected with new client instance in turn creating a new connection. 

Effect:
This resulted in error `Only one usage of each socket address (protocol/network address/port) is normally permitted` for some vacancies and messages ended in the poison queue. 

Resolution:
Changing the IOC registration of the EAS API client to be a singleton to use only one outbound connection. There are chances that this can backfire, only testing will tell. 