### PR TITLE
FAI-859 Update content and close date in banner in Recruit a Trainee

### DIFF
--- a/src/Provider/Provider.Web/Views/Dashboard/DashboardNoReview.cshtml
+++ b/src/Provider/Provider.Web/Views/Dashboard/DashboardNoReview.cshtml
@@ -19,13 +19,13 @@
         </div>
         <div class="govuk-notification-banner__content">
             <h3>
-                The last possible start date for a traineeship is 31 July 2023.
+                Find a traineeship will now close on 31 December 2023.
             </h3>
             <p>
-                You will not be able to submit new vacancies after 30 June 2023. Any new vacancies you create must close on or before 15 July 2023.
+                After this date, you will not be able to advertise your traineeship courses on GOV.UK.
             </p>
             <p>
-                Read the <a href="https://questions-statements.parliament.uk/written-statements/detail/2022-12-12/hcws434" target="_blank" rel="noreferrer">statement about how traineeships are changing</a>
+                Read <a href="https://www.gov.uk/guidance/traineeship-information-for-training-providers" target="_blank" rel="noreferrer">traineeship information for training providers</a> and learn more about how traineeships are changing.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Commit Details:
Update banner
GIVEN the provider is on the dashboard page of the Recruit a Trainee service WHEN they look below the header
THEN they’ll see the banner with the updated content with new service close date

Story: https://skillsfundingagency.atlassian.net/browse/FAI-859