### PR TITLE
FAI-2754 Update QA review screen to ensure long URLs wrap

### DIFF
--- a/src/QA/QA.Web/Views/Review/ReadonlyReview.cshtml
+++ b/src/QA/QA.Web/Views/Review/ReadonlyReview.cshtml
@@ -274,7 +274,7 @@
         <div asp-show="@Model.HasApplicationUrl" id="@Anchors.ApplicationUrl">
             <h3 class="govuk-heading-s">Application website</h3>
             <p class="govuk-body">
-                <a href="@Model.ApplicationUrl" class="govuk-link govuk-link--no-visited-state das-breakable" target="_blank" rel="noopener noreferrer">
+                    <a href="@Model.ApplicationUrl" class="govuk-link govuk-link--no-visited-state das-breakable das-hyperlink-wrapper" target="_blank" rel="noopener noreferrer">
                     @Model.ApplicationUrl
                 </a>
             </p>

--- a/src/QA/QA.Web/Views/Review/Review.cshtml
+++ b/src/QA/QA.Web/Views/Review/Review.cshtml
@@ -478,7 +478,7 @@
                         <div class="@Model.ApplicationUrlClass" id="@FieldIdentifiers.ApplicationUrl">
                             <h3 class="govuk-heading-s">Application website link</h3>
                             <p class="govuk-body">
-                                <a href="@Model.ApplicationUrl" class="govuk-link govuk-link--no-visited-state das-breakable" target="_blank" rel="noopener noreferrer">
+                                <a href="@Model.ApplicationUrl" class="govuk-link govuk-link--no-visited-state das-breakable das-hyperlink-wrapper" target="_blank" rel="noopener noreferrer">
                                     @Model.ApplicationUrl
                                 </a>
                             </p>

--- a/src/QA/QA.Web/wwwroot/css/application.css
+++ b/src/QA/QA.Web/wwwroot/css/application.css
@@ -486,3 +486,9 @@ mce-tinymce {
 .float-right {
     float: right;
 }
+
+.das-hyperlink-wrapper {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+}


### PR DESCRIPTION
✨ Enhance application URL links and styling

- Added `das-hyperlink-wrapper` class to anchor elements.
- Ensured application URLs are displayed as clickable text.
- Introduced CSS styles for improved text wrapping and display.
- Modified `.float-right` class for better element positioning.
- Improved overall link responsiveness and visual appeal.

Changes made by Balaji Jambulingam