### PR TITLE
FAI-2992 FAI-3030 FAI-3035 Update Manage vacancy page

### DIFF
--- a/src/Employer/Employer.Web/Orchestrators/ApplicationReviewOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/ApplicationReviewOrchestrator.cs
@@ -116,11 +116,6 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
         }
 
         public async Task<bool> IsAllApplicationReviewsHasOutcomeAsync(Guid vacancyId)
-        {
-            var applicationReviews = await vacancyClient.GetApplicationReviewsAsync(vacancyId);
-            return applicationReviews
-                .Where(ar => !ar.IsWithdrawn)
-                .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
-        }
+            => await vacancyClient.IsAllApplicationReviewsHasOutcomeAsync(vacancyId);
     }
 }

--- a/src/Employer/Employer.Web/Orchestrators/ApplicationReviewsOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/ApplicationReviewsOrchestrator.cs
@@ -94,12 +94,6 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             await client.SetApplicationReviewsToUnsuccessful(request.VacancyApplicationsToUnsuccessful.Select(c=>c.ApplicationReviewId), request.CandidateFeedback, user, request.VacancyId);
         }
 
-        public async Task<bool> IsAllApplicationReviewsHasOutcomeAsync(Guid vacancyId)
-        {
-            var applicationReviews = await client.GetApplicationReviewsAsync(vacancyId);
-            return applicationReviews
-                .Where(ar => !ar.IsWithdrawn)
-                .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
-        }
+        public async Task<bool> IsAllApplicationReviewsHasOutcomeAsync(Guid vacancyId) => await client.IsAllApplicationReviewsHasOutcomeAsync(vacancyId);
     }
 }

--- a/src/Employer/Employer.Web/Utility.cs
+++ b/src/Employer/Employer.Web/Utility.cs
@@ -145,10 +145,6 @@ public class Utility(IRecruitVacancyClient vacancyClient, ITaskListValidator tas
     {
         if (vacancy is null) return false;
 
-        var applicationReviews = await vacancyClient.GetApplicationReviewsAsync(vacancy.Id);
-        return applicationReviews
-            .Where(ar => !ar.IsWithdrawn)
-            .All(ar =>
-            ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
+        return await vacancyClient.IsAllApplicationReviewsHasOutcomeAsync(vacancy.Id);
     }
 }

--- a/src/Employer/Employer.Web/Views/Shared/_EmployerRevokedTransferredVacanciesAlert.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_EmployerRevokedTransferredVacanciesAlert.cshtml
@@ -7,7 +7,7 @@
         <span class="govuk-!-font-weight-bold">@Model.ProviderNamesCaption</span> after you turned off their permissions.
     </p>
     <p class="das-notification__body">Live adverts transferred from the provider are now closed and any adverts sent for review are in draft.</p>
-    <p class="das-notification__body">You can clone closed adverts if you want to republish them.</p>
+    <p class="das-notification__body">You can clone closed or archived adverts if you want to republish them.</p>
     <form asp-route="@RouteNames.Alerts_Dismiss_Post" asp-route-employerAccountId="@Model.EmployerAccountId">
         <p class="das-notification__body">
             @{ string returnUrl = ViewContext.HttpContext.Request.Path + ViewContext.HttpContext.Request.QueryString; }

--- a/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
+++ b/src/Employer/Employer.Web/Views/VacancyManage/ManageVacancy.cshtml
@@ -139,7 +139,9 @@
             <a asp-show="@Model.CanShowArchiveLink" asp-route="@RouteNames.ArchiveVacancy_Get"
                 asp-all-route-data="@Model.RouteDictionary" class="govuk-link">Archive advert</a>
         </div>
-
+        <govuk-inset>
+            Closed adverts can be archived when all applicants have received their outcome. You can clone an archived advert to advertise it again.
+        </govuk-inset>
         <div asp-show="@Model.CanShowVacancyAnalytics">
             <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
             <h2 class="govuk-heading-m">

--- a/src/Employer/UnitTests/Employer.Web/Orchestrators/ApplicationReviewOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Orchestrators/ApplicationReviewOrchestratorTests.cs
@@ -65,15 +65,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Orchestrators
             var model = _fixture.Build<ApplicationReviewEditModel>()
                 .With(x => x.VacancyId, routeModel.VacancyId)
                 .Create();
-            var applicationReviews = _fixture.Create<List<ApplicationReview>>();
-            applicationReviews.ForEach(ar =>
-            {
-                ar.IsWithdrawn = false;
-                ar.Status = status;
-            });
-
-            _vacancyClient.Setup(x => x.GetApplicationReviewsAsync(routeModel.VacancyId))
-                .ReturnsAsync(applicationReviews);
+            _vacancyClient.Setup(x => x.IsAllApplicationReviewsHasOutcomeAsync(routeModel.VacancyId))
+                .ReturnsAsync(expectedResult);
 
             var result = await _orchestrator.IsAllApplicationReviewsHasOutcomeAsync(model.VacancyId);
 

--- a/src/Provider/Provider.Web/Orchestrators/ApplicationReviewOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/ApplicationReviewOrchestrator.cs
@@ -137,10 +137,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             if (!vacancyId.HasValue)
                 return false;
 
-            var applicationReviews = await vacancyClient.GetApplicationReviewsAsync(vacancyId.Value);
-            return applicationReviews
-                .Where(ar => !ar.IsWithdrawn)
-                .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
+            return await vacancyClient.IsAllApplicationReviewsHasOutcomeAsync(vacancyId.Value);
         }
     }
 }

--- a/src/Provider/Provider.Web/Orchestrators/ApplicationReviewsOrchestrator.cs
+++ b/src/Provider/Provider.Web/Orchestrators/ApplicationReviewsOrchestrator.cs
@@ -132,10 +132,7 @@ namespace Esfa.Recruit.Provider.Web.Orchestrators
             if (!vacancyId.HasValue)
                 return false;
 
-            var applicationReviews = await client.GetApplicationReviewsAsync(vacancyId.Value);
-            return applicationReviews
-                .Where(ar => !ar.IsWithdrawn)
-                .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
+            return await client.IsAllApplicationReviewsHasOutcomeAsync(vacancyId.Value);
         }
     }
 }

--- a/src/Provider/Provider.Web/Utility.cs
+++ b/src/Provider/Provider.Web/Utility.cs
@@ -144,10 +144,7 @@ public class Utility(IRecruitVacancyClient vacancyClient, ITaskListValidator tas
     {
         if (vacancy is null) return false;
 
-        var applicationReviews = await vacancyClient.GetApplicationReviewsAsync(vacancy.Id);
-        return applicationReviews
-            .Where(ar => !ar.IsWithdrawn)
-            .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
+        return await vacancyClient.IsAllApplicationReviewsHasOutcomeAsync(vacancy.Id);
     }
 
     [Obsolete("Use an instance of ITaskListValidator instead")]

--- a/src/Provider/Provider.Web/Views/VacancyManage/ManageVacancy.cshtml
+++ b/src/Provider/Provider.Web/Views/VacancyManage/ManageVacancy.cshtml
@@ -98,6 +98,9 @@
             <a asp-show="@Model.CanShowDeleteVacancyLink" asp-route="@RouteNames.DeleteVacancy_Get" asp-all-route-data="@Model.RouteDictionary" class="govuk-link">Delete vacancy</a>
             <a asp-show="@Model.CanShowArchiveVacancyLink" asp-route="@RouteNames.ArchiveVacancy_Get" asp-all-route-data="@Model.RouteDictionary" class="govuk-link">Archive vacancy</a>
         </div>
+        <govuk-inset>
+                Closed vacancies can be archived when all applicants have received their outcome. You can clone an archived vacancy to advertise it again.
+        </govuk-inset>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <div asp-show="@Model.CanShowVacancyAnalytics">
             <h2 class="govuk-heading-m govuk-!-margin-top-0">

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/ApplicationReviewsOrchestratorTests/ApplicationReviewOrchestratorTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/ApplicationReviewsOrchestratorTests/ApplicationReviewOrchestratorTests.cs
@@ -125,15 +125,8 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.Orchestrators.Application
             var model = _fixture.Build<ApplicationReviewEditModel>()
                 .With(x => x.VacancyId, routeModel.VacancyId)
                 .Create();
-            var applicationReviews = _fixture.Create<List<ApplicationReview>>();
-            applicationReviews.ForEach(ar =>
-            {
-                ar.IsWithdrawn = false;
-                ar.Status = status;
-            });
-
-            _recruitVacancyClient.Setup(x => x.GetApplicationReviewsAsync(routeModel.VacancyId.Value))
-                .ReturnsAsync(applicationReviews);
+            _recruitVacancyClient.Setup(x => x.IsAllApplicationReviewsHasOutcomeAsync(routeModel.VacancyId.Value))
+                .ReturnsAsync(expectedResult);
 
             var result = await _orchestrator.IsAllApplicationReviewsHasOutcomeAsync(model.VacancyId);
 

--- a/src/Provider/UnitTests/Provider.Web/Orchestrators/ApplicationReviewsOrchestratorTests/ApplicationReviewsOrchestratorTests.cs
+++ b/src/Provider/UnitTests/Provider.Web/Orchestrators/ApplicationReviewsOrchestratorTests/ApplicationReviewsOrchestratorTests.cs
@@ -204,15 +204,8 @@ namespace Esfa.Recruit.Provider.UnitTests.Provider.Web.Orchestrators.Application
             var model = _fixture.Build<ApplicationReviewEditModel>()
                 .With(x => x.VacancyId, routeModel.VacancyId)
                 .Create();
-            var applicationReviews = _fixture.Create<List<ApplicationReview>>();
-            applicationReviews.ForEach(ar =>
-            {
-                ar.IsWithdrawn = false;
-                ar.Status = status;
-            });
-
-            _vacancyClient.Setup(x => x.GetApplicationReviewsAsync(routeModel.VacancyId.Value))
-                .ReturnsAsync(applicationReviews);
+            _vacancyClient.Setup(x => x.IsAllApplicationReviewsHasOutcomeAsync(routeModel.VacancyId.Value))
+                .ReturnsAsync(expectedResult);
 
             var result = await _orchestrator.IsAllApplicationReviewsHasOutcomeAsync(model.VacancyId);
 

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/IRecruitVacancyClient.cs
@@ -16,7 +16,7 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<Vacancy> GetVacancyAsync(Guid vacancyId);
         Task<Domain.Entities.VacancyReview> GetCurrentReferredVacancyReviewAsync(long vacancyReference);
         Task<Domain.Entities.ApplicationReview> GetApplicationReviewAsync(Guid applicationReviewId);
-        Task<List<Domain.Entities.ApplicationReview>> GetApplicationReviewsAsync(Guid vacancyId);
+        Task<bool> IsAllApplicationReviewsHasOutcomeAsync(Guid vacancyId);
         EntityValidationResult Validate(Vacancy vacancy, VacancyRuleSet rules);
         Task UpdateDraftVacancyAsync(Vacancy vacancy, VacancyUser user);
         Task<IEnumerable<IApprenticeshipProgramme>> GetActiveApprenticeshipProgrammesAsync(bool includePlaceholderProgramme = false);
@@ -33,7 +33,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         Task<VacancyAnalyticsSummary> GetVacancyAnalyticsSummaryAsync(long vacancyReference);
         Task<Domain.Entities.User> GetUsersDetailsAsync(string userId);
         Task<UserNotificationPreferences> GetUserNotificationPreferencesAsync(string vacancyUserId, string dfeUserId = null);
-
         Task<UserNotificationPreferences> GetUserNotificationPreferencesByDfEUserIdAsync(string idamsUserId, string dfeUserId = null);
         Task UpdateUserNotificationPreferencesAsync(UserNotificationPreferences preferences);
         EntityValidationResult ValidateUserNotificationPreferences(UserNotificationPreferences preferences);

--- a/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Infrastructure/Client/VacancyClient.cs
@@ -37,7 +37,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         IApprenticeshipProgrammeProvider apprenticeshipProgrammesProvider,
         IEmployerAccountProvider employerAccountProvider,
         IVacancyReviewQuery vacancyReviewQuery,
-        IVacancyService vacancyService,
         IEmployerProfileService employerProfileService,
         IUserRepository userRepository,
         IEmployerService employerService,
@@ -256,6 +255,14 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
             };
         }
 
+        public async Task<bool> IsAllApplicationReviewsHasOutcomeAsync(Guid vacancyId)
+        {
+            var applicationReviews = await applicationReadRepository.GetForVacancyAsync<Domain.Entities.ApplicationReview>(vacancyId);
+            return applicationReviews
+                .Where(ar => !ar.IsWithdrawn)
+                .All(ar => ar.Status is ApplicationReviewStatus.Successful or ApplicationReviewStatus.Unsuccessful);
+        }
+
         public EntityValidationResult Validate(Vacancy vacancy, VacancyRuleSet rules)
         {
             return validator.Validate(vacancy, rules);
@@ -279,11 +286,6 @@ namespace Esfa.Recruit.Vacancies.Client.Infrastructure.Client
         public async Task<Domain.Entities.ApplicationReview> GetApplicationReviewAsync(Guid applicationReviewId)
         {
             return await applicationReadRepository.GetAsync(applicationReviewId);
-        }
-
-        public async Task<List<Domain.Entities.ApplicationReview>> GetApplicationReviewsAsync(Guid vacancyId)
-        {
-            return await applicationReadRepository.GetForVacancyAsync<Domain.Entities.ApplicationReview>(vacancyId);
         }
 
         public async Task<List<VacancyApplication>> GetVacancyApplicationsSortedAsync(long vacancyReference, SortColumn sortColumn, SortOrder sortOrder, bool vacancySharedByProvider = false)

--- a/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Client/VacancyClientTests..cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Infrastructure/Client/VacancyClientTests..cs
@@ -79,4 +79,38 @@ public class VacancyClientTests
         result.Application.ApplicationId.Should().Be(applicationReviewId);
         sqlDbRepositoryMock.Verify(r => r.GetAsync(applicationReviewId), Times.Once);
     }
+
+    [Test]
+    [MoqInlineAutoData(ApplicationReviewStatus.Successful, true)]
+    [MoqInlineAutoData(ApplicationReviewStatus.Unsuccessful, true)]
+    [MoqInlineAutoData(ApplicationReviewStatus.AllShared, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.InReview, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.Interviewing, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.EmployerInterviewing, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.EmployerUnsuccessful, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.PendingShared, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.PendingToMakeUnsuccessful, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.New, false)]
+    [MoqInlineAutoData(ApplicationReviewStatus.Shared, false)]
+    public async Task IsAllApplicationReviewsHasOutcomeAsync_Returns_Valid(
+        ApplicationReviewStatus status,
+        bool expectedResult,
+        List<Recruit.Vacancies.Client.Domain.Entities.ApplicationReview> applicationReviews,
+        [Frozen] Mock<IApplicationReadRepository> sqlDbRepositoryMock,
+        [Greedy] VacancyClient vacancyClient)
+    {
+        var vacancyId = Guid.NewGuid();
+        applicationReviews.ForEach(ar =>
+        {
+            ar.IsWithdrawn = false;
+            ar.Status = status;
+        });
+
+        sqlDbRepositoryMock.Setup(x => x.GetForVacancyAsync<Recruit.Vacancies.Client.Domain.Entities.ApplicationReview>(vacancyId))
+            .ReturnsAsync(applicationReviews);
+
+        var result = await vacancyClient.IsAllApplicationReviewsHasOutcomeAsync(vacancyId);
+
+        result.Should().Be(expectedResult);
+    }
 }


### PR DESCRIPTION
refactor(vacancy): centralize app review outcome logic

Move application review outcome check to VacancyClient. Update orchestrators and utilities to use new method. Remove GetApplicationReviewsAsync from client interface. Update and add unit tests for new logic.
Add UI inset about archiving closed vacancies.