### PR TITLE
FAI-621 - Fix issue with duration mapping in API

### DIFF
--- a/src/API/Recruit.Api.UnitTests/Mappers/VacancyMapperTests.cs
+++ b/src/API/Recruit.Api.UnitTests/Mappers/VacancyMapperTests.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Mappers
         public void Then_The_Request_Is_Mapped_To_The_Vacancy(CreateVacancyRequest request, Guid id)
         {
             request.Wage.WageType = WageType.NationalMinimumWageForApprentices;
-            request.Wage.DurationUnit = DurationUnit.Year;
+            request.Wage.DurationUnit = DurationUnit.Month;
             request.ApplicationMethod = CreateVacancyApplicationMethod.ThroughExternalApplicationSite;
             
             var actual = request.MapFromCreateVacancyRequest(id);
@@ -24,9 +24,12 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Mappers
             actual.Should().BeEquivalentTo(request, options => options
                 .Excluding(c => c.User)
                 .Excluding(c => c.Address)
+                .Excluding(c=>c.Wage.DurationUnit)
             );
             actual.EmployerLocation.Should().BeEquivalentTo(request.Address);
             actual.CreatedByUser.Should().BeEquivalentTo(request.User);
+            actual.Wage.DurationUnit.Should().Be(Esfa.Recruit.Vacancies.Client.Domain.Entities.DurationUnit.Month);
+
         }
     }
 }

--- a/src/API/Recruit.Api/Mappers/VacancyMapper.cs
+++ b/src/API/Recruit.Api/Mappers/VacancyMapper.cs
@@ -48,7 +48,7 @@ namespace SFA.DAS.Recruit.Api.Mappers
                     WorkingWeekDescription = request.Wage.WorkingWeekDescription,
                     WeeklyHours = request.Wage.WeeklyHours,
                     Duration = request.Wage.Duration,
-                    DurationUnit = (DurationUnit?) request.Wage.DurationUnit,
+                    DurationUnit = Enum.Parse<DurationUnit>(request.Wage.DurationUnit.ToString(), true),
                     WageAdditionalInformation = request.Wage.WageAdditionalInformation,
                     FixedWageYearlyAmount = request.Wage.FixedWageYearlyAmount
                 },


### PR DESCRIPTION
Fix an issue where the duration was not correctly mapping from the value provided in the API to the value that is stored on the vacancy