### PR TITLE
FAI-971 Add get all live vacancies endpoint

### DIFF
--- a/src/API/Recruit.Api.UnitTests/Controllers/LiveVacanciesControllerTests.cs
+++ b/src/API/Recruit.Api.UnitTests/Controllers/LiveVacanciesControllerTests.cs
@@ -1,0 +1,40 @@
+﻿using AutoFixture.NUnit3;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Api.Queries;
+using SFA.DAS.Testing.AutoFixture;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers;
+public class LiveVacanciesControllerTests
+{
+    [Test, MoqAutoData]
+    public async Task When_Getting_Live_Vacancies_Then_Query_Is_Created_And_Live_Vacancies_Returned(
+    List<LiveVacancy> items,
+    GetLiveVacanciesQueryResponse response,
+    [Frozen] Mock<IMediator> mockMediator,
+    [Greedy] LiveVacanciesController controller)
+    {
+        response.Data = items;
+        mockMediator
+            .Setup(x => x.Send(It.IsAny<GetLiveVacanciesQuery>(), CancellationToken.None))
+            .ReturnsAsync(response);
+
+        var actual = await controller.Get() as OkObjectResult;
+
+        using (new AssertionScope())
+        {
+            Assert.IsNotNull(actual);
+            var actualResult = actual.Value as List<LiveVacancy>;
+            actualResult.Should().BeEquivalentTo(items);
+        }
+    }
+}

--- a/src/API/Recruit.Api.UnitTests/Queries/GetAllLiveVacanciesQueryHandlerTests.cs
+++ b/src/API/Recruit.Api.UnitTests/Queries/GetAllLiveVacanciesQueryHandlerTests.cs
@@ -20,8 +20,7 @@ public class GetAllLiveVacanciesQueryHandlerTests
     private Mock<IQueryStoreReader> _mockQueryStoreReader;
     private IEnumerable<LiveVacancy> liveVacancies;
 
-    [SetUp]
-    public async Task GetVacanciesQueryHandlerTests()
+    public GetAllLiveVacanciesQueryHandlerTests()
     {
         _mockQueryStoreReader = new Mock<IQueryStoreReader>();
 

--- a/src/API/Recruit.Api.UnitTests/Queries/GetAllLiveVacanciesQueryHandlerTests.cs
+++ b/src/API/Recruit.Api.UnitTests/Queries/GetAllLiveVacanciesQueryHandlerTests.cs
@@ -1,0 +1,66 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Recruit.Api.Models;
+using SFA.DAS.Recruit.Api.Queries;
+using SFA.DAS.Testing.AutoFixture;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using AutoFixture;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Queries;
+public class GetAllLiveVacanciesQueryHandlerTests
+{
+    private GetLiveVacanciesQueryHandler _sut;
+    private Mock<IQueryStoreReader> _mockQueryStoreReader;
+    private IEnumerable<LiveVacancy> liveVacancies;
+
+    [SetUp]
+    public async Task GetVacanciesQueryHandlerTests()
+    {
+        _mockQueryStoreReader = new Mock<IQueryStoreReader>();
+
+        var liveVacanciesSummaryFixture = new Fixture();
+        liveVacancies = liveVacanciesSummaryFixture.Build<LiveVacancy>().CreateMany(10);
+
+        _mockQueryStoreReader.Setup(x => x.GetAllLiveVacancies(10)).ReturnsAsync(liveVacancies);
+
+        _sut = new GetLiveVacanciesQueryHandler(_mockQueryStoreReader.Object);
+    }
+
+    [Test]
+    public async Task Then_The_Live_Vacancies_Are_Returned()
+    {
+        var query = new GetLiveVacanciesQuery(10, 1);
+        var actual = await _sut.Handle(query, CancellationToken.None);
+
+        using (new AssertionScope())
+        {
+            actual.Data.Should().BeOfType<LiveVacanciesSummary>();
+            actual.Data.As<LiveVacanciesSummary>().Vacancies.Should().BeEquivalentTo(liveVacancies);
+            actual.Data.As<LiveVacanciesSummary>().PageNo.Should().Be(query.PageNumber);
+            actual.Data.As<LiveVacanciesSummary>().PageSize.Should().Be(query.PageSize);
+            actual.Data.As<LiveVacanciesSummary>().TotalResults.Should().Be(10);
+            actual.Data.As<LiveVacanciesSummary>().TotalPages.Should().Be(1);
+            actual.ResultCode.Should().Be(ResponseCode.Success);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task And_No_Live_Vacancies_Found_Then_Not_Found_Is_Returned(
+            GetLiveVacanciesQuery query,
+            [Frozen] Mock<IQueryStoreReader> mockQueryStoreReader)
+    {
+        mockQueryStoreReader.Setup(x => x.GetAllLiveVacancies(It.IsAny<int>())).ReturnsAsync(() => null);
+        var handler = new GetLiveVacanciesQueryHandler(mockQueryStoreReader.Object);
+
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        actual.ResultCode.Should().Be(ResponseCode.NotFound);
+    }
+}

--- a/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
+++ b/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Recruit.Api.Queries;
+using RouteAttribute = Microsoft.AspNetCore.Mvc.RouteAttribute;
+
+namespace SFA.DAS.Recruit.Api.Controllers;
+
+[Route("api/[controller]")]
+public class LiveVacanciesController : ApiControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public LiveVacanciesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var resp = await _mediator.Send(new GetLiveVacanciesQuery());
+        return GetApiResponse(resp);
+    }
+}

--- a/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
+++ b/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
@@ -17,7 +17,7 @@ public class LiveVacanciesController : ApiControllerBase
     }
 
     [HttpGet]
-    public async Task<IActionResult> Get([FromQuery] uint pageSize = 100, uint pageNo = 1)
+    public async Task<IActionResult> Get([FromQuery] uint pageSize = 100, [FromQuery] uint pageNo = 1)
     {
         var resp = await _mediator.Send(new GetLiveVacanciesQuery((int)pageSize, (int)pageNo));
         return GetApiResponse(resp);

--- a/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
+++ b/src/API/Recruit.Api/Controllers/LiveVacanciesController.cs
@@ -17,9 +17,9 @@ public class LiveVacanciesController : ApiControllerBase
     }
 
     [HttpGet]
-    public async Task<IActionResult> Get()
+    public async Task<IActionResult> Get([FromQuery] uint pageSize = 100, uint pageNo = 1)
     {
-        var resp = await _mediator.Send(new GetLiveVacanciesQuery());
+        var resp = await _mediator.Send(new GetLiveVacanciesQuery((int)pageSize, (int)pageNo));
         return GetApiResponse(resp);
     }
 }

--- a/src/API/Recruit.Api/Models/LiveVacanciesSummary.cs
+++ b/src/API/Recruit.Api/Models/LiveVacanciesSummary.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.Vacancy;
+
+namespace SFA.DAS.Recruit.Api.Models;
+
+public class LiveVacanciesSummary
+{
+    public LiveVacanciesSummary(IEnumerable<LiveVacancy> vacancies, int pageSize, int pageNo, int totalResults, int totalPages)
+    {
+        Vacancies = vacancies;
+        PageSize = pageSize;
+        PageNo = pageNo;
+        TotalResults = totalResults;
+        TotalPages = totalPages;
+    }
+
+    public IEnumerable<LiveVacancy> Vacancies { get; }
+    public int PageSize { get; }
+    public int PageNo { get; }
+    public int TotalResults { get; }
+    public int TotalPages { get; }
+
+}

--- a/src/API/Recruit.Api/Models/LiveVacanciesSummary.cs
+++ b/src/API/Recruit.Api/Models/LiveVacanciesSummary.cs
@@ -5,19 +5,20 @@ namespace SFA.DAS.Recruit.Api.Models;
 
 public class LiveVacanciesSummary
 {
-    public LiveVacanciesSummary(IEnumerable<LiveVacancy> vacancies, int pageSize, int pageNo, int totalResults, int totalPages)
+    public LiveVacanciesSummary(IEnumerable<LiveVacancy> vacancies, int pageSize, int pageNo, int totalLiveVacanciesReturned, int totalLiveVacancies, int totalPages)
     {
         Vacancies = vacancies;
         PageSize = pageSize;
         PageNo = pageNo;
-        TotalResults = totalResults;
+        TotalLiveVacanciesReturned = totalLiveVacanciesReturned;
+        TotalLiveVacancies = totalLiveVacancies;
         TotalPages = totalPages;
     }
 
     public IEnumerable<LiveVacancy> Vacancies { get; }
     public int PageSize { get; }
     public int PageNo { get; }
-    public int TotalResults { get; }
+    public int TotalLiveVacanciesReturned { get; set; }
+    public int TotalLiveVacancies { get; }
     public int TotalPages { get; }
-
 }

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQuery.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQuery.cs
@@ -1,0 +1,7 @@
+﻿using MediatR;
+
+namespace SFA.DAS.Recruit.Api.Queries;
+
+public class GetLiveVacanciesQuery : IRequest<GetLiveVacanciesQueryResponse>
+{
+}

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQuery.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQuery.cs
@@ -4,4 +4,12 @@ namespace SFA.DAS.Recruit.Api.Queries;
 
 public class GetLiveVacanciesQuery : IRequest<GetLiveVacanciesQueryResponse>
 {
+    public GetLiveVacanciesQuery(int pageSize, int pageNumber)
+    {
+        PageSize = pageSize;
+        PageNumber = pageNumber;
+    }
+
+    public int PageSize { get; set; }
+    public int PageNumber { get; set; }
 }

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
@@ -1,14 +1,30 @@
-﻿using System;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore;
 using MediatR;
 
 namespace SFA.DAS.Recruit.Api.Queries;
 
 public class GetLiveVacanciesQueryHandler : IRequestHandler<GetLiveVacanciesQuery, GetLiveVacanciesQueryResponse>
 {
+    private readonly IQueryStoreReader _queryStoreReader;
+
+    public GetLiveVacanciesQueryHandler(IQueryStoreReader queryStoreReader)
+    {
+        _queryStoreReader = queryStoreReader;
+    }
+
     public async Task<GetLiveVacanciesQueryResponse> Handle(GetLiveVacanciesQuery request, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var queryResult = await _queryStoreReader.GetAllLiveVacancies();
+
+        if (queryResult == null) { return new GetLiveVacanciesQueryResponse { ResultCode = Models.ResponseCode.NotFound }; }
+
+        //var numberResults = queryResult.ToList().Count();
+
+        return new GetLiveVacanciesQueryResponse { ResultCode = Models.ResponseCode.Success, Data = queryResult.ToList() };
+
+        // implement paging
     }
 }

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+
+namespace SFA.DAS.Recruit.Api.Queries;
+
+public class GetLiveVacanciesQueryHandler : IRequestHandler<GetLiveVacanciesQuery, GetLiveVacanciesQueryResponse>
+{
+    public async Task<GetLiveVacanciesQueryResponse> Handle(GetLiveVacanciesQuery request, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryHandler.cs
@@ -20,12 +20,16 @@ public class GetLiveVacanciesQueryHandler : IRequestHandler<GetLiveVacanciesQuer
 
     public async Task<GetLiveVacanciesQueryResponse> Handle(GetLiveVacanciesQuery request, CancellationToken cancellationToken)
     {
-        var vacanciesToSkipCount = request.PageNumber < 2 ? 0 : (request.PageNumber - 1) * request.PageSize;
-        var vacanciesToGetCount = (request.PageNumber * request.PageSize) - vacanciesToSkipCount;
+        var vacanciesToGetCount = request.PageSize > 1000 ? 1000 : request.PageSize;
+        var vacanciesToSkipCount = request.PageNumber < 2 ? 0 : (request.PageNumber - 1) * vacanciesToGetCount;
+        
 
-        var queryResult = vacanciesToGetCount > 1000 ? await _queryStoreReader.GetAllLiveVacancies(vacanciesToSkipCount, 1000) : await _queryStoreReader.GetAllLiveVacancies(vacanciesToSkipCount, vacanciesToGetCount);
+        var queryResult = await _queryStoreReader.GetAllLiveVacancies(vacanciesToSkipCount, vacanciesToGetCount);
 
-        if (queryResult == null) { return new GetLiveVacanciesQueryResponse { ResultCode = ResponseCode.Success, Data = Enumerable.Empty<LiveVacancy>() }; }
+        if (queryResult == null)
+        {
+            return new GetLiveVacanciesQueryResponse { ResultCode = ResponseCode.Success, Data = Enumerable.Empty<LiveVacancy>() };
+        }
 
         var totalLiveVacanciesReturned = queryResult.Count();
         var liveVacanciesCount = await _queryStoreReader.GetAllLiveVacanciesCount();

--- a/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryResponse.cs
+++ b/src/API/Recruit.Api/Queries/GetLiveVacanciesQueryResponse.cs
@@ -1,0 +1,7 @@
+﻿using SFA.DAS.Recruit.Api.Models;
+
+namespace SFA.DAS.Recruit.Api.Queries;
+
+public class GetLiveVacanciesQueryResponse : ResponseBase
+{
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
@@ -20,5 +20,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         Task<long> DeleteAllAsync<T>(string typeName) where T : QueryProjectionBase;
         Task<IEnumerable<LiveVacancy>> GetAllLiveExpired(DateTime? closingDate);
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
@@ -20,6 +20,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         Task<long> DeleteAllAsync<T>(string typeName) where T : QueryProjectionBase;
         Task<IEnumerable<LiveVacancy>> GetAllLiveExpired(DateTime? closingDate);
-        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies();
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStore.cs
@@ -20,6 +20,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
         Task<long> DeleteAllAsync<T>(string typeName) where T : QueryProjectionBase;
         Task<IEnumerable<LiveVacancy>> GetAllLiveExpired(DateTime? closingDate);
-        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet);
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int vacanciesToSkip, int vacanciesToGet);
+        Task<long> GetAllLiveVacanciesCount();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
@@ -27,6 +27,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         Task<BlockedProviderOrganisations> GetBlockedProvidersAsync();
         Task<IEnumerable<LiveVacancy>> GetLiveExpiredVacancies(DateTime closingDate);
         Task<ClosedVacancy> GetClosedVacancy(long vacancyReference);
-        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet);
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int vacanciesToSkip, int vacanciesToGet);
+        Task<long> GetAllLiveVacanciesCount();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
@@ -27,5 +27,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         Task<BlockedProviderOrganisations> GetBlockedProvidersAsync();
         Task<IEnumerable<LiveVacancy>> GetLiveExpiredVacancies(DateTime closingDate);
         Task<ClosedVacancy> GetClosedVacancy(long vacancyReference);
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies();
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/IQueryStoreReader.cs
@@ -27,6 +27,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         Task<BlockedProviderOrganisations> GetBlockedProvidersAsync();
         Task<IEnumerable<LiveVacancy>> GetLiveExpiredVacancies(DateTime closingDate);
         Task<ClosedVacancy> GetClosedVacancy(long vacancyReference);
-        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies();
+        Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
@@ -152,5 +152,22 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
 
             return result.DeletedCount;
         }
+
+        public async Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        {
+            var builderFilter = Builders<LiveVacancy>.Filter;
+            var filter = builderFilter.Gt(identifier => identifier.ClosingDate, DateTime.UtcNow);
+
+            var builderSort = Builders<LiveVacancy>.Sort;
+            var sort = builderSort.Descending(identifier => identifier.ClosingDate);
+
+            var collection = GetCollection<LiveVacancy>();
+
+            var result = await RetryPolicy.Execute(_ =>
+                    collection.Find(filter).Sort(sort).Project<LiveVacancy>(GetProjection<LiveVacancy>()).ToListAsync(),
+                new Context(nameof(GetAllLiveVacancies)));
+
+            return result;
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
@@ -153,7 +153,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return result.DeletedCount;
         }
 
-        public async Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
+        public async Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int vacanciesToSkip, int vacanciesToGet)
         {
             var builderFilter = Builders<LiveVacancy>.Filter;
             var filter = builderFilter.Gt(identifier => identifier.ClosingDate, DateTime.UtcNow);
@@ -164,7 +164,21 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             var collection = GetCollection<LiveVacancy>();
 
             var result = await RetryPolicy.Execute(_ =>
-                    collection.Find(filter).Sort(sort).Limit(numberToGet).Project<LiveVacancy>(GetProjection<LiveVacancy>()).ToListAsync(),
+                    collection.Find(filter).Sort(sort).Skip(vacanciesToSkip).Limit(vacanciesToGet).Project<LiveVacancy>(GetProjection<LiveVacancy>()).ToListAsync(),
+                new Context(nameof(GetAllLiveVacancies)));
+
+            return result;
+        }
+
+        public async Task<long> GetAllLiveVacanciesCount()
+        {
+            var builderFilter = Builders<LiveVacancy>.Filter;
+            var filter = builderFilter.Gt(identifier => identifier.ClosingDate, DateTime.UtcNow);
+
+            var collection = GetCollection<LiveVacancy>();
+
+            var result = await RetryPolicy.Execute(_ =>
+                    collection.CountDocumentsAsync(filter),
                 new Context(nameof(GetAllLiveVacancies)));
 
             return result;

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/MongoQueryStore.cs
@@ -153,7 +153,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return result.DeletedCount;
         }
 
-        public async Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        public async Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
         {
             var builderFilter = Builders<LiveVacancy>.Filter;
             var filter = builderFilter.Gt(identifier => identifier.ClosingDate, DateTime.UtcNow);
@@ -164,7 +164,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             var collection = GetCollection<LiveVacancy>();
 
             var result = await RetryPolicy.Execute(_ =>
-                    collection.Find(filter).Sort(sort).Project<LiveVacancy>(GetProjection<LiveVacancy>()).ToListAsync(),
+                    collection.Find(filter).Sort(sort).Limit(numberToGet).Project<LiveVacancy>(GetProjection<LiveVacancy>()).ToListAsync(),
                 new Context(nameof(GetAllLiveVacancies)));
 
             return result;

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -265,5 +265,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
         {
             return _queryStore.GetAsync<BlockedProviderOrganisations>(QueryViewType.BlockedProviderOrganisations.GetIdValue());
         }
+
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        {
+            return _queryStore.GetAllLiveVacancies();
+        }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -266,9 +266,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return _queryStore.GetAsync<BlockedProviderOrganisations>(QueryViewType.BlockedProviderOrganisations.GetIdValue());
         }
 
-        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
         {
-            return _queryStore.GetAllLiveVacancies();
+            return _queryStore.GetAllLiveVacancies(numberToGet);
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/QueryStore/QueryStoreClient.cs
@@ -266,9 +266,14 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore
             return _queryStore.GetAsync<BlockedProviderOrganisations>(QueryViewType.BlockedProviderOrganisations.GetIdValue());
         }
 
-        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int vacanciesToSkip, int vacanciesToGet)
         {
-            return _queryStore.GetAllLiveVacancies(numberToGet);
+            return _queryStore.GetAllLiveVacancies(vacanciesToSkip, vacanciesToGet);
+        }
+
+        public Task<long> GetAllLiveVacanciesCount()
+        {
+            return _queryStore.GetAllLiveVacanciesCount();
         }
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
@@ -90,6 +90,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.TableStore
             throw new NotImplementedException();
         }
 
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task DeleteAsync<T>(string typeName, string key) where T : QueryProjectionBase
         {
             var retrieveOperation = TableOperation.Retrieve<QueryEntity>(typeName, key);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
@@ -90,7 +90,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.TableStore
             throw new NotImplementedException();
         }
 
-        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies()
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
         {
             throw new NotImplementedException();
         }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/TableStore/TableStorageQueryStore.cs
@@ -90,7 +90,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.TableStore
             throw new NotImplementedException();
         }
 
-        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int numberToGet)
+        public Task<IEnumerable<LiveVacancy>> GetAllLiveVacancies(int vacanciesToSkip, int vacanciesToGet)
+        {
+            throw new NotImplementedException();
+        }
+        public Task<long> GetAllLiveVacanciesCount()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Add endpoint to get all vacancies:
-  that have a closing date that is in the future, 
- and sort these results by closing date (in descending order)
- with a default of 100 results per page,
- and a maximum of 1000 results returned (even if the paging numbers would expect more)