### PR TITLE
FAI-2781 Incorrect link style on provider recruit select training screen

### DIFF
--- a/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
+++ b/src/Provider/Provider.Web/Views/Part1/Training/Training.cshtml
@@ -18,7 +18,7 @@
         </h1>
         <p class="govuk-body">
             You can choose from the standards you've added.
-            <a asp-external-controller="standards" asp-external-subdomain="roatp" asp-external-id="@Model.Ukprn">Manage your standards</a>
+            <a asp-external-controller="standards" asp-external-subdomain="roatp" asp-external-id="@Model.Ukprn" class="govuk-link govuk-link--no-visited-state">Manage your standards</a>
             to add more.
         </p>
         <form asp-route="@RouteNames.Training_Post" asp-route-vacancyId="@Model.VacancyId" asp-route-ukprn="@Model.Ukprn" asp-route-wizard="@Model.PageInfo.IsWizard" novalidate>


### PR DESCRIPTION
✨ Enhance link styling in Training.cshtml

- Added `govuk-link` and `govuk-link--no-visited-state` classes.
- Improved the appearance and behavior of the standards management link.
- Ensured consistency with other links in the application.

Changes made by Balaji Jambulingam