### PR TITLE
FAI-2375 - Make sure error not thrown if country not found

### DIFF
--- a/src/API/Recruit.Api/Commands/CreateVacancyCommandHandler.cs
+++ b/src/API/Recruit.Api/Commands/CreateVacancyCommandHandler.cs
@@ -160,7 +160,7 @@ namespace SFA.DAS.Recruit.Api.Commands
             {
                 if (x.Country is null && results.TryGetValue(x.Postcode, out var postcodeData))
                 {
-                    x.Country = postcodeData.Country;
+                    x.Country = postcodeData?.Country;
                 }
             });
         }


### PR DESCRIPTION
Change made so that if the postcode isnt found it doesnt result in an exception being thrown and 500 error response returned