### PR TITLE
FAI-552 - Update UpdatedPermissionEventHandler

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/ExternalSystemEventHandlers/UpdatedPermissionsExternalSystemEventHandlerTests.cs
@@ -30,32 +30,30 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
         private const string UserLastName = "Smith";
         private const long EmployerAccountId = 12345;
         private const string EmployerAccountIdEncoded = "ABC123";
+        private const string EmployerAccountLegalEntityIdPublicEncoded = "ZXY987";
         private const long AccountLegalEntityId = 1231;
         private const long AccountProviderId = 321;
         private const long AccountProviderLegalEntityId = 1223;
         private const long Ukprn = 11111111;
-        private const long RecruitLegalEntityId = 5678;
-        private const int NoOfDummyLegalEntitiesToCreate = 10;
         private readonly Fixture _autoFixture = new Fixture();
-        private readonly IEnumerable<AccountLegalEntity> _dummyLegalEntities;
         private readonly RecruitWebJobsSystemConfiguration _jobsConfig;
         private readonly Mock<IRecruitQueueService> _mockRecruitQueueService;
-        private readonly Mock<IEmployerAccountProvider> _mockEmployerAccountProvider;
         private readonly Mock<IEncodingService> _mockEncoder;
         private readonly Mock<IMessaging> _mockMessaging;
         private readonly UpdatedPermissionsExternalSystemEventsHandler _sut;
 
         public UpdatedPermissionsExternalSystemEventHandlerTests()
         {
-            _dummyLegalEntities = _autoFixture.CreateMany<AccountLegalEntity>(NoOfDummyLegalEntitiesToCreate);
             _jobsConfig = new RecruitWebJobsSystemConfiguration { DisabledJobs = new List<string>() };
             _mockRecruitQueueService = new Mock<IRecruitQueueService>();
-            _mockEmployerAccountProvider = new Mock<IEmployerAccountProvider>();
             _mockEncoder = new Mock<IEncodingService>();
             _mockMessaging = new Mock<IMessaging>();
 
+            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
+            _mockEncoder.Setup(x => x.Encode(AccountLegalEntityId, EncodingType.PublicAccountLegalEntityId)).Returns(EmployerAccountLegalEntityIdPublicEncoded);
+            
             _sut = new UpdatedPermissionsExternalSystemEventsHandler(Mock.Of<ILogger<UpdatedPermissionsExternalSystemEventsHandler>>(), _jobsConfig,
-                                                        _mockRecruitQueueService.Object, _mockEmployerAccountProvider.Object,
+                                                        _mockRecruitQueueService.Object, 
                                                         _mockEncoder.Object, _mockMessaging.Object);
         }
 
@@ -68,7 +66,6 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
 
             _mockRecruitQueueService.VerifyNoOtherCalls();
             _mockMessaging.VerifyNoOtherCalls();
-            _mockEmployerAccountProvider.VerifyNoOtherCalls();
             _mockEncoder.VerifyNoOtherCalls();
         }
 
@@ -81,8 +78,6 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
             await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.Empty, string.Empty, string.Empty, string.Empty, grantedOperations, previousOperations, DateTime.UtcNow), null);
 
             _mockRecruitQueueService.VerifyNoOtherCalls();
-            _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
             _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
         }
 
@@ -95,8 +90,6 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
             await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, previousOperations, DateTime.UtcNow), null);
 
             _mockRecruitQueueService.VerifyNoOtherCalls();
-            _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
             _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
         }
 
@@ -109,91 +102,15 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
             await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, previousOperations, DateTime.UtcNow), null);
 
             _mockRecruitQueueService.VerifyNoOtherCalls();
-            _mockEmployerAccountProvider.VerifyNoOtherCalls();
-            _mockEncoder.VerifyNoOtherCalls();
-            _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GivenNotExistingLegalEntityId_ThenExceptionIsThrown()
-        {
-            var grantedOperations = new HashSet<Operation> { Operation.CreateCohort };
-            var previousOperations = new HashSet<Operation>();
-
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
-            _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
-                                        .ReturnsAsync(_dummyLegalEntities);
-
-            var exception = await Assert.ThrowsAsync<Exception>(() => _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, previousOperations, DateTime.UtcNow), null));
-
-            exception.Message.Should().Be($"Could not find matching Account Legal Entity Id {AccountLegalEntityId} for Employer Account {EmployerAccountId}");
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
-            _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
-        }
-
-        [Fact]
-        public async Task GivenMatchingExistingLegalEntityId_ThenVerifyTransferProcessIsQueued()
-        {
-            var matchingLegalEntityViewModel = _autoFixture.Build<AccountLegalEntity>()
-                                                            .With(l => l.DasAccountId, EmployerAccountIdEncoded)
-                                                            .With(l => l.AccountLegalEntityId, AccountLegalEntityId)
-                                                            .With(l => l.LegalEntityId, RecruitLegalEntityId)
-                                                            .Create();
-
-            var grantedOperations = new HashSet<Operation> { Operation.CreateCohort };
-            var previousOperations = new HashSet<Operation>();
-
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
-            _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
-                                        .ReturnsAsync(_dummyLegalEntities.Append(matchingLegalEntityViewModel));
-
-            await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, previousOperations, DateTime.UtcNow), null);
-
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
-            _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
-            _mockRecruitQueueService.Verify(x => x.AddMessageAsync(It.IsAny<TransferVacanciesFromProviderQueueMessage>()), Times.Once);
-            _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
-        }
-
-        [Fact]
-        public async Task GivenMatchingExistingLegalEntityId_ThenVerifyTransferReviewProcessIsQueued()
-        {
-            var matchingLegalEntityViewModel = _autoFixture.Build<AccountLegalEntity>()
-                .With(l => l.DasAccountId, EmployerAccountIdEncoded)
-                .With(l => l.AccountLegalEntityId, AccountLegalEntityId)
-                .With(l => l.LegalEntityId, RecruitLegalEntityId)
-                .Create();
-
-            var grantedOperations = new HashSet<Operation> { Operation.Recruitment, Operation.CreateCohort };
-            var previousOperations = new HashSet<Operation>();
-
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
-            _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
-                .ReturnsAsync(_dummyLegalEntities.Append(matchingLegalEntityViewModel));
-
-            await _sut.Handle(new UpdatedPermissionsEvent(EmployerAccountId, AccountLegalEntityId, AccountProviderId, AccountProviderLegalEntityId, Ukprn, Guid.NewGuid(), UserEmailAddress, UserFirstName, UserLastName, grantedOperations, previousOperations, DateTime.UtcNow), null);
-
-            _mockEncoder.Verify(x => x.Encode(EmployerAccountId, EncodingType.AccountId), Times.Once);
-            _mockEmployerAccountProvider.Verify(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded), Times.Once);
-            _mockRecruitQueueService.Verify(x => x.AddMessageAsync(It.IsAny<TransferVacanciesFromEmployerReviewToQAReviewQueueMessage>()), Times.Once);
             _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
         }
 
         [Fact]
         public async Task GivenMatchingExistingLegalEntityId_ThenTransferQueuedMessageIsMappedCorrectly()
         {
-            var matchingLegalEntityViewModel = _autoFixture.Build<AccountLegalEntity>()
-                                                            .With(l => l.DasAccountId, EmployerAccountIdEncoded)
-                                                            .With(l => l.AccountLegalEntityId, AccountLegalEntityId)
-                                                            .With(l => l.LegalEntityId, RecruitLegalEntityId)
-                                                            .Create();
-
             var grantedOperations = new HashSet<Operation> { Operation.CreateCohort };
             var previousOperations = new HashSet<Operation>();
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
-            _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
-                                        .ReturnsAsync(_dummyLegalEntities.Append(matchingLegalEntityViewModel));
-
+            
             var userRef = Guid.NewGuid();
 
             TransferVacanciesFromProviderQueueMessage queuedMessage = null;
@@ -207,28 +124,20 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
             Assert.NotNull(queuedMessage);
             Assert.Equal(Ukprn, queuedMessage.Ukprn);
             Assert.Equal(EmployerAccountIdEncoded, queuedMessage.EmployerAccountId);
-            Assert.Equal(matchingLegalEntityViewModel.AccountLegalEntityPublicHashedId, queuedMessage.AccountLegalEntityPublicHashedId);
+            Assert.Equal(EmployerAccountLegalEntityIdPublicEncoded, queuedMessage.AccountLegalEntityPublicHashedId);
             Assert.Equal(userRef, queuedMessage.UserRef);
             Assert.Equal(UserEmailAddress, queuedMessage.UserEmailAddress);
             Assert.Equal($"{UserFirstName} {UserLastName}", queuedMessage.UserName);
             Assert.Equal(TransferReason.EmployerRevokedPermission, queuedMessage.TransferReason);
+            _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
         }
 
         [Fact]
         public async Task GivenMatchingExistingLegalEntityId_ThenReviewQueuedMessageIsMappedCorrectly()
         {
-            var matchingLegalEntityViewModel = _autoFixture.Build<AccountLegalEntity>()
-                                                            .With(l => l.DasAccountId, EmployerAccountIdEncoded)
-                                                            .With(l => l.AccountLegalEntityId, AccountLegalEntityId)
-                                                            .With(l => l.LegalEntityId, RecruitLegalEntityId)
-                                                            .Create();
-
             var grantedOperations = new HashSet<Operation> { Operation.Recruitment, Operation.CreateCohort };
             var previousOperations = new HashSet<Operation>();
-            _mockEncoder.Setup(x => x.Encode(EmployerAccountId, EncodingType.AccountId)).Returns(EmployerAccountIdEncoded);
-            _mockEmployerAccountProvider.Setup(x => x.GetLegalEntitiesConnectedToAccountAsync(EmployerAccountIdEncoded))
-                                        .ReturnsAsync(_dummyLegalEntities.Append(matchingLegalEntityViewModel));
-
+            
             var userRef = Guid.NewGuid();
 
             TransferVacanciesFromEmployerReviewToQAReviewQueueMessage queuedMessage = null;
@@ -241,10 +150,11 @@ namespace Recruit.Vacancies.Jobs.UnitTests.ExternalSystemEventHandlers
 
             Assert.NotNull(queuedMessage);
             Assert.Equal(Ukprn, queuedMessage.Ukprn);
-            Assert.Equal(matchingLegalEntityViewModel.AccountLegalEntityPublicHashedId, queuedMessage.AccountLegalEntityPublicHashedId);
+            Assert.Equal(EmployerAccountLegalEntityIdPublicEncoded, queuedMessage.AccountLegalEntityPublicHashedId);
             Assert.Equal(userRef, queuedMessage.UserRef);
             Assert.Equal(UserEmailAddress, queuedMessage.UserEmailAddress);
             Assert.Equal($"{UserFirstName} {UserLastName}", queuedMessage.UserName);
+            _mockMessaging.Verify(x => x.SendCommandAsync(It.Is<SetupProviderCommand>(c => c.Ukprn == Ukprn)), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Updated the handler to no longer call the accounts database to get the public encoded account legal entity id. Instead just gets it from encoding the known internal id. This is to stop the issue of the dashboard not being created when the ALE has been deleted and provider permissions updated