### PR TITLE
FAI-2630 - Always exclude withdrawn apps from get

### DIFF
--- a/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateApplicationReviewCommandHandler.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/CommandHandlers/CreateApplicationReviewCommandHandler.cs
@@ -36,7 +36,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.CommandHandlers
             var vacancy = await _vacancyRepository.GetVacancyAsync(message.Application.VacancyReference);
 
             var existingReview = await _applicationReviewRepository.GetAsync(vacancy.VacancyReference.Value, message.Application.CandidateId);
-            if (existingReview is { IsWithdrawn: false })
+            if (existingReview != null)
             {
                 _logger.LogWarning("Application review already exists for vacancyReference:{vacancyReference} and candidateId:{candidateId}. Found applicationReviewId:{applicationReviewId}",
                     vacancy.VacancyReference.Value, message.Application.CandidateId, existingReview.Id);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Repositories/MongoDbApplicationReviewRepository.cs
@@ -102,7 +102,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Repositories
         {
             var builder = Builders<Domain.Entities.ApplicationReview>.Filter;
             var filter = builder.Eq(r => r.VacancyReference, vacancyReference) &
-                         builder.Eq(r => r.CandidateId, candidateId);
+                         builder.Eq(r => r.CandidateId, candidateId) & 
+                         builder.Eq(r => r.IsWithdrawn, false);
 
             var collection = GetCollection<Domain.Entities.ApplicationReview>();
 


### PR DESCRIPTION
This method is only used to check if a user has already submitted, or if they can withdraw so having it always filter out withdrawn is ok