### PR TITLE
FAI-2733 Bug Dashboard Numbers not matching

### DIFF
--- a/src/Provider/Provider.Web/Orchestrators/VacanciesOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacanciesOrchestrator.cs
@@ -48,7 +48,8 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
 
             await Task.WhenAll(getDashboardTask, getUserDetailsTask, providerTask);
             
-            long providerVacancyCountTask = getDashboardTask.Result?.TotalVacancies ?? await _providerVacancyClient.GetVacancyCount(user.Ukprn.Value, filteringOption, searchTerm);//TODO FAI-2541 - ignore this for ones for applications
+            long providerVacancyCountTask = getDashboardTask.Result?.TotalVacancies 
+                                            ?? await _providerVacancyClient.GetVacancyCount(user.Ukprn.Value, filteringOption, searchTerm);//TODO FAI-2541 - ignore this for ones for applications
 
             var dashboard = getDashboardTask.Result;
             var userDetails = getUserDetailsTask.Result;

--- a/src/Provider/Provider.Web/Orchestrators/VacanciesOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/VacanciesOrchestrator.cs
@@ -17,49 +17,36 @@ using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship
 
 namespace Esfa.Recruit.Provider.Web.Orchestrators
 {
-    public class VacanciesOrchestrator
+    public class VacanciesOrchestrator(
+        IProviderVacancyClient providerVacancyClient,
+        IRecruitVacancyClient recruitVacancyClient,
+        IProviderAlertsViewModelFactory providerAlertsViewModelFactory,
+        IProviderRelationshipsService providerRelationshipsService)
     {
         private const int VacanciesPerPage = 25;
-        private readonly IProviderVacancyClient _providerVacancyClient;
-        private readonly IRecruitVacancyClient _recruitVacancyClient;
-        private readonly IProviderAlertsViewModelFactory _providerAlertsViewModelFactory;
-        private readonly IProviderRelationshipsService _providerRelationshipsService;
-
-        public VacanciesOrchestrator(
-            IProviderVacancyClient providerVacancyClient,
-            IRecruitVacancyClient recruitVacancyClient,
-            IProviderAlertsViewModelFactory providerAlertsViewModelFactory,
-            IProviderRelationshipsService providerRelationshipsService)
-        {
-            _providerVacancyClient = providerVacancyClient;
-            _recruitVacancyClient = recruitVacancyClient;
-            _providerAlertsViewModelFactory = providerAlertsViewModelFactory;
-            _providerRelationshipsService = providerRelationshipsService;
-        }
 
         public async Task<VacanciesViewModel> GetVacanciesViewModelAsync(
             VacancyUser user, string filter, int page, string searchTerm)
         {
             var filteringOption = SanitizeFilter(filter);
-            var getDashboardTask = _providerVacancyClient.GetDashboardAsync(user.Ukprn.Value, page, filteringOption, searchTerm);
-            var getUserDetailsTask = _recruitVacancyClient.GetUsersDetailsByDfEUserId(user.DfEUserId) ?? _recruitVacancyClient.GetUsersDetailsAsync(user.UserId);
-            var providerTask = _providerRelationshipsService.CheckProviderHasPermissions(user.Ukprn.Value, OperationType.RecruitmentRequiresReview);
+            var getDashboardTask = providerVacancyClient.GetDashboardAsync(user.Ukprn!.Value, page, filteringOption, searchTerm);
+            var getUserDetailsTask = recruitVacancyClient.GetUsersDetailsByDfEUserId(user.DfEUserId) ?? recruitVacancyClient.GetUsersDetailsAsync(user.UserId);
+            var providerTask = providerRelationshipsService.CheckProviderHasPermissions(user.Ukprn.Value, OperationType.RecruitmentRequiresReview);
             
 
             await Task.WhenAll(getDashboardTask, getUserDetailsTask, providerTask);
             
             long providerVacancyCountTask = getDashboardTask.Result?.TotalVacancies 
-                                            ?? await _providerVacancyClient.GetVacancyCount(user.Ukprn.Value, filteringOption, searchTerm);//TODO FAI-2541 - ignore this for ones for applications
+                                            ?? await providerVacancyClient.GetVacancyCount(user.Ukprn.Value, filteringOption, searchTerm);//TODO FAI-2541 - ignore this for ones for applications
 
             var dashboard = getDashboardTask.Result;
             var userDetails = getUserDetailsTask.Result;
-            var providerPermissions = providerTask.Result;
-            var vacancyCount = providerVacancyCountTask;
-            var totalItems = Convert.ToInt32(vacancyCount);
+            bool providerPermissions = providerTask.Result;
+            int totalItems = Convert.ToInt32(providerVacancyCountTask);
 
-            var alerts = _providerAlertsViewModelFactory.Create(dashboard, userDetails);
+            var alerts = providerAlertsViewModelFactory.Create(dashboard, userDetails);
 
-            var vacancies = new List<VacancySummary>(dashboard?.Vacancies ?? Array.Empty<VacancySummary>());
+            var vacancies = new List<VacancySummary>(dashboard?.Vacancies ?? []);
             
             page = SanitizePage(page, totalItems);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/OuterApi/Requests/GetEmployerDashboardVacanciesApiRequest.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/OuterApi/Requests/GetEmployerDashboardVacanciesApiRequest.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.OuterApi.Requests;
 
-public record GetEmployerDashboardVacanciesApiRequest(long AccountId,int PageNumber, List<ApplicationReviewStatus> ApplicationReviewStatuses) : IGetApiRequest
+public record GetEmployerDashboardVacanciesApiRequest(long AccountId, int PageNumber, int PageSize, List<ApplicationReviewStatus> ApplicationReviewStatuses) : IGetApiRequest
 {
-    public string GetUrl => $"employerAccounts/{AccountId}/dashboard/vacancies?pageNumber={PageNumber}&status={string.Join("&status=",ApplicationReviewStatuses)}";
+    public string GetUrl => $"employerAccounts/{AccountId}/dashboard/vacancies?pageNumber={PageNumber}&pageSize={PageSize}&status={string.Join("&status=", ApplicationReviewStatuses)}";
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/OuterApi/Requests/GetProviderDashboardVacanciesApiRequest.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/OuterApi/Requests/GetProviderDashboardVacanciesApiRequest.cs
@@ -3,7 +3,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 
 namespace Esfa.Recruit.Vacancies.Client.Infrastructure.OuterApi.Requests;
 
-public record GetProviderDashboardVacanciesApiRequest(long Ukprn,int PageNumber, List<ApplicationReviewStatus> ApplicationReviewStatuses) : IGetApiRequest
+public record GetProviderDashboardVacanciesApiRequest(long Ukprn, int PageNumber, int PageSize, List<ApplicationReviewStatus> ApplicationReviewStatuses) : IGetApiRequest
 {
-    public string GetUrl => $"providers/dashboard/{Ukprn}/vacancies?pageNumber={PageNumber}&status={string.Join("&status=",ApplicationReviewStatuses)}";
+    public string GetUrl => $"providers/dashboard/{Ukprn}/vacancies?pageNumber={PageNumber}&pageSize={PageSize}&status={string.Join("&status=",ApplicationReviewStatuses)}";
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/EmployerAccountProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/EmployerAccountProvider.cs
@@ -159,13 +159,16 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount
                     }
                 });
         }
-        public async Task<GetVacanciesDashboardResponse> GetEmployerVacancyDashboardStats(string hashedAccountId, int pageNumber, List<ApplicationReviewStatus> statuses)
+        public async Task<GetVacanciesDashboardResponse> GetEmployerVacancyDashboardStats(string hashedAccountId,
+            List<ApplicationReviewStatus> statuses,
+            int pageNumber = 1,
+            int pageSize = 25)
         {
             var retryPolicy = PollyRetryPolicy.GetPolicy();
             long accountId = encodingService.Decode(hashedAccountId, EncodingType.AccountId);
 
             return await retryPolicy.Execute(_ => outerApiClient.Get<GetVacanciesDashboardResponse>(
-                    new GetEmployerDashboardVacanciesApiRequest(accountId,pageNumber,statuses)),
+                    new GetEmployerDashboardVacanciesApiRequest(accountId, pageNumber, pageSize, statuses)),
                 new Dictionary<string, object>
                 {
                     {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/IEmployerAccountProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerAccount/IEmployerAccountProvider.cs
@@ -22,6 +22,9 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.EmployerAccount
             string sortColumn,
             bool isAscending);
 
-        Task<GetVacanciesDashboardResponse> GetEmployerVacancyDashboardStats(string hashedAccountId, int pageNumber, List<ApplicationReviewStatus> statuses);
+        Task<GetVacanciesDashboardResponse> GetEmployerVacancyDashboardStats(string hashedAccountId,
+            List<ApplicationReviewStatus> statuses,
+            int pageNumber,
+            int pageSize);
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/ITrainingProviderService.cs
@@ -35,11 +35,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
         
         
         /// <summary>
-        /// Contract to get the vacancies under a application review statuses.
+        /// Contract to get the vacancies under an application review statuses.
         /// </summary>
         /// <returns></returns>
         Task<GetVacanciesDashboardResponse> GetProviderDashboardVacanciesByApplicationReviewStatuses(long ukprn,
-            List<ApplicationReviewStatus> vacancyReferences, int pageNumber);
+            List<ApplicationReviewStatus> vacancyReferences, int pageNumber, int pageSize);
 
         Task<IEnumerable<TrainingProviderSummary>> GetCourseProviders(int programmeId);
     }

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/TrainingProvider/TrainingProviderService.cs
@@ -92,12 +92,16 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider
                 });
         }
 
-        public async Task<GetVacanciesDashboardResponse> GetProviderDashboardVacanciesByApplicationReviewStatuses(long ukprn, List<ApplicationReviewStatus> vacancyReferences, int pageNumber)
+        public async Task<GetVacanciesDashboardResponse> GetProviderDashboardVacanciesByApplicationReviewStatuses(
+            long ukprn,
+            List<ApplicationReviewStatus> applicationReviewStatusList,
+            int pageNumber = 1,
+            int pageSize = 25)
         {
             var retryPolicy = PollyRetryPolicy.GetPolicy();
 
             return await retryPolicy.Execute(_ => outerApiClient.Get<GetVacanciesDashboardResponse>(
-                    new GetProviderDashboardVacanciesApiRequest(ukprn,pageNumber,vacancyReferences)),
+                    new GetProviderDashboardVacanciesApiRequest(ukprn, pageNumber, pageSize, applicationReviewStatusList)),
                 new Dictionary<string, object>
                 {
                     {

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
@@ -197,7 +197,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 }
             };
 
-
+            // FAI-2733: Temporary fix to get all results for the provider. For more information, please check the ticket FAI-2733.
+            // This whole logic could be simplified by having the business logic in the recruit inner api layer. Once we migrate the Vacancy Reviews to Sql, we can remove this logic.
             BsonDocument vacancyReferenceMatch = null; 
             int? totalCount = null;
             if (status is FilteringOptions.EmployerReviewedApplications or FilteringOptions.AllApplications or FilteringOptions.NewApplications)
@@ -225,7 +226,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                     ukprn,
                     applicationReviewStatusList,
                     1, //override
-                    1000); // Get all results for the provider. Temp fix until Vacancy Reviews are migrated to Sql.
+                    1000); // FAI-2733: Get all results for the provider. Temp fix until Vacancy Reviews are migrated to Sql.
 
                 refs.Add("vacancyReference", new BsonDocument { { "$in", new BsonArray(results.Items.Select(result => result.VacancyReference).ToArray()) } });
                 vacancyReferenceMatch = new BsonDocument{
@@ -254,11 +255,11 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
 
             var dashboardStats = await _trainingProviderService.GetProviderDashboardApplicationReviewStats(ukprn, vacancyReferences);
 
-            var applicationReviewStatsLookup = dashboardStats.ApplicationReviewStatsList
+            var applicationReviewStatsLookup = dashboardStats
+                .ApplicationReviewStatsList
                 .ToDictionary(x => x.VacancyReference);
 
             var tempCount = 0;
-            var unknownCount = 0;
 
             foreach (var vacancySummary in pipelineResult)
             {
@@ -266,7 +267,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                     !applicationReviewStatsLookup.TryGetValue(vacancySummary.VacancyReference.Value,
                         out var applicationReview))
                 {
-                    unknownCount++;
                     continue;
                 }
 
@@ -280,10 +280,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 tempCount += vacancySummary.NoOfNewApplications;
             }
 
-            Console.WriteLine(tempCount);
-            Console.WriteLine(unknownCount);
-
-            return (pipelineResult,totalCount);
+            return (pipelineResult, totalCount);
         }
 
         public async Task<(IList<VacancySummary>, int? totalCount)> GetEmployerOwnedVacancySummariesByEmployerAccountId(string employerAccountId, int page,
@@ -348,8 +345,12 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                         break;
                 }
 
-                var results = await _employerAccountProvider.GetEmployerVacancyDashboardStats(employerAccountId,page,
-                    applicationReviewStatusList);
+                // FAI-2733: Temporary fix to get all results for the employer. For more information, please check the ticket FAI-2733.
+                // This whole logic could be simplified by having the business logic in the recruit inner api layer. Once we migrate the Vacancy Reviews to Sql, we can remove this logic.
+                var results = await _employerAccountProvider.GetEmployerVacancyDashboardStats(employerAccountId,
+                    applicationReviewStatusList,
+                    1,
+                    1000); // FAI-2733: Get all results for the employer. Temp fix until Vacancy Reviews are migrated to Sql.
                 
                 refs.Add("vacancyReference", new BsonDocument { { "$in", new BsonArray(results.Items.Select(result => result.VacancyReference).ToArray()) } });
                 vacancyReferenceMatch = new BsonDocument{
@@ -387,7 +388,10 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
             {
                 if (!vacancySummary.VacancyReference.HasValue ||
                     !applicationReviewStatsLookup.TryGetValue(vacancySummary.VacancyReference.Value,
-                        out var applicationReview)) continue;
+                        out var applicationReview))
+                {
+                    continue;
+                }
 
                 vacancySummary.NoOfSuccessfulApplications = applicationReview.SuccessfulApplications;
                 vacancySummary.NoOfUnsuccessfulApplications = applicationReview.UnsuccessfulApplications;
@@ -397,7 +401,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 vacancySummary.NoOfEmployerReviewedApplications = applicationReview.EmployerReviewedApplications;
             }
 
-            return (pipelineResult,totalCount);
+            return (pipelineResult, totalCount);
         }
 
         public async Task<IList<TransferInfo>> GetTransferredFromProviderAsync(long ukprn)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummariesProvider.cs
@@ -366,7 +366,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
 
             var pipelineResult = await RunAggPipelineQuery(aggPipeline);
 
-            // If the Mongo migration feature is enabled, retrieve the application review stats
             var vacancyReferences = pipelineResult
                 .Where(x => x.VacancyReference.HasValue)
                 .Select(x => x.VacancyReference.Value)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
@@ -779,8 +779,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 pipeline.Insert(index, vacancyRefMatch);
             }
             
-            pipeline.Insert(pipeline.Count, new BsonDocument { { "$skip", (pageNumber - 1) * 100 } });
-            pipeline.Insert(pipeline.Count, new BsonDocument { { "$limit", 100 } });
+            pipeline.Insert(pipeline.Count, new BsonDocument { { "$skip", (pageNumber - 1) * 25 } });
+            pipeline.Insert(pipeline.Count, new BsonDocument { { "$limit", 25 } });
             
             pipeline.Insert(0, vacanciesMatchClause);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/VacancySummariesProvider/VacancySummaryAggQueryBuilder.cs
@@ -779,8 +779,8 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Services.VacancySummaries
                 pipeline.Insert(index, vacancyRefMatch);
             }
             
-            pipeline.Insert(pipeline.Count, new BsonDocument { { "$skip", (pageNumber - 1) * 25 } });
-            pipeline.Insert(pipeline.Count, new BsonDocument { { "$limit", 25 } });
+            pipeline.Insert(pipeline.Count, new BsonDocument { { "$skip", (pageNumber - 1) * 100 } });
+            pipeline.Insert(pipeline.Count, new BsonDocument { { "$limit", 100 } });
             
             pipeline.Insert(0, vacanciesMatchClause);
 

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/OuterApi/Requests/WhenBuildingGetEmployerVacanciesDashboardApiRequest.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/OuterApi/Requests/WhenBuildingGetEmployerVacanciesDashboardApiRequest.cs
@@ -12,10 +12,11 @@ public class WhenBuildingGetEmployerVacanciesDashboardApiRequest
     public void Then_It_Is_Correctly_Constructed(
         int accountId,
         List<ApplicationReviewStatus> status,
-        int pageNumber)
+        int pageNumber,
+        int pageSize)
     {
-        var actual = new GetEmployerDashboardVacanciesApiRequest(accountId, pageNumber, status);
+        var actual = new GetEmployerDashboardVacanciesApiRequest(accountId, pageNumber, pageSize, status);
 
-        actual.GetUrl.Should().Be($"employerAccounts/{accountId}/dashboard/vacancies?pageNumber={pageNumber}&status={string.Join("&status=", status)}");
+        actual.GetUrl.Should().Be($"employerAccounts/{accountId}/dashboard/vacancies?pageNumber={pageNumber}&pageSize={pageSize}&status={string.Join("&status=", status)}");
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/OuterApi/Requests/WhenBuildingGetProviderVacanciesDashboardApiRequest.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/OuterApi/Requests/WhenBuildingGetProviderVacanciesDashboardApiRequest.cs
@@ -12,10 +12,11 @@ public class WhenBuildingGetProviderVacanciesDashboardApiRequest
     public void Then_It_Is_Correctly_Constructed(
         int ukprn,
         List<ApplicationReviewStatus> status,
-        int pageNumber)
+        int pageNumber,
+        int pageSize)
     {
-        var actual = new GetProviderDashboardVacanciesApiRequest(ukprn, pageNumber, status);
+        var actual = new GetProviderDashboardVacanciesApiRequest(ukprn, pageNumber, pageSize, status);
 
-        actual.GetUrl.Should().Be($"providers/dashboard/{ukprn}/vacancies?pageNumber={pageNumber}&status={string.Join("&status=", status)}");
+        actual.GetUrl.Should().Be($"providers/dashboard/{ukprn}/vacancies?pageNumber={pageNumber}&pageSize={pageSize}&status={string.Join("&status=", status)}");
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/EmployerAccount/EmployerAccountProviderTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/EmployerAccount/EmployerAccountProviderTests.cs
@@ -66,6 +66,7 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructur
             string hashedAccountId,
             long accountId,
             int pageNumber, 
+            int pageSize,
             List<ApplicationReviewStatus> statuses,
             GetVacanciesDashboardResponse response,
             [Frozen] Mock<IEncodingService> encodingService,
@@ -75,12 +76,12 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructur
             encodingService.Setup(x => x.Decode(hashedAccountId, EncodingType.AccountId))
                 .Returns(accountId);
 
-            var expectedGetUrl = new GetEmployerDashboardVacanciesApiRequest(accountId, pageNumber, statuses);
+            var expectedGetUrl = new GetEmployerDashboardVacanciesApiRequest(accountId, pageNumber, pageSize, statuses);
             outerApiClient.Setup(x => x.Get<GetVacanciesDashboardResponse>(
                     It.Is<GetEmployerDashboardVacanciesApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
                 .ReturnsAsync(response);
 
-            var result = await employerAccountProvider.GetEmployerVacancyDashboardStats(hashedAccountId, pageNumber, statuses);
+            var result = await employerAccountProvider.GetEmployerVacancyDashboardStats(hashedAccountId, statuses, pageNumber, pageSize);
 
 
             result.Should().BeEquivalentTo(response);

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/TrainingProviderServiceTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Services/TrainingProviderServiceTests.cs
@@ -109,17 +109,18 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Infrastructur
         public async Task GetProviderDashboardVacanciesByApplicationReviewStatuses_Should_Return_As_Expected(
             long ukprn,
             int pageNumber,
+            int pageSize,
             List<ApplicationReviewStatus> status,
             GetVacanciesDashboardResponse response,
             [Frozen] Mock<IOuterApiClient> outerApiClient,
             [Greedy] TrainingProviderService trainingProviderService)
         {
-            var expectedGetUrl = new GetProviderDashboardVacanciesApiRequest(ukprn, pageNumber, status);
+            var expectedGetUrl = new GetProviderDashboardVacanciesApiRequest(ukprn, pageNumber, pageSize, status);
             outerApiClient.Setup(x => x.Get<GetVacanciesDashboardResponse>(
                     It.Is<GetProviderDashboardVacanciesApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
                 .ReturnsAsync(response);
 
-            var result = await trainingProviderService.GetProviderDashboardVacanciesByApplicationReviewStatuses(ukprn, status, pageNumber);
+            var result = await trainingProviderService.GetProviderDashboardVacanciesByApplicationReviewStatuses(ukprn, status, pageNumber, pageSize);
 
             result.Should().BeEquivalentTo(response);
         }


### PR DESCRIPTION
Notes on Mismatched Numbers
Issue 1: Pagination Limit

The method used to fetch the count for a given status and UKPRN defaulted to a page size of 25.

This caused a discrepancy between the vacancy references retrieved from the Mongo collection and the list returned by the Recruit Inner API, since the API only returned 25 items at a time.

Fix:

The default page size has been increased to 1000 as a temporary solution, until the full migration of VacancyReviews to SQL is complete.

Issue 2: OwnerType Inconsistency

There are some vacancies (e.g., 1000010503, 1000014343) where permissions were revoked.

For these vacancies, the OwnerType is showing as Employer, even though the source is showing correctly as ProviderWeb.

In the Recruit SQL, the OwnerType is still showing as Provider.

This mismatch occurs because vacancy information is being pulled from two different sources, leading to data inconsistency.

Fix:

Once the migration is fully complete, this issue will be resolved.