### PR TITLE
FAI-2627 Add locations field and filter to the Shared applications page

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -77,13 +77,13 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                 Applications = string.IsNullOrEmpty(locationFilter)
                     ? applications
                     : applications.Where(fil => fil.CandidateAppliedLocations.Contains(locationFilter)).ToList(),
-                ApplicationsCount = applications.Count,
+                TotalUnfilteredApplicationsCount = applications.Count,
                 EmploymentLocations = vacancy.EmployerLocations.GetCityDisplayList(),
                 SelectedLocation = locationFilter,
                 ShowDisability = vacancy.IsDisabilityConfident,
                 VacancyId = vacancy.Id,
                 EmployerAccountId = vacancy.EmployerAccountId,
-                VacancySharedByProvier = vacancySharedByProvider
+                VacancySharedByProvider = vacancySharedByProvider
             };
 
             return viewModel;

--- a/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
@@ -17,11 +17,11 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyManage
         public bool IsWithdrawn => string.IsNullOrEmpty(WithdrawnDate) == false;
         public bool IsClosedBlockedByQa { get; set; }
         public VacancyApplicationsViewModel Applications { get; internal set; }
-        public bool HasApplications => ApplicationCount > 0;
-        public bool HasNoApplications => ApplicationCount == 0;
-        public int ApplicationCount => Applications?.ApplicationsCount ?? 0;
-        public bool ShowEmployerApplications => !Applications.VacancySharedByProvier;
-        public bool ShowSharedApplications => HasApplications && Applications.VacancySharedByProvier;
+        public bool HasApplications => TotalUnfilteredApplicationsCount > 0;
+        public bool HasNoApplications => TotalUnfilteredApplicationsCount == 0;
+        public int TotalUnfilteredApplicationsCount => Applications?.TotalUnfilteredApplicationsCount ?? 0;
+        public bool ShowEmployerApplications => !Applications.VacancySharedByProvider;
+        public bool ShowSharedApplications => HasApplications && Applications.VacancySharedByProvider;
         public bool CanShowMultipleApplicationsUnsuccessfulLink => (IsVacancyLive || IsVacancyClosed) && Applications.CanShowMultipleApplicationsUnsuccessfulLink && ShowEmployerApplications;
 
         public bool CanShowEditVacancyLink { get; internal set; }

--- a/src/Employer/Employer.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
@@ -11,14 +11,17 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyManage
         public IEnumerable<VacancyApplication> Applications { get; internal set; }
         public List<string> EmploymentLocations { get; set; } = [];
         public string? SelectedLocation { get; set; }
-        public int ApplicationsCount { get; set; } = 0;
-        public string FilteredApplicationLabelText => Applications.Count() == 1
+        public int TotalUnfilteredApplicationsCount { get; set; } = 0;
+        public string FilteredApplicationsLabelText => Applications.Count() == 1
             ? "1 Application"
             : $"{Applications.Count()} Applications";
 
+        public bool HasApplications => Applications != null && Applications.Any();
+        public bool HasNoApplications => !HasApplications;
+
         public UserType UserType { get; internal set; }
         public bool ShowDisability { get; internal set; }
-        public bool VacancySharedByProvier { get; internal set; }
+        public bool VacancySharedByProvider { get; internal set; }
         public bool CanShowMultipleApplicationsUnsuccessfulLink =>
             Applications?.Any(app => app.Status != ApplicationReviewStatus.Successful && app.Status != ApplicationReviewStatus.Unsuccessful) ?? false;
 

--- a/src/Employer/Employer.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
@@ -30,14 +30,13 @@
     <div class="govuk-grid-column-two-thirds">
         <div>
             <h2 class="govuk-heading-s">
-                @Model.FilteredApplicationLabelText
+                @Model.FilteredApplicationsLabelText
             </h2>
         </div>
     </div>
 </div>
 <section id="applications">
-    @if (Model.Applications.Any())
-    {
+    <div asp-show="@Model.HasApplications">
         <table class="govuk-table responsive">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
@@ -66,13 +65,10 @@
                 }
             </tbody>
         </table>
-    }
-    else
-    {
-        <div>
-            <p class="govuk-body">
-                No applications for @Model.SelectedLocation have been received.
-            </p>
-        </div>
-    }
+    </div>
+    <div asp-show="Model.HasNoApplications">
+        <p class="govuk-body">
+            No applications for @Model.SelectedLocation have been received.
+        </p>
+    </div>
 </section>

--- a/src/Employer/Employer.Web/Views/Shared/_VacancySharedApplicationsTablePartial.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_VacancySharedApplicationsTablePartial.cshtml
@@ -1,40 +1,82 @@
 @using Esfa.Recruit.Employer.Web.ViewModels.VacancyManage
 @model VacancyApplicationsViewModel
-<table class="govuk-table responsive">
-    <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header das-table-cell-width-38 das-table--double-arrows">
-                <sortable-column column-name="Applicant" column-label="Applicant" default="false" default-order="Ascending" shared-vacancy="true"></sortable-column>
-            </th>
-            <th scope="col" class="govuk-table__header das-table-cell-width-25 das-table--double-arrows">
-                <sortable-column column-name="Response" column-label="Response" default="false" default-order="Descending" shared-vacancy="true"></sortable-column>
-            </th>
-            <th scope="col" class="govuk-table__header status das-table--double-arrows">
-                <sortable-column column-name="DateReviewed" column-label="Date reviewed" default="false" default-order="Descending" shared-vacancy="true"></sortable-column>
-            </th>
-            <th scope="col" class="govuk-table__header das-table-cell-width-18 das-table--double-arrows">
-                <sortable-column column-name="DateShared" column-label="Date shared" default="false" default-order="Ascending" shared-vacancy="true"></sortable-column>
-            </th>
-        </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-        @foreach (var application in Model.Applications)
-        {
-            <tr class="govuk-table__row" asp-show="@application.IsNotWithdrawn">
-                <td class="govuk-table__cell" data-label="Applicant">
-                    <a id="@($"application-id-{application.GetFriendlyId()}")" data-label="application_review" asp-route="@RouteNames.ApplicationReview_Get" asp-route-employerAccountId="@Model.EmployerAccountId" asp-route-vacancyId="@Model.VacancyId" asp-route-applicationReviewId="@application.ApplicationReviewId" asp-route-vacancySharedByProvider=@application.IsSharedApplication class="govuk-link">@application.GetFriendlyId()</a>
-                    <p asp-show="@application.ShowCandidateName" class="govuk-table__cell" data-label="ApplicantName">@application.CandidateName</p>
-                </td>
-                <td class="govuk-table__cell" data-label="Response"><strong class="@application.Status.GetCssClassForApplicationReviewStatusForEmployer()">@application.Status.GetDisplayName(Model.UserType)</strong></td>
-                <td class="govuk-table__cell" data-label="Date reviewed">@application.DateReviewedText</td>
-                <td class="govuk-table__cell" data-label="Date shared">@application.DateSharedWithEmployer.AsGdsDate()</td>
+<form method="get" autocomplete="off">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="locationFilter">Filter by locations</label>
+                <select class="govuk-select"
+                        id="locationFilter"
+                        name="locationFilter"
+                        data-ays-ignore="true">
+                    <option value="">All locations</option>
+                    @foreach (var location in Model.EmploymentLocations)
+                    {
+                        if (location == Model.SelectedLocation)
+                        {
+                            <option value="@location" selected>@location</option>
+                        }
+                        else
+                        {
+                            <option value="@location">@location</option>
+                        }
+                    }
+                </select>
+            </div>
+        </div>
+    </div>
+</form>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div>
+            <h2 class="govuk-heading-s">
+                @Model.FilteredApplicationsLabelText
+            </h2>
+        </div>
+    </div>
+</div>
+<div asp-show="@Model.HasApplications">
+    <table class="govuk-table responsive">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header das-table-cell-width-38 das-table--double-arrows">
+                    <sortable-column column-name="Applicant" column-label="Applicant" default="false" default-order="Ascending" shared-vacancy="true"></sortable-column>
+                </th>
+                <th scope="col" class="govuk-table__header das-table-cell-width-25 das-table--double-arrows">
+                    <sortable-column column-name="Response" column-label="Response" default="false" default-order="Descending" shared-vacancy="true"></sortable-column>
+                </th>
+                <th scope="col" class="govuk-table__header status das-table--double-arrows">
+                    <sortable-column column-name="DateReviewed" column-label="Date reviewed" default="false" default-order="Descending" shared-vacancy="true"></sortable-column>
+                </th>
+                <th scope="col" class="govuk-table__header das-table-cell-width-18 das-table--double-arrows">
+                    <sortable-column column-name="DateShared" column-label="Date shared" default="false" default-order="Ascending" shared-vacancy="true"></sortable-column>
+                </th>
             </tr>
-            <tr class="govuk-table__row" asp-show="@application.IsWithdrawn">
-                <td class="govuk-table__cell" data-label="Applicant">@application.GetFriendlyId()</td>
-                <td class="govuk-table__cell" data-label="Response">Withdrawn</td>
-                <td class="govuk-table__cell" data-label="Date reviewed">@application.DateReviewedText</td>
-                <td class="govuk-table__cell" data-label="Date shared">@application.DateSharedWithEmployer.AsGdsDate()</td>
-            </tr>
-        }
-    </tbody>
-</table>
+        </thead>
+        <tbody class="govuk-table__body">
+            @foreach (var application in Model.Applications)
+            {
+                <tr class="govuk-table__row" asp-show="@application.IsNotWithdrawn">
+                    <td class="govuk-table__cell" data-label="Applicant">
+                        <a id="@($"application-id-{application.GetFriendlyId()}")" data-label="application_review" asp-route="@RouteNames.ApplicationReview_Get" asp-route-employerAccountId="@Model.EmployerAccountId" asp-route-vacancyId="@Model.VacancyId" asp-route-applicationReviewId="@application.ApplicationReviewId" asp-route-vacancySharedByProvider=@application.IsSharedApplication class="govuk-link">@application.GetFriendlyId()</a>
+                        <p asp-show="@application.ShowCandidateName" class="govuk-table__cell" data-label="ApplicantName">@application.CandidateName</p>
+                    </td>
+                    <td class="govuk-table__cell" data-label="Response"><strong class="@application.Status.GetCssClassForApplicationReviewStatusForEmployer()">@application.Status.GetDisplayName(Model.UserType)</strong></td>
+                    <td class="govuk-table__cell" data-label="Date reviewed">@application.DateReviewedText</td>
+                    <td class="govuk-table__cell" data-label="Date shared">@application.DateSharedWithEmployer.AsGdsDate()</td>
+                </tr>
+                <tr class="govuk-table__row" asp-show="@application.IsWithdrawn">
+                    <td class="govuk-table__cell" data-label="Applicant">@application.GetFriendlyId()</td>
+                    <td class="govuk-table__cell" data-label="Response">Withdrawn</td>
+                    <td class="govuk-table__cell" data-label="Date reviewed">@application.DateReviewedText</td>
+                    <td class="govuk-table__cell" data-label="Date shared">@application.DateSharedWithEmployer.AsGdsDate()</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+<div asp-show="@Model.HasNoApplications">
+    <p class="govuk-body">
+        No applications for @Model.SelectedLocation have been shared with you.
+    </p>
+</div>

--- a/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
@@ -157,7 +157,7 @@
     <div class="govuk-grid-column-two-thirds">
         <div>
             <h2 asp-show="@Model.ShowEmployerApplications" class="govuk-heading-m">
-                Applications (@Model.ApplicationCount)
+                Applications (@Model.TotalUnfilteredApplicationsCount)
             </h2>
         </div>
         <div asp-show="@Model.IsApplyThroughFaaVacancy">

--- a/src/Provider/Provider.Web/Orchestrators/VacancyManageOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacancyManageOrchestrator.cs
@@ -77,7 +77,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
                 Applications = string.IsNullOrEmpty(locationFilter)
                         ? applications
                         : applications.Where(fil => fil.CandidateAppliedLocations.Contains(locationFilter)).ToList(),
-                ApplicationsCount = applications.Count,
+                TotalUnfilteredApplicationsCount = applications.Count,
                 EmploymentLocations = vacancy.EmployerLocations.GetCityDisplayList(),
                 SelectedLocation = locationFilter,
                 ShowDisability = vacancy.IsDisabilityConfident,

--- a/src/Provider/Provider.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
@@ -17,9 +17,9 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.VacancyManage
         public bool IsApplyThroughFaaVacancy { get; internal set; }
 
         public VacancyApplicationsViewModel Applications { get; internal set; }
-        public bool HasApplications => ApplicationCount > 0;
-        public bool HasNoApplications => ApplicationCount == 0;
-        public int ApplicationCount => Applications?.ApplicationsCount ?? 0;
+        public bool HasApplications => TotalUnfilteredApplicationsCount > 0;
+        public bool HasNoApplications => TotalUnfilteredApplicationsCount == 0;
+        public int TotalUnfilteredApplicationsCount => Applications?.TotalUnfilteredApplicationsCount ?? 0;
         public bool CanShowEditVacancyLink { get; internal set; }
         public bool CanShowCloseVacancyLink { get; internal set; }
         public bool CanShowCloneVacancyLink { get; internal set; }

--- a/src/Provider/Provider.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
@@ -12,11 +12,14 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.VacancyView
 
         public List<string> EmploymentLocations { get; set; } = [];
         public string? SelectedLocation { get; set; }
-        public int ApplicationsCount { get; set; } = 0;
+        public int TotalUnfilteredApplicationsCount { get; set; } = 0;
 
-        public string FilteredApplicationLabelText => Applications.Count == 1
+        public string FilteredApplicationsLabelText => Applications.Count == 1
             ? "1 Application"
             : $"{Applications.Count} Applications";
+
+        public bool HasApplications => Applications is not null && Applications.Any();
+        public bool HasNoApplications => !HasApplications;
 
         public bool ShowDisability { get; internal set; }
 

--- a/src/Provider/Provider.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
+++ b/src/Provider/Provider.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
@@ -29,13 +29,12 @@
     <div class="govuk-grid-column-two-thirds">
         <div>
             <h2 class="govuk-heading-s">
-                @Model.FilteredApplicationLabelText
+                @Model.FilteredApplicationsLabelText
             </h2>
         </div>
     </div>
 </div>
-@if (Model.Applications.Count > 0)
-{
+<div asp-show="@Model.HasApplications">
     <table class="govuk-table das-table--responsive">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
@@ -62,12 +61,9 @@
             }
         </tbody>
     </table>
-}
-else
-{
-    <div>
-        <p class="govuk-body">
-            No applications for @Model.SelectedLocation have been received.
-        </p>
-    </div>
-}
+</div>
+<div asp-show="@Model.HasNoApplications">
+    <p class="govuk-body">
+        No applications for @Model.SelectedLocation have been received.
+    </p>
+</div>

--- a/src/Provider/Provider.Web/Views/VacancyManage/ManageVacancy.cshtml
+++ b/src/Provider/Provider.Web/Views/VacancyManage/ManageVacancy.cshtml
@@ -122,7 +122,7 @@
     <div class="govuk-grid-column-two-thirds">
         <div>
             <h2 class="govuk-heading-m">
-                Applications (@Model.ApplicationCount)
+                Applications (@Model.TotalUnfilteredApplicationsCount)
             </h2>
         </div>
         <div asp-show="@(Model.IsApplyThroughFaaVacancy || Model.IsApplyThroughFatVacancy)">

--- a/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/AddressExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Domain/Extensions/AddressExtensions.cs
@@ -54,6 +54,8 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
 
         public static string GetCities(this IEnumerable<Address> addresses)
         {
+            if (addresses == null) return string.Empty;
+
             // Group by city
             var cityGroups = addresses
                 .Where(a => !string.IsNullOrWhiteSpace(a.GetCity()))
@@ -75,6 +77,8 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
 
         public static List<string> GetCityDisplayList(this IEnumerable<Address> addresses)
         {
+            if (addresses == null) return [];
+
             var enumerable = addresses.ToList();
             if (!enumerable.Any())
             {
@@ -98,6 +102,7 @@ namespace Esfa.Recruit.Vacancies.Client.Domain.Extensions
             });
 
             return displayValues.ToList();
+
         }
 
         public static List<string> SplitCitiesToList(this string cities)

--- a/src/Shared/UnitTests/Shared.Web/Extensions/AddressExtensionsTests.cs
+++ b/src/Shared/UnitTests/Shared.Web/Extensions/AddressExtensionsTests.cs
@@ -129,7 +129,15 @@ public class AddressExtensionsTests
         result.Last().Should().HaveCount(3);
     }
 
-    [Test, MoqAutoData]
+    [Test]
+    public void GetCities_ReturnsEmptyString_When_Given_Null()
+    {
+        string result = ((IEnumerable<Address>)null).GetCities();
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
     public void GetCities_ReturnsEmptyString_WhenNoAddresses()
     {
         string result = new List<Address>().GetCities();
@@ -280,6 +288,19 @@ public class AddressExtensionsTests
         string input = "London, , Manchester,,Leeds, ";
         var result = input.SplitCitiesToList();
         result.Should().BeEquivalentTo(new List<string> { "London", "Manchester", "Leeds" });
+    }
+
+    [Test]
+    public void GetCityDisplayList_When_Given_Null_ShouldReturnEmptyList_WhenNoAddresses()
+    {
+        // Arrange
+        List<Address> addresses = null;
+
+        // Act
+        var result = addresses.GetCityDisplayList();
+
+        // Assert
+        result.Should().BeEmpty();
     }
 
     [Test]


### PR DESCRIPTION
✨ Refactor application count handling in view models

- Updated `VacancyApplicationsViewModel` to use `TotalUnfilteredApplicationsCount`.
- Renamed `FilteredApplicationLabelText` to `FilteredApplicationsLabelText`.
- Modified Razor views to utilize new properties for application counts.
- Introduced `HasApplications` and `HasNoApplications` for better checks.
- Added null checks in `AddressExtensions` and corresponding unit tests.

Changes made by Balaji Jambulingam