### PR TITLE
FAI-1206 - change so that we always call the outer api

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApplicationReviewCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/ApplicationReviewCommandHandler.cs
@@ -74,16 +74,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
 
             await _applicationReviewRepository.UpdateAsync(applicationReview);
 
-            if (applicationReview.Application.IsFaaV2Application)
-            {
-                await _outerApiClient.Post(new PostApplicationStatusRequest(applicationReview.Application.CandidateId,
-                    applicationReview.Application.ApplicationId, new PostApplicationStatus
-                    {
-                        Status = applicationReview.Status.ToString(),
-                        CandidateFeedback = applicationReview.CandidateFeedback
-                    }));
-            }
-            else
+            if (!applicationReview.Application.IsFaaV2Application)
             {
                 await _messaging.PublishEvent(new ApplicationReviewedEvent
                 {
@@ -93,6 +84,13 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
                     CandidateId = applicationReview.CandidateId
                 });    
             }
+            
+            await _outerApiClient.Post(new PostApplicationStatusRequest(applicationReview.Application.CandidateId,
+                applicationReview.Application.ApplicationId, new PostApplicationStatus
+                {
+                    Status = applicationReview.Status.ToString(),
+                    CandidateFeedback = applicationReview.CandidateFeedback
+                }));
             
 
             var shouldMakeOthersUnsuccessful = await CheckForPositionsFilledAsync(message.Outcome, applicationReview.VacancyReference);


### PR DESCRIPTION
This is to cover the scenarios where a application has been migrated and will be a non v2 created but exists in v2 to be updated