### PR TITLE
FAI-3030

### DIFF
--- a/src/Employer/Employer.Web/Views/Shared/_EmployerRevokedTransferredVacanciesAlert.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_EmployerRevokedTransferredVacanciesAlert.cshtml
@@ -7,7 +7,7 @@
         <span class="govuk-!-font-weight-bold">@Model.ProviderNamesCaption</span> after you turned off their permissions.
     </p>
     <p class="das-notification__body">Live adverts transferred from the provider are now closed and any adverts sent for review are in draft.</p>
-    <p class="das-notification__body">You can clone closed adverts if you want to republish them.</p>
+    <p class="das-notification__body">You can clone closed or archived adverts if you want to republish them.</p>
     <form asp-route="@RouteNames.Alerts_Dismiss_Post" asp-route-employerAccountId="@Model.EmployerAccountId">
         <p class="das-notification__body">
             @{ string returnUrl = ViewContext.HttpContext.Request.Path + ViewContext.HttpContext.Request.QueryString; }


### PR DESCRIPTION
Feat: clarify cloning of closed and archived adverts

Update notification text to state that users can clone both closed and archived adverts if they want to republish them, instead of only closed adverts. This improves clarity for employers managing adverts.