### PR TITLE
FAI-1889 - Add new queue trigger to refresh provider info

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/UpdateProviderInfoQueueTrigger.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/Triggers/QueueTriggers/UpdateProviderInfoQueueTrigger.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Threading.Tasks;
+using Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Esfa.Recruit.Vacancies.Client.Domain.Messaging;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue;
+using Microsoft.Azure.WebJobs;
+
+namespace Esfa.Recruit.Vacancies.Jobs.Triggers.QueueTriggers;
+
+public class UpdateProviderInfoQueueTrigger
+{
+    private readonly IMessaging _messaging;
+
+    public UpdateProviderInfoQueueTrigger(IMessaging messaging)
+    {
+        _messaging = messaging;
+    }
+    public async Task ExecuteAsync(
+        [QueueTrigger(QueueNames.UpdateProviderInfoQueueName, Connection = "QueueStorage")] UpdateProviderInfoQueueMessage message, 
+        TextWriter log)
+    {
+        foreach (var ukprn in message.Ukprns)
+        {
+            await _messaging.PublishEvent(new SetupProviderEvent(ukprn));
+        }
+    }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/UpdateProviderInfoQueueMessage.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Queues/Messages/UpdateProviderInfoQueueMessage.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Esfa.Recruit.Vacancies.Client.Application.Queues.Messages;
+
+public class UpdateProviderInfoQueueMessage
+{
+    public List<long> Ukprns { get; set; }
+}

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/QueueNames.cs
@@ -32,5 +32,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue
         public const string DataMigrationQueueName = "data-migration";
         public const string CommunicationsHouseKeepingQueueName = "communications-house-keeping-queue";
         public const string UpdateProvidersQueueName = "update-providers-queue";
+        public const string UpdateProviderInfoQueueName = "update-provider-info-queue";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/RecruitStorageQueueService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/StorageQueue/RecruitStorageQueueService.cs
@@ -28,6 +28,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.StorageQueue
             { typeof(DataMigrationQueueMessage), QueueNames.DataMigrationQueueName },
             { typeof(CommunicationsHouseKeepingQueueMessage), QueueNames.CommunicationsHouseKeepingQueueName},
             { typeof(UpdateProvidersQueueMessage), QueueNames.UpdateProvidersQueueName},
+            { typeof(UpdateProviderInfoQueueMessage), QueueNames.UpdateProviderInfoQueueName},
             { typeof(TransferVacanciesFromEmployerReviewToQAReviewQueueMessage), QueueNames.TransferVacanciesFromEmployerReviewToQAReviewQueueName },
             { typeof(VacancyAnalyticsV2QueueMessage), QueueNames.GenerateV2VacancyAnalyticsQueueName }
         };


### PR DESCRIPTION
Can add a single message to the queue `update-provider-info-queue` in the format of:

```
{
    "ukprns": [
        10000001,
        10000002
    ]
}
```