### PR TITLE
FAI-2424 Add pagination to the Vacancy manage page

### DIFF
--- a/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
+++ b/src/Employer/Employer.Web/Controllers/VacancyManageController.cs
@@ -23,12 +23,16 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         IUtility utility)
         : Controller
     {
+        // The number of vacancies displayed per page on the manage vacancies page
+        private const int PageSize = 20;
+
         [HttpGet("manage", Name = RouteNames.VacancyManage_Get)]
         public async Task<IActionResult> ManageVacancy(ManageVacancyRouteModel vrm,
             [FromQuery] string sortColumn,
             [FromQuery] string sortOrder,
             [FromQuery] bool vacancySharedByProvider,
-            [FromQuery] string locationFilter = "All")
+            [FromQuery] string locationFilter = "All",
+            [FromQuery] int page = 1)
         {
             EnsureProposedChangesCookiesAreCleared(vrm.VacancyId);
 
@@ -42,7 +46,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
                 return HandleRedirectOfEditableVacancy(vacancy);
             }
 
-            var viewModel = await orchestrator.GetManageVacancyViewModel(vacancy, outputSortColumn, outputSortOrder, vacancySharedByProvider, locationFilter);
+            var viewModel = await orchestrator.GetManageVacancyViewModel(vacancy, page, PageSize, outputSortColumn, outputSortOrder, vacancySharedByProvider, locationFilter);
 
             if (TempData.ContainsKey(TempDataKeys.VacancyClosedMessage))
                 viewModel.VacancyClosedInfoMessage = TempData[TempDataKeys.VacancyClosedMessage].ToString();

--- a/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Esfa.Recruit.Employer.Web.RouteModel;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 

--- a/src/Employer/Employer.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Esfa.Recruit.Employer.Web.RouteModel;
+using Esfa.Recruit.Shared.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
 
@@ -9,12 +10,15 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.VacancyManage
     public class VacancyApplicationsViewModel : VacancyRouteModel
     {
         public IEnumerable<VacancyApplication> Applications { get; internal set; }
+        public PagerViewModel Pager { get; internal set; }
         public List<string> EmploymentLocations { get; set; } = [];
         public string? SelectedLocation { get; set; }
         public int TotalUnfilteredApplicationsCount { get; set; } = 0;
-        public string FilteredApplicationsLabelText => Applications.Count() == 1
+        public int TotalFilteredApplicationsCount { get; set; } = 0;
+
+        public string FilteredApplicationsLabelText => TotalFilteredApplicationsCount == 1
             ? "1 Application"
-            : $"{Applications.Count()} Applications";
+            : $"{TotalFilteredApplicationsCount} Applications";
 
         public bool HasApplications => Applications != null && Applications.Any();
         public bool HasNoApplications => !HasApplications;

--- a/src/Employer/Employer.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
@@ -65,6 +65,31 @@
                 }
             </tbody>
         </table>
+        <nav role="navigation" aria-label="Pagination" asp-show="@Model.Pager.ShowPager" >
+            <div class="das-pagination__summary">
+                @Model.Pager.Caption
+            </div>
+            <ul class="das-pagination">
+                <li class="das-pagination__item" asp-show="@Model.Pager.ShowPrevious">
+                    <a class="das-pagination__link" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.PreviousPageRouteData" aria-label="Previous page">Previous</a>
+                </li>
+                @for (var pageIndex = 1; pageIndex <= Model.Pager.TotalPages; pageIndex++)
+                {
+                    <li class="das-pagination__item">
+                        @if (pageIndex == Model.Pager.CurrentPage) {
+                            <a class="das-pagination__link current" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-current="true" aria-label="Page @pageIndex, current page">@pageIndex</a>
+                        } 
+                        else 
+                        {
+                            <a class="das-pagination__link asp-route="  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-label="Page @pageIndex">@pageIndex</a>
+                        }
+                    </li>
+                }
+                <li class="das-pagination__item" asp-show="@Model.Pager.ShowNext">
+                    <a class="das-pagination__link"  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.NextPageRouteData" aria-label="Next page">Next</a>
+                </li>
+            </ul>
+        </nav>
     </div>
     <div asp-show="Model.HasNoApplications">
         <p class="govuk-body">

--- a/src/Employer/Employer.Web/Views/Shared/_VacancySharedApplicationsTablePartial.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_VacancySharedApplicationsTablePartial.cshtml
@@ -80,6 +80,31 @@
             }
         </tbody>
     </table>
+    <nav role="navigation" aria-label="Pagination" asp-show="@Model.Pager.ShowPager" >
+        <div class="das-pagination__summary">
+            @Model.Pager.Caption
+        </div>
+        <ul class="das-pagination">
+            <li class="das-pagination__item" asp-show="@Model.Pager.ShowPrevious">
+                <a class="das-pagination__link" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.PreviousPageRouteData" aria-label="Previous page">Previous</a>
+            </li>
+            @for (var pageIndex = 1; pageIndex <= Model.Pager.TotalPages; pageIndex++)
+            {
+                <li class="das-pagination__item">
+                    @if (pageIndex == Model.Pager.CurrentPage) {
+                        <a class="das-pagination__link current" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-current="true" aria-label="Page @pageIndex, current page">@pageIndex</a>
+                    } 
+                    else 
+                    {
+                        <a class="das-pagination__link asp-route="  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-label="Page @pageIndex">@pageIndex</a>
+                    }
+                </li>
+            }
+            <li class="das-pagination__item" asp-show="@Model.Pager.ShowNext">
+                <a class="das-pagination__link"  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.NextPageRouteData" aria-label="Next page">Next</a>
+            </li>
+        </ul>
+    </nav>
 </div>
 <div asp-show="@Model.HasNoApplications">
     <p class="govuk-body">

--- a/src/Employer/Employer.Web/wwwroot/javascripts/application.js
+++ b/src/Employer/Employer.Web/wwwroot/javascripts/application.js
@@ -487,8 +487,16 @@ if (locationFilterSelect) {
         const locationValue = e.target.value;
         const queryString = window.location.search;
         const params = new URLSearchParams(queryString);
-        params.delete("locationFilter");
+        for (const key of [...params.keys()]) {
+            if (key.toLowerCase() === "locationfilter") {
+                params.delete(key);
+            }
+            if (key.toLowerCase() === "page") {
+                params.delete(key);
+            }
+        }
         params.append("locationFilter", locationValue);
+        params.append("page", 1);
         document.location.href = "?" + params.toString();
     });
 }

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/VacancyManageOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/VacancyManageOrchestratorTests.cs
@@ -73,7 +73,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators
                 .ReturnsAsync(vacancyApplications);
 
             // Act
-            var viewModel = await _orchestrator.GetManageVacancyViewModel(vacancy, sortColumn, sortOrder, vacancyShared);
+            var viewModel = await _orchestrator.GetManageVacancyViewModel(vacancy, 1, 20, sortColumn, sortOrder, vacancyShared);
 
             // Assert
             Assert.That(_vacancyId, Is.EqualTo(viewModel.VacancyId));

--- a/src/Provider/Provider.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/VacancyManage/ManageVacancyViewModel.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Esfa.Recruit.Provider.Web.RouteModel;
 using Esfa.Recruit.Provider.Web.ViewModels.VacancyView;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;

--- a/src/Provider/Provider.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/VacancyView/VacancyApplicationsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Esfa.Recruit.Provider.Web.RouteModel;
+using Esfa.Recruit.Shared.Web.ViewModels;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.QueryStore.Projections.VacancyApplications;
 
@@ -10,13 +11,16 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.VacancyView
     {
         public List<VacancyApplication> Applications { get; set; }
 
+        public PagerViewModel Pager { get; internal set; }
+
         public List<string> EmploymentLocations { get; set; } = [];
         public string? SelectedLocation { get; set; }
         public int TotalUnfilteredApplicationsCount { get; set; } = 0;
+        public int TotalFilteredApplicationsCount { get; set; } = 0;
 
-        public string FilteredApplicationsLabelText => Applications.Count == 1
+        public string FilteredApplicationsLabelText => TotalFilteredApplicationsCount == 1
             ? "1 Application"
-            : $"{Applications.Count} Applications";
+            : $"{TotalFilteredApplicationsCount} Applications";
 
         public bool HasApplications => Applications is not null && Applications.Any();
         public bool HasNoApplications => !HasApplications;

--- a/src/Provider/Provider.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
+++ b/src/Provider/Provider.Web/Views/Shared/_VacancyApplicationsTablePartial.cshtml
@@ -61,6 +61,31 @@
             }
         </tbody>
     </table>
+    <nav role="navigation" aria-label="Pagination" asp-show="@Model.Pager.ShowPager" >
+        <div class="das-pagination__summary">
+            @Model.Pager.Caption
+        </div>
+        <ul class="das-pagination">
+            <li class="das-pagination__item" asp-show="@Model.Pager.ShowPrevious">
+                <a class="das-pagination__link" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.PreviousPageRouteData" aria-label="Previous page">Previous</a>
+            </li>
+            @for (var pageIndex = 1; pageIndex <= Model.Pager.TotalPages; pageIndex++)
+            {
+                <li class="das-pagination__item">
+                    @if (pageIndex == Model.Pager.CurrentPage) {
+                        <a class="das-pagination__link current" asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-current="true" aria-label="Page @pageIndex, current page">@pageIndex</a>
+                    } 
+                    else 
+                    {
+                        <a class="das-pagination__link asp-route="  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.GetRouteData(pageIndex)" aria-label="Page @pageIndex">@pageIndex</a>
+                    }
+                </li>
+            }
+            <li class="das-pagination__item" asp-show="@Model.Pager.ShowNext">
+                <a class="das-pagination__link"  asp-route="@Model.Pager.RouteName" asp-all-route-data="@Model.Pager.NextPageRouteData" aria-label="Next page">Next</a>
+            </li>
+        </ul>
+    </nav>
 </div>
 <div asp-show="@Model.HasNoApplications">
     <p class="govuk-body">

--- a/src/Provider/Provider.Web/wwwroot/javascripts/application.js
+++ b/src/Provider/Provider.Web/wwwroot/javascripts/application.js
@@ -654,8 +654,12 @@ if (locationFilterSelect) {
             if (key.toLowerCase() === "locationfilter") {
                 params.delete(key);
             }
+            if (key.toLowerCase() === "page") {
+                params.delete(key);
+            }
         }
         params.append("locationFilter", locationValue);
+        params.append("page", 1);
         document.location.href = "?" + params.toString();
     });
 }


### PR DESCRIPTION
✨ Add pagination to vacancy management functionality

- Updated `VacancyManageController` to support pagination with `page` parameter.
- Enhanced `GetManageVacancyViewModel` in `VacancyManageOrchestrator` for pagination.
- Modified `VacancyApplicationsViewModel` to include `Pager` property.
- Updated Razor views to include pagination controls for applications.
- Adjusted `application.js` to reset `page` parameter on location filter change.

Changes made by Balaji Jambulingam