### PR TITLE
FAI-2370 - Ensure ML adverts can have analytics data stored

### DIFF
--- a/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/AnalyticsSummaryProcessor/AnalyticsAggregatorTests.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs.UnitTests/AnalyticsSummaryProcessor/AnalyticsAggregatorTests.cs
@@ -60,7 +60,54 @@ public class AnalyticsAggregatorTests
         actual.NoOfApprenticeshipApplicationsSubmitted.Should().Be(summary.ApplicationSubmittedCount);  
         actual.NoOfApprenticeshipDetailsViews.Should().Be(summary.ViewsCount);
     }
-     [Test, MoqAutoData]
+    
+    [Test]
+    [MoqInlineAutoData("")]
+    [MoqInlineAutoData("-1")]
+    [MoqInlineAutoData("-123")]
+    [MoqInlineAutoData("-123444")]
+    public async Task Then_The_Vacancy_Metrics_Are_Returned_And_Aggregated_To_Existing_For_ML(
+        string mlExtension,
+        long vacancyReference,
+        VacancyAnalyticsV2QueueMessage metricData,
+        VacancyAnalytics summary,
+        [Frozen] Mock<IQueryStoreReader> queryStoreReader,
+        [Frozen] Mock<IQueryStoreWriter> queryStoreWriter,
+        [Frozen] Mock<ITimeProvider> dateTimeService,
+        [Frozen] Mock<IOuterApiClient> apiClient,
+        AnalyticsAggregator analyticsAggregator)
+    {
+        metricData.VacancyReference = $"{vacancyReference}{mlExtension}";
+        summary.AnalyticsDate = new DateTime(2024, 11, 30);
+        dateTimeService.Setup(x => x.Now)
+            .Returns(new DateTime(2024, 11, 30, 12, 00, 00));
+        
+        queryStoreReader.Setup(x => x.GetVacancyAnalyticsSummaryV2Async(vacancyReference.ToString())).ReturnsAsync(
+            new VacancyAnalyticsSummaryV2
+            {
+                VacancyReference = vacancyReference.ToString(),
+                VacancyAnalytics = [summary]
+            });
+
+        var actual = await analyticsAggregator.GetVacancyAnalyticEventSummaryAsync(metricData);
+
+        queryStoreWriter.Verify(
+            x => x.UpsertVacancyAnalyticSummaryV2Async(It.Is<VacancyAnalyticsSummaryV2>(c =>
+                c.VacancyAnalytics.First(a => a.AnalyticsDate == new DateTime(2024, 11, 30)).ViewsCount == summary.ViewsCount
+                && c.VacancyAnalytics.First(a => a.AnalyticsDate == new DateTime(2024, 11, 30)).ApplicationStartedCount == summary.ApplicationStartedCount
+                && c.VacancyAnalytics.First(a => a.AnalyticsDate == new DateTime(2024, 11, 30)).ApplicationSubmittedCount == summary.ApplicationSubmittedCount
+                && c.VacancyAnalytics.First(a => a.AnalyticsDate == new DateTime(2024, 11, 30)).SearchResultsCount == summary.SearchResultsCount)), Times.Once);
+
+        actual.VacancyReference.Should().Be(vacancyReference);
+        actual.NoOfApprenticeshipSaved.Should().Be(0);
+        actual.NoOfApprenticeshipSavedSearchAlerts.Should().Be(0);
+        actual.NoOfApprenticeshipSearches.Should().Be(summary.SearchResultsCount);
+        actual.NoOfApprenticeshipApplicationsCreated.Should().Be(summary.ApplicationStartedCount);
+        actual.NoOfApprenticeshipApplicationsSubmitted.Should().Be(summary.ApplicationSubmittedCount);  
+        actual.NoOfApprenticeshipDetailsViews.Should().Be(summary.ViewsCount);
+    }
+    
+    [Test, MoqAutoData]
     public async Task Then_The_Vacancy_Metrics_Are_Returned_And_New_Created_If_Not_Exists(
         long vacancyReference,
         VacancyAnalyticsV2QueueMessage metricData,

--- a/src/Jobs/Recruit.Vacancies.Jobs/AnalyticsSummaryProcessor/AnalyticsAggregator.cs
+++ b/src/Jobs/Recruit.Vacancies.Jobs/AnalyticsSummaryProcessor/AnalyticsAggregator.cs
@@ -23,14 +23,16 @@ public class AnalyticsAggregator(IOuterApiClient apiClient, ITimeProvider timePr
     {
         var endDate = timeProvider.Now;
         var startDate = new DateTime(endDate.Year, endDate.Month, endDate.Day);
-        
+        var vacancyRef =vacancyAnalyticsV2QueueMessage.VacancyReference.Contains('-') ?
+            vacancyAnalyticsV2QueueMessage.VacancyReference[
+                ..vacancyAnalyticsV2QueueMessage.VacancyReference.IndexOf('-')] : vacancyAnalyticsV2QueueMessage.VacancyReference;
 
-        var metrics = await queryStoreReader.GetVacancyAnalyticsSummaryV2Async(vacancyAnalyticsV2QueueMessage.VacancyReference);
+        var metrics = await queryStoreReader.GetVacancyAnalyticsSummaryV2Async(vacancyRef);
         if (metrics == null)
         {
             metrics = new VacancyAnalyticsSummaryV2
             {
-                VacancyReference = vacancyAnalyticsV2QueueMessage.VacancyReference,
+                VacancyReference = vacancyRef,
                 ViewType = nameof(VacancyAnalyticsSummaryV2),
                 VacancyAnalytics = []
             };
@@ -66,7 +68,7 @@ public class AnalyticsAggregator(IOuterApiClient apiClient, ITimeProvider timePr
         
         return new VacancyAnalyticsSummary
         {
-            VacancyReference = Convert.ToInt32(vacancyAnalyticsV2QueueMessage.VacancyReference),
+            VacancyReference = Convert.ToInt32(vacancyRef),
             NoOfApprenticeshipSearches = metrics.VacancyAnalytics.Sum(c=>c.SearchResultsCount),
             NoOfApprenticeshipSearchesSevenDaysAgo = sevenDaysAgoTotals.Sum(c=>c.SearchResultsCount),
             NoOfApprenticeshipSearchesSixDaysAgo = sixDaysAgoTotals.Sum(c=>c.SearchResultsCount),


### PR DESCRIPTION
Make sure that if we do receive a ML advert with - in the vacancy ref, we can still process it