### PR TITLE
CON-2685 Since removing the LegalEntityId from the code, we didn't re…

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventsHandler.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventsHandler.cs
@@ -74,6 +74,7 @@ namespace Esfa.Recruit.Vacancies.Jobs.ExternalSystemEventHandlers
                 {
                     Ukprn = message.Ukprn,
                     EmployerAccountId = employerAccountId,
+                    AccountLegalEntityPublicHashedId = legalEntity.AccountLegalEntityPublicHashedId,
                     UserRef = message.UserRef.Value,
                     UserEmailAddress = message.UserEmailAddress,
                     UserName = $"{message.UserFirstName} {message.UserLastName}",


### PR DESCRIPTION
…place the property on the message with the accountLegalEntityId.