### PR TITLE
FAI-3340 HotFix Employer profile not found in recruit journey is causing a 500 in recruit frontend

### DIFF
--- a/src/API/Recruit.Api/Commands/CreateVacancyCommandHandler.cs
+++ b/src/API/Recruit.Api/Commands/CreateVacancyCommandHandler.cs
@@ -214,6 +214,7 @@ public class CreateVacancyCommandHandler(
                 draftVacancyFromRequest.EmployerAccountId,
                 draftVacancyFromRequest.AccountLegalEntityPublicHashedId);
             employerProfile.TradingName = draftVacancyFromRequest.EmployerName;
+            await recruitVacancyClient.UpdateEmployerProfileAsync(employerProfile);
         }
             
         if (requiresEmployerReview)

--- a/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/Part2/AboutEmployerOrchestrator.cs
@@ -108,6 +108,7 @@ public class AboutEmployerOrchestrator(
         if (employerProfile.AboutOrganisation != employerDescription)
         {
             employerProfile.AboutOrganisation = employerDescription;
+            await vacancyClient.UpdateEmployerProfileAsync(employerProfile);
         }
     }
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
@@ -56,7 +56,7 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
         return result.EmployerProfiles.Select(MapEmployerProfile).ToList();
     }
 
-    public async Task<Domain.Entities.EmployerProfile> GetAsync(string hashedAccountId,
+    public async Task<Domain.Entities.EmployerProfile> GetAsync(string employerAccountId,
         string accountLegalEntityPublicHashedId)
     {
         logger.LogTrace("Getting employer profile Details from Outer Api");

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
@@ -59,17 +59,30 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
     public async Task<Domain.Entities.EmployerProfile> GetAsync(string employerAccountId,
         string accountLegalEntityPublicHashedId)
     {
-        logger.LogTrace("Getting employer profile Details from Outer Api");
+        logger.LogTrace("Getting employer profile details from Outer API");
 
         var retryPolicy = PollyRetryPolicy.GetPolicy();
 
-        var legalEntityId = encodingService.Decode(accountLegalEntityPublicHashedId, EncodingType.PublicAccountLegalEntityId);
+        var legalEntityId = encodingService.Decode(accountLegalEntityPublicHashedId,
+            EncodingType.PublicAccountLegalEntityId);
 
-        var result = await retryPolicy.Execute(_ =>
-                outerApiClient.Get<GetEmployerProfilesByLegalEntityIdResponse>(new GetEmployerProfileByLegalEntityIdRequest(legalEntityId)),
+        var result = await retryPolicy.Execute(_ => outerApiClient.Get<GetEmployerProfilesByLegalEntityIdResponse>(
+                new GetEmployerProfileByLegalEntityIdRequest(legalEntityId)),
             _apiLoggingContext);
 
-        return MapEmployerProfile(result.EmployerProfile);
+        if (result?.EmployerProfile != null)
+            return MapEmployerProfile(result.EmployerProfile);
+
+        logger.LogInformation("No employer profile found for LegalEntityId {LegalEntityId}, creating new profile", legalEntityId);
+
+        var newProfile = new Domain.Entities.EmployerProfile
+        {
+            AccountLegalEntityPublicHashedId = accountLegalEntityPublicHashedId,
+            EmployerAccountId = employerAccountId
+        };
+
+        await CreateAsync(newProfile);
+        return newProfile;
     }
 
     public async Task UpdateAsync(Domain.Entities.EmployerProfile profile)

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Services/EmployerProfile/EmployerProfileService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Recruit.Vacancies.Client.Domain.EmployerProfiles;
@@ -16,6 +15,13 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
     IOuterApiClient outerApiClient,
     IEncodingService encodingService) : IEmployerProfileService
 {
+    private readonly Dictionary<string, object> _apiLoggingContext = new()
+    {
+        {
+            "apiCall", "EmployerProfile"
+        }
+    };
+
     public async Task CreateAsync(Domain.Entities.EmployerProfile profile)
     {
         logger.LogTrace("Posting Employer Provider details to Outer Api");
@@ -32,12 +38,7 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
                     AboutOrganisation = profile.AboutOrganisation,
                     TradingName = profile.TradingName
                 })),
-            new Dictionary<string, object>
-            {
-                {
-                    "apiCall", "EmployerProfile"
-                }
-            });
+            _apiLoggingContext);
     }
 
     public async Task<IList<Domain.Entities.EmployerProfile>> GetEmployerProfilesForEmployerAsync(
@@ -50,12 +51,7 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
         var accountId = encodingService.Decode(hashedAccountId, EncodingType.AccountId);
         var result = await retryPolicy.Execute(_ =>
                 outerApiClient.Get<GetEmployerProfilesByAccountIdResponse>(new GetEmployerProfilesByAccountIdRequest(accountId)),
-            new Dictionary<string, object>
-            {
-                {
-                    "apiCall", "EmployerProfile"
-                }
-            });
+            _apiLoggingContext);
 
         return result.EmployerProfiles.Select(MapEmployerProfile).ToList();
     }
@@ -71,12 +67,7 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
 
         var result = await retryPolicy.Execute(_ =>
                 outerApiClient.Get<GetEmployerProfilesByLegalEntityIdResponse>(new GetEmployerProfileByLegalEntityIdRequest(legalEntityId)),
-            new Dictionary<string, object>
-            {
-                {
-                    "apiCall", "EmployerProfile"
-                }
-            });
+            _apiLoggingContext);
 
         return MapEmployerProfile(result.EmployerProfile);
     }
@@ -89,12 +80,7 @@ public class EmployerProfileService(ILogger<EmployerProfileService> logger,
 
         await retryPolicy.Execute(_ => outerApiClient.Post(
                 new PatchEmployerProfileRequest(ToEmployerProfile(profile))),
-            new Dictionary<string, object>
-            {
-                {
-                    "apiCall", "EmployerProfile"
-                }
-            });
+            _apiLoggingContext);
     }
 
     private Domain.Entities.EmployerProfile MapEmployerProfile(Domain.EmployerProfiles.EmployerProfile source) =>


### PR DESCRIPTION
Persist the employer description updates to the profile

Ensure that changes to the employer's "AboutOrganisation" field are saved by updating the employer profile via vacancyClient.UpdateEmployerProfileAsync. This guarantees that edits to the employer description are properly persisted.