### PR TITLE
FAI-556 application missing from vacancy

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -74,19 +74,19 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
             if (vacancy.LiveDate >= _systemConfig.ShowAnalyticsForVacanciesApprovedAfterDate)
             {
-                var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
+                var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
                 var vacancyAnalyticsTask = _client.GetVacancyAnalyticsSummaryAsync(vacancy.VacancyReference.Value);
 
                 await Task.WhenAll(vacancyApplicationsTask, vacancyAnalyticsTask);
 
-                applications = vacancyApplicationsTask.Result?.Applications ?? new List<VacancyApplication>();
+                applications = vacancyApplicationsTask.Result ?? new List<VacancyApplication>();
                 var analyticsSummary = vacancyAnalyticsTask.Result ?? new VacancyAnalyticsSummary();
                 viewModel.AnalyticsSummary = VacancyAnalyticsSummaryMapper.MapToVacancyAnalyticsSummaryViewModel(analyticsSummary, vacancy.LiveDate.GetValueOrDefault());
             }
             else
             {
-                var vacancyApplications = await _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
-                applications = vacancyApplications?.Applications ?? new List<VacancyApplication>();
+                var vacancyApplications = await _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
+                applications = vacancyApplications ?? new List<VacancyApplication>();
             }
 
             viewModel.Applications = new VacancyApplicationsViewModel

--- a/src/Employer/Employer.Web/Orchestrators/VacancyViewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyViewOrchestrator.cs
@@ -146,11 +146,11 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
         private void PopulateViewModelWithApplications(Vacancy vacancy, DisplayVacancyApplicationViewModel viewModel)
         {
             var mappedDisplayVacancyViewModelTask = _vacancyDisplayMapper.MapFromVacancyAsync(viewModel, vacancy);
-            var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
+            var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
 
             Task.WaitAll(mappedDisplayVacancyViewModelTask, vacancyApplicationsTask);
 
-            var applications = vacancyApplicationsTask.Result?.Applications ?? new List<VacancyApplication>();
+            var applications = vacancyApplicationsTask.Result ?? new List<VacancyApplication>();
 
             viewModel.Applications = new VacancyApplicationsViewModel
             {

--- a/src/Provider/Provider.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -82,19 +82,19 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
             if (vacancy.LiveDate >= _systemConfig.ShowAnalyticsForVacanciesApprovedAfterDate)
             {
-                var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
+                var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
                 var vacancyAnalyticsTask = _client.GetVacancyAnalyticsSummaryAsync(vacancy.VacancyReference.Value);
 
                 await Task.WhenAll(vacancyApplicationsTask, vacancyAnalyticsTask);
 
-                applications = vacancyApplicationsTask.Result?.Applications ?? new List<VacancyApplication>();
+                applications = vacancyApplicationsTask.Result ?? new List<VacancyApplication>();
                 var analyticsSummary = vacancyAnalyticsTask.Result ?? new VacancyAnalyticsSummary();
                 viewModel.AnalyticsSummary = VacancyAnalyticsSummaryMapper.MapToVacancyAnalyticsSummaryViewModel(analyticsSummary, vacancy.LiveDate.GetValueOrDefault());
             }
             else
             {
-                var vacancyApplications = await _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
-                applications = vacancyApplications?.Applications ?? new List<VacancyApplication>();
+                var vacancyApplications = await _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
+                applications = vacancyApplications ?? new List<VacancyApplication>();
             }
 
             viewModel.Applications = new VacancyApplicationsViewModel

--- a/src/Provider/Provider.Web/Orchestrators/VacancyViewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyViewOrchestrator.cs
@@ -158,11 +158,11 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
         private void PopulateViewModelWithApplications(Vacancy vacancy, DisplayVacancyApplicationViewModel viewModel)
         {
             var mappedDisplayVacancyViewModelTask = _vacancyDisplayMapper.MapFromVacancyAsync(viewModel, vacancy);
-            var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value.ToString());
+            var vacancyApplicationsTask = _client.GetVacancyApplicationsAsync(vacancy.VacancyReference.Value);
 
             Task.WaitAll(mappedDisplayVacancyViewModelTask, vacancyApplicationsTask);
 
-            var applications = vacancyApplicationsTask.Result?.Applications ?? new List<VacancyApplication>();
+            var applications = vacancyApplicationsTask.Result ?? new List<VacancyApplication>();
 
             viewModel.Applications = new VacancyApplicationsViewModel
             {

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IApplicationReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Repositories/IApplicationReviewRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
@@ -11,5 +12,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Repositories
         Task<ApplicationReview> GetAsync(long vacancyReference, Guid candidateId);
         Task UpdateAsync(ApplicationReview applicationReview);
         Task HardDelete(Guid applicationReviewId);
+        Task<List<T>> GetForVacancyAsync<T>(long vacancyReference);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
@@ -22,7 +22,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task<IEnumerable<IApprenticeshipProgramme>> GetActiveApprenticeshipProgrammesAsync();
         Task<IApprenticeshipProgramme> GetApprenticeshipProgrammeAsync(string programmeId);
-        Task<VacancyApplications> GetVacancyApplicationsAsync(string vacancyReference);
+        Task<List<VacancyApplication>> GetVacancyApplicationsAsync(long vacancyReference);
         Task UpdatePublishedVacancyAsync(Vacancy vacancy, VacancyUser user, LiveUpdateKind updateKind);
         Task<Guid> CloneVacancyAsync(Guid vacancyId, VacancyUser user, SourceOrigin sourceOrigin, DateTime startDate, DateTime closingDate);
         Task<string> GetEmployerNameAsync(Vacancy vacancy);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -306,9 +306,14 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             return _applicationReviewRepository.GetAsync(applicationReviewId);
         }
 
-        public Task<VacancyApplications> GetVacancyApplicationsAsync(string vacancyReference)
+        public async Task<List<VacancyApplication>> GetVacancyApplicationsAsync(long vacancyReference)
         {
-            return _reader.GetVacancyApplicationsAsync(vacancyReference);
+            var applicationReviews =
+                await _applicationReviewRepository.GetForVacancyAsync<ApplicationReview>(vacancyReference);
+
+            return applicationReviews == null 
+                ? new List<VacancyApplication>() 
+                : applicationReviews.Select(c=>(VacancyApplication)c).ToList();
         }
 
         public Task SetApplicationReviewSuccessful(Guid applicationReviewId, VacancyUser user)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/VacancyApplications/VacancyApplication.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/Projections/VacancyApplications/VacancyApplication.cs
@@ -33,5 +33,27 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Va
         public ApplicationReviewDisabilityStatus DisabilityStatus { get; set; }
         public bool IsWithdrawn { get; set; }
         public bool IsNotWithdrawn => !IsWithdrawn;
+        
+        public static implicit operator VacancyApplication(ApplicationReview applicationReview)
+        {
+            var projection = new VacancyApplication
+            {
+                CandidateId = applicationReview.CandidateId,
+                Status = applicationReview.Status,
+                SubmittedDate = applicationReview.SubmittedDate,
+                ApplicationReviewId = applicationReview.Id,
+                IsWithdrawn = applicationReview.IsWithdrawn,
+                DisabilityStatus = ApplicationReviewDisabilityStatus.Unknown
+            };
+
+            if (applicationReview.IsWithdrawn == false)
+            {
+                projection.FirstName = applicationReview.Application.FirstName;
+                projection.LastName = applicationReview.Application.LastName;
+                projection.DateOfBirth = applicationReview.Application.BirthDate;
+                projection.DisabilityStatus = applicationReview.Application.DisabilityStatus ?? ApplicationReviewDisabilityStatus.Unknown;
+            }
+            return projection;
+        }
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/QueryStore/WhenConvertingFromApplicationReviewToVacancyApplication.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/QueryStore/WhenConvertingFromApplicationReviewToVacancyApplication.cs
@@ -1,0 +1,53 @@
+using AutoFixture.NUnit3;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructure.QueryStore
+{
+    public class WhenConvertingFromApplicationReviewToVacancyApplication
+    {
+        [Test, AutoData]
+        public void Then_The_Fields_Are_Mapped(ApplicationReview source)
+        {
+            //Arrange
+            source.IsWithdrawn = false;
+            
+            //Act
+            var actual = (VacancyApplication) source;
+
+            //Assert
+            actual.CandidateId.Should().Be(source.CandidateId);
+            actual.Status.Should().Be(source.Status);
+            actual.SubmittedDate.Should().Be(source.SubmittedDate);
+            actual.ApplicationReviewId.Should().Be(source.Id);
+            actual.IsWithdrawn.Should().Be(source.IsWithdrawn);
+            actual.FirstName.Should().Be(source.Application.FirstName);
+            actual.LastName.Should().Be(source.Application.LastName);
+            actual.DateOfBirth.Should().Be(source.Application.BirthDate);
+            actual.DisabilityStatus.Should().Be(actual.DisabilityStatus);
+        }
+
+        [Test, AutoData]
+        public void Then_If_Withdrawn_Then_Name_And_Dob_Not_Populated(ApplicationReview source)
+        {
+            //Arrange
+            source.IsWithdrawn = true;
+            
+            //Act
+            var actual = (VacancyApplication) source;
+            
+            //Assert
+            actual.CandidateId.Should().Be(source.CandidateId);
+            actual.Status.Should().Be(source.Status);
+            actual.SubmittedDate.Should().Be(source.SubmittedDate);
+            actual.ApplicationReviewId.Should().Be(source.Id);
+            actual.IsWithdrawn.Should().Be(source.IsWithdrawn);
+            actual.FirstName.Should().BeNullOrEmpty();
+            actual.LastName.Should().BeNullOrEmpty();
+            actual.DateOfBirth.Should().BeNull();
+            actual.DisabilityStatus.Should().Be(ApplicationReviewDisabilityStatus.Unknown);
+        }
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/VacancyClientGetVacancyApplications.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/VacancyClientGetVacancyApplications.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructure.Services
+{
+    public class VacancyClientGetVacancyApplications
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Service_Is_Called_And_VacancyApplications_Returned(
+            long vacancyReference,
+            List<ApplicationReview> applicationReviews,
+            [Frozen] Mock<IApplicationReviewRepository> applicationReviewRepository,
+            VacancyClient vacancyClient)
+        {
+            //Arrange
+            applicationReviewRepository.Setup(x => x.GetForVacancyAsync<ApplicationReview>(vacancyReference))
+                .ReturnsAsync(applicationReviews);
+            
+            //Act
+            var actual = await vacancyClient.GetVacancyApplicationsAsync(vacancyReference);
+            
+            //Assert
+            actual.Should().BeEquivalentTo(applicationReviews.Select(c=>(VacancyApplication)c).ToList());
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Returns_Empty_List_If_No_Results(
+            long vacancyReference,
+            [Frozen] Mock<IApplicationReviewRepository> applicationReviewRepository,
+            VacancyClient vacancyClient)
+        {
+            //Arrange
+            applicationReviewRepository.Setup(x => x.GetForVacancyAsync<ApplicationReview>(vacancyReference))
+                .ReturnsAsync(new List<ApplicationReview>());
+            
+            //Act
+            var actual = await vacancyClient.GetVacancyApplicationsAsync(vacancyReference);
+            
+            //Assert
+            actual.Should().BeEmpty();
+        }
+        
+        [Test, MoqAutoData]
+        public async Task Then_Returns_Empty_List_If_Null(
+            long vacancyReference,
+            [Frozen] Mock<IApplicationReviewRepository> applicationReviewRepository,
+            VacancyClient vacancyClient)
+        {
+            //Arrange
+            applicationReviewRepository.Setup(x => x.GetForVacancyAsync<ApplicationReview>(vacancyReference))
+                .ReturnsAsync((List<ApplicationReview>) null);
+            
+            //Act
+            var actual = await vacancyClient.GetVacancyApplicationsAsync(vacancyReference);
+            
+            //Assert
+            actual.Should().BeEmpty();
+        }
+    }
+}


### PR DESCRIPTION
This removes the need for the QueryStore view that shows the applications. The logic for creating and maintaining has been maintained in the code base should it need to be changed back due to performance issues.