### PR TITLE
FAI-635 qa reports

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/DashboardOrchestrator.cs
@@ -3,33 +3,27 @@ using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels.Dashboard;
-using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Models;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators
 {
     public class DashboardOrchestrator
     {
-        private const int ClosingSoonDays = 5;
         private readonly IEmployerVacancyClient _vacancyClient;
-        private readonly ITimeProvider _timeProvider;
         private readonly IRecruitVacancyClient _client;
         private readonly IEmployerAlertsViewModelFactory _alertsViewModelFactory;
         private readonly IProviderRelationshipsService _providerRelationshipsService;
 
         public DashboardOrchestrator(
             IEmployerVacancyClient vacancyClient,
-            ITimeProvider timeProvider,
             IRecruitVacancyClient client,
             IEmployerAlertsViewModelFactory alertsViewModelFactory,
             IProviderRelationshipsService providerRelationshipsService)
         {
             _vacancyClient = vacancyClient;
-            _timeProvider = timeProvider;
             _client = client;
             _alertsViewModelFactory = alertsViewModelFactory;
             _providerRelationshipsService = providerRelationshipsService;

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/Dashboard/GetDashboardViewModelAsyncTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/Dashboard/GetDashboardViewModelAsyncTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Orchestrators;
 using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels;
-using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Models;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.EditVacancyInfo;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Employer;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 using FluentAssertions;
@@ -23,7 +19,6 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Dashboard
         private const string EmployerAccountId = "XXXXXX";
         private const string UserId = "user id";
 
-        private readonly DateTime _today = DateTime.Parse("2019-09-18");
         private readonly VacancyUser _user = new VacancyUser { UserId = UserId };
 
         [Fact]
@@ -64,9 +59,6 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Dashboard
 
         private DashboardOrchestrator GetSut(EmployerDashboardSummary dashboardSummary)
         {
-            var timeProviderMock = new Mock<ITimeProvider>();
-            timeProviderMock.Setup(t => t.Today).Returns(_today);
-
             var vacancyClientMock = new Mock<IEmployerVacancyClient>();
             vacancyClientMock.Setup(c => c.GetDashboardSummary(EmployerAccountId))
                 .ReturnsAsync(dashboardSummary);
@@ -86,7 +78,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators.Dashboard
             alertsFactoryMock.Setup(a => a.Create(EmployerAccountId, userDetails))
                 .ReturnsAsync(alertsViewModel);
 
-            var dashboardOrchestrator = new DashboardOrchestrator(vacancyClientMock.Object, timeProviderMock.Object, clientMock.Object, alertsFactoryMock.Object, permissionServiceMock.Object);
+            var dashboardOrchestrator = new DashboardOrchestrator(vacancyClientMock.Object, clientMock.Object, alertsFactoryMock.Object, permissionServiceMock.Object);
 
             return dashboardOrchestrator;
         }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Services/Reports/IReportService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Services/Reports/IReportService.cs
@@ -8,6 +8,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Services.Reports
     public interface IReportService
     {
         Task GenerateReportAsync(Guid reportId);
-        void WriteReportAsCsv(Stream stream, Report report);
+        Task WriteReportAsCsv(Stream stream, Report report);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Report.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Entities/Report.cs
@@ -33,5 +33,6 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Entities
         public int DownloadCount { get; set; }
         public string Data { get; set; }
         public IEnumerable<KeyValuePair<string, string>> Headers { get; set; }
+        public string Query { get; set; }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/IReportStrategy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/IReportStrategy.cs
@@ -7,5 +7,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
     {
         Task<ReportStrategyResult> GetReportDataAsync(Dictionary<string, object> parameters);
         ReportDataType ResolveFormat(string fieldName);
+
+        Task<string> GetApplicationReviewsRecursiveAsync(string queryJson);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ProviderApplicationsReportStrategy.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ProviderApplicationsReportStrategy.cs
@@ -103,6 +103,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
             }
         }
 
+        public Task<string> GetApplicationReviewsRecursiveAsync(string queryJson)
+        {
+            throw new NotImplementedException();
+        }
+
         private async Task<ReportStrategyResult> GetProviderApplicationsAsync(long ukprn, DateTime fromDate, DateTime toDate)
         {
             var collection = GetCollection<BsonDocument>();
@@ -130,7 +135,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
                 new KeyValuePair<string, string>("Date", _timeProvider.Now.ToUkTime().ToString("dd/MM/yyyy HH:mm:ss")),
                 new KeyValuePair<string, string>("Total_Number_Of_Applications", results.Count.ToString())
             };
-            return new ReportStrategyResult(headers, data);
+            return new ReportStrategyResult(headers, data,"");
         }
 
         private async Task ProcessResultsAsync(List<BsonDocument> results)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services.Reports;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -67,7 +66,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
                     return;
                 }
                 report.Headers = reportStrategyResult.Headers;
-                report.Data = reportStrategyResult.Data;
+                report.Query = reportStrategyResult.Query;
                 report.Status = ReportStatus.Generated;
                 report.GeneratedOn = _timeProvider.Now;
 
@@ -83,7 +82,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
             }
         }
 
-        public void WriteReportAsCsv(Stream stream, Report report)
+        public async Task WriteReportAsCsv(Stream stream, Report report)
         {
             if (report.Status != ReportStatus.Generated)
             {
@@ -91,8 +90,17 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
             }
 
             var reportStrategy = _reportStrategyAccessor(report.ReportType);
+            string reportData;
+            if (!string.IsNullOrEmpty(report.Query))
+            {
+                reportData = await reportStrategy.GetApplicationReviewsRecursiveAsync(report.Query);    
+            }
+            else
+            {
+                reportData = report.Data;
+            }
 
-            var results = JArray.Parse(report.Data);
+            var results = JArray.Parse(reportData);
 
             _csvBuilder.WriteCsvToStream(stream, results, report.Headers, reportStrategy.ResolveFormat);
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportService.cs
@@ -67,6 +67,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
                 }
                 report.Headers = reportStrategyResult.Headers;
                 report.Query = reportStrategyResult.Query;
+                report.Data = reportStrategyResult.Data;
                 report.Status = ReportStatus.Generated;
                 report.GeneratedOn = _timeProvider.Now;
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportStrategyResult.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Reports/ReportStrategyResult.cs
@@ -6,11 +6,13 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Reports
     {
         public IEnumerable<KeyValuePair<string, string>> Headers { get; set; }
         public string Data { get; set; }
+        public string Query { get; set; }
 
-        public ReportStrategyResult(IEnumerable<KeyValuePair<string, string>> headers, string data)
+        public ReportStrategyResult(IEnumerable<KeyValuePair<string, string>> headers, string data, string query)
         {
             Headers = headers;
             Data = data;
+            Query = query;
         }
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Reports/WhenWritingReportCsv.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Reports/WhenWritingReportCsv.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using Esfa.Recruit.Vacancies.Client.Application.Providers;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Reports;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructure.Reports
+{
+    public class WhenWritingReportCsv
+    {
+        [Test]
+        [MoqInlineAutoData(ReportStatus.Failed)]
+        [MoqInlineAutoData(ReportStatus.New)]
+        [MoqInlineAutoData(ReportStatus.InProgress)]
+        public void Then_If_The_Report_Is_Not_In_The_Correct_Status_Then_Not_Downloaded(
+            ReportStatus status,
+            Report report,
+            [Frozen] Mock<IReportStrategy> reportStrategy,
+            [Frozen] Mock<IReportRepository> reportRepository,
+            [Frozen] Mock<ICsvBuilder> csvBuilder)
+        {
+            //Arrange
+            IReportStrategy ReportStrategyAccessor(ReportType type) => reportStrategy.Object;
+            report.Query = string.Empty;
+            report.Status = status;
+            var reportService = new ReportService(Mock.Of<ILogger<ReportService>>(), reportRepository.Object,
+                ReportStrategyAccessor, Mock.Of<ITimeProvider>(), csvBuilder.Object);
+
+            //Act Assert
+            Assert.ThrowsAsync<Exception>( () => reportService.WriteReportAsCsv(new MemoryStream(), report));
+            csvBuilder.Verify(x=>x.WriteCsvToStream(It.IsAny<Stream>(), It.IsAny<JArray>(), It.IsAny<IEnumerable<KeyValuePair<string,string>>>(), It.IsAny<Func<string, ReportDataType>>()), Times.Never);
+        }
+        
+        [Test, MoqAutoData]
+        public async Task Then_If_The_Query_Is_Empty_Then_The_Report_Is_Written_From_The_Stored_Data(
+            JArray reportData, 
+            Report report,
+            [Frozen] Mock<IReportStrategy> reportStrategy,
+            [Frozen] Mock<IReportRepository> reportRepository,
+            [Frozen] Mock<ICsvBuilder> csvBuilder)
+        {
+            //Arrange
+            IReportStrategy ReportStrategyAccessor(ReportType type) => reportStrategy.Object;
+            report.Query = string.Empty;
+            report.Status = ReportStatus.Generated;
+            report.Data = JsonConvert.SerializeObject(reportData);
+
+            var reportService = new ReportService(Mock.Of<ILogger<ReportService>>(), reportRepository.Object,
+                ReportStrategyAccessor, Mock.Of<ITimeProvider>(), csvBuilder.Object);
+
+            //Act
+            await reportService.WriteReportAsCsv(new MemoryStream(), report);
+            
+            //Assert
+            csvBuilder.Verify(x=>x.WriteCsvToStream(It.IsAny<Stream>(), reportData, report.Headers, reportStrategy.Object.ResolveFormat));
+        }
+        
+        [Test, MoqAutoData]
+        public async Task Then_If_The_Query_Is_Not_Empty_Then_The_Report_Is_Written_From_The_Stored_Data(
+            JArray reportData, 
+            Report report,
+            [Frozen] Mock<IReportStrategy> reportStrategy,
+            [Frozen] Mock<IReportRepository> reportRepository,
+            [Frozen] Mock<ICsvBuilder> csvBuilder)
+        {
+            //Arrange
+            reportStrategy.Setup(x => x.GetApplicationReviewsRecursiveAsync(report.Query))
+                .ReturnsAsync(JsonConvert.SerializeObject(reportData));
+            IReportStrategy ReportStrategyAccessor(ReportType type) => reportStrategy.Object;
+            report.Status = ReportStatus.Generated;
+            report.Data = null;
+
+            var reportService = new ReportService(Mock.Of<ILogger<ReportService>>(), reportRepository.Object,
+                ReportStrategyAccessor, Mock.Of<ITimeProvider>(), csvBuilder.Object);
+
+            //Act
+            await reportService.WriteReportAsCsv(new MemoryStream(), report);
+            
+            //Assert
+            csvBuilder.Verify(x=>x.WriteCsvToStream(It.IsAny<Stream>(), reportData, report.Headers, reportStrategy.Object.ResolveFormat));
+        }
+    }
+}


### PR DESCRIPTION
This only affects the generation of QA reports. Instead of the data being stored on the document, the query is instead, and when downloaded the query pages the data and builds the csv for download