### PR TITLE
FAI-2361 Bug Unexpected validation behaviour on apprenticeship start date page

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
@@ -4,6 +4,7 @@
     {
         public const string TrainingNotExist = "260";
         public const string TrainingExpiryDate = "26";
+        public const string TrainingExpiryDateMustExist = "27";
         public const string TrainingProviderUkprnNotEmpty = "101";
         public const string TrainingProviderUkprnMustBeCorrectLength = "99";
         public const string TrainingProviderMustExist = "102";

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -5,6 +5,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using Esfa.Recruit.Vacancies.Client.Domain.Models;
 using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 using FluentValidation;
 using FluentValidation.Results;
@@ -111,10 +112,9 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
             {
                 if (!vacancy.StartDate.HasValue)
                 {
-                    var message = $"The start date must have a value.";
-                    var failure = new ValidationFailure(string.Empty, message)
+                    var failure = new ValidationFailure(string.Empty, "The start date must have a value.")
                     {
-                        ErrorCode = ErrorCodes.TrainingExpiryDate,
+                        ErrorCode = ErrorCodes.TrainingExpiryDateMustExist,
                         CustomState = VacancyRuleSet.TrainingExpiryDate,
                         PropertyName = nameof(Vacancy.StartDate)
                     };


### PR DESCRIPTION
✨ Add training expiry error code and update validation

- Added `TrainingExpiryDateMustExist` constant to `ErrorCodes.cs`.
- Included a using directive for apprenticeship programmes in `VacancyFluentValidationExtensions.cs`.
- Updated error handling to use the new error code for missing start dates.
- Improved specificity of error messages related to training expiry dates.

https://skillsfundingagency.atlassian.net/browse/FAI-2361

