### PR TITLE
FAI-3442 RAA - Error message asking for reason application is unsuccessful when rejecting a shared application

### DIFF
--- a/src/Employer/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewEditModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewEditModel.cs
@@ -8,7 +8,6 @@ namespace Esfa.Recruit.Employer.Web.ViewModels.ApplicationReview
     {
         public ApplicationReviewStatus? Outcome { get; set; }
         public string CandidateFeedback { get; set; }
-        public bool NavigateToFeedbackPage { get; set; }
         public bool IsApplicationSharedByProvider { get; set; }
     }
 }

--- a/src/Employer/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewStatusChangeModel.cs
+++ b/src/Employer/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewStatusChangeModel.cs
@@ -8,5 +8,5 @@ public class ApplicationReviewStatusChangeModel : ApplicationReviewRouteModel, I
 {
     public ApplicationReviewStatus? Outcome { get; set; }
     public string CandidateFeedback { get; set; }
-    public bool NavigateToFeedbackPage { get; set; }
+    public bool IsApplicationSharedByProvider { get; set; }
 }

--- a/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReview.cshtml
+++ b/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReview.cshtml
@@ -298,6 +298,17 @@
                                 Send a notification to the applicant telling them they won't be offered this apprenticeship.
                             </div>
                         </div>
+                        <div esfa-validation-marker-for="CandidateFeedback" id="unsuccessful-candidate-feedback" class="govuk-radios__conditional govuk-radios__conditional--hidden">
+                            <div class="govuk-character-count" id="conditional-contact-3" data-module="govuk-character-count" data-maxwords="200">
+                                <label asp-for="CandidateFeedback" class="govuk-label govuk-!-font-weight-bold">Feedback</label>
+                                <span esfa-validation-message-for="CandidateFeedback" class="govuk-error-message"></span>
+                                <span class="govuk-hint">@Model.FormRadioButtonNoFeedbackText</span>
+                                <textarea asp-for="CandidateFeedback" class="govuk-textarea govuk-js-character-count govuk-!-margin-top-4" id="CandidateFeedback" name="CandidateFeedback" rows="6"></textarea>
+                                <div id="CandidateFeedbackEmployerUnsuccessful-info" class="govuk-hint govuk-character-count__message">
+                                    You have 200 words remaining
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>

--- a/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReviewV2.cshtml
+++ b/src/Employer/Employer.Web/Views/ApplicationReview/ApplicationReviewV2.cshtml
@@ -399,6 +399,17 @@
                                 Send a notification to the applicant telling them they won't be offered this apprenticeship.
                             </div>
                         </div>
+                        <div esfa-validation-marker-for="CandidateFeedback" id="unsuccessful-candidate-feedback" class="govuk-radios__conditional govuk-radios__conditional--hidden">
+                            <div class="govuk-character-count" id="conditional-contact-3" data-module="govuk-character-count" data-maxwords="200">
+                                <label asp-for="CandidateFeedback" class="govuk-label govuk-!-font-weight-bold">Feedback</label>
+                                <span esfa-validation-message-for="CandidateFeedback" class="govuk-error-message"></span>
+                                <span class="govuk-hint">@Model.FormRadioButtonNoFeedbackText</span>
+                                <textarea asp-for="CandidateFeedback" class="govuk-textarea govuk-js-character-count govuk-!-margin-top-4" id="CandidateFeedback" name="CandidateFeedback" rows="6"></textarea>
+                                <div id="CandidateFeedbackEmployerUnsuccessful-info" class="govuk-hint govuk-character-count__message">
+                                    You have 200 words remaining
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>

--- a/src/Employer/UnitTests/Employer.Web/Controllers/ApplicationReviewControllerTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Controllers/ApplicationReviewControllerTests.cs
@@ -63,7 +63,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .Create();
 
             _orchestrator.Setup(o => o.GetApplicationReviewViewModelAsync(routeModel))
-                .ReturnsAsync(new ApplicationReviewViewModel 
+                .ReturnsAsync(new ApplicationReviewViewModel
                 {
                     ApplicationReviewId = _applicationReviewId,
                     VacancyId = _vacancyId,
@@ -117,7 +117,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         }
 
         [Test]
-        public async Task GET_ApplicationReview_Applicationunsuccessful_CanShowRadioButtonReviewAndInterviewingFalse()
+        public async Task GET_ApplicationReview_ApplicationUnsuccessful_CanShowRadioButtonReviewAndInterviewingFalse()
         {
             // Arrange
             var routeModel = _fixture.Build<ApplicationReviewRouteModel>()
@@ -157,10 +157,10 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .With(x => x.Outcome, ApplicationReviewStatus.EmployerInterviewing)
                 .With(x => x.VacancyId, _vacancyId)
                 .With(x => x.EmployerAccountId, _employerAccountId)
-                .With(c=>c.IsApplicationSharedByProvider,true)
+                .With(c => c.IsApplicationSharedByProvider, true)
                 .Create();
 
-            _orchestrator.Setup(o => o.PostApplicationReviewEditModelAsync( editModel, It.IsAny<VacancyUser>()))
+            _orchestrator.Setup(o => o.PostApplicationReviewEditModelAsync(editModel, It.IsAny<VacancyUser>()))
                 .ReturnsAsync(_candidateInfo);
 
             // Act
@@ -184,10 +184,10 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .With(x => x.Outcome, ApplicationReviewStatus.EmployerUnsuccessful)
                 .With(x => x.VacancyId, _vacancyId)
                 .With(x => x.EmployerAccountId, _employerAccountId)
-                .With(c=>c.IsApplicationSharedByProvider,true)
+                .With(c => c.IsApplicationSharedByProvider, true)
                 .Create();
 
-            _orchestrator.Setup(o => o.PostApplicationReviewEditModelAsync( editModel, It.IsAny<VacancyUser>()))
+            _orchestrator.Setup(o => o.PostApplicationReviewEditModelAsync(editModel, It.IsAny<VacancyUser>()))
                 .ReturnsAsync(_candidateInfo);
 
             // Act
@@ -199,7 +199,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             Assert.That(_vacancyId, Is.EqualTo(redirectResult.RouteValues["VacancyId"]));
             Assert.That(_employerAccountId, Is.EqualTo(redirectResult.RouteValues["EmployerAccountId"]));
             Assert.That(_controller.TempData.ContainsKey(TempDataKeys.ApplicationReviewStatusInfoMessage), Is.True);
-            Assert.That(string.Format(InfoMessages.ApplicationEmployerUnsuccessfulHeader, _candidateInfo.FriendlyId), Is.EqualTo(_controller.TempData[TempDataKeys.ApplicationReviewStatusInfoMessage]));
+            Assert.That(InfoMessages.ApplicationEmployerUnsuccessfulHeader, Is.EqualTo(_controller.TempData[TempDataKeys.ApplicationReviewStatusInfoMessage]));
         }
 
         [Test]
@@ -209,6 +209,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             var editModel = _fixture.Build<ApplicationReviewEditModel>()
                 .With(x => x.ApplicationReviewId, _applicationReviewId)
                 .With(x => x.Outcome, ApplicationReviewStatus.Unsuccessful)
+                .With(c => c.IsApplicationSharedByProvider, false)
                 .With(x => x.VacancyId, _vacancyId)
                 .With(x => x.EmployerAccountId, _employerAccountId)
                 .Create();
@@ -222,7 +223,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             Assert.That(_vacancyId, Is.EqualTo(redirectResult.RouteValues["VacancyId"]));
             Assert.That(_employerAccountId, Is.EqualTo(redirectResult.RouteValues["EmployerAccountId"]));
         }
-      
+
         [Test] //This was never enabled
         public async Task POST_ApplicationReview_StatusInReview_RedirectsToVacancyManageWithCorrectTempDataMessage()
         {
@@ -232,6 +233,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .With(x => x.Outcome, ApplicationReviewStatus.InReview)
                 .With(x => x.VacancyId, _vacancyId)
                 .With(x => x.EmployerAccountId, _employerAccountId)
+                .With(x => x.IsApplicationSharedByProvider, false)
                 .With(x => x.CandidateFeedback, "feedback")
                 .Create();
 
@@ -266,11 +268,11 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .Create();
 
             _orchestrator.Setup(o => o.PostApplicationReviewConfirmationEditModelAsync(It.Is<ApplicationReviewStatusConfirmationEditModel>(y => y == editModel), It.IsAny<VacancyUser>()))
-                .ReturnsAsync(new  ApplicationReviewStatusUpdateInfo
-                    {
-                        CandidateName = _candidateInfo.Name,
-                        ShouldMakeOthersUnsuccessful = true,
-                    });
+                .ReturnsAsync(new ApplicationReviewStatusUpdateInfo
+                {
+                    CandidateName = _candidateInfo.Name,
+                    ShouldMakeOthersUnsuccessful = true,
+                });
 
             // Act
             var redirectResult = await _controller.ApplicationStatusConfirmation(editModel) as RedirectToRouteResult;
@@ -305,7 +307,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
 
             // Act
             var redirectResult = await _controller.ApplicationStatusConfirmation(editModel) as RedirectToRouteResult;
-          
+
             // Assert
             Assert.That(redirectResult, Is.Not.Null);
             Assert.That(RouteNames.VacancyManage_Get, Is.EqualTo(redirectResult.RouteName));

--- a/src/Employer/UnitTests/Employer.Web/Controllers/ApplicationReviewsControllerTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/Controllers/ApplicationReviewsControllerTests.cs
@@ -27,9 +27,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         private ApplicationReviewsController _controller;
         private Guid _vacancyId;
         private Guid _applicationReviewId;
-        private Guid _applicationReviewIdTwo;
         private string _employerAccountId;
-        protected Mock<IProfanityListProvider> _mockProfanityListProvider;
+        private Mock<IProfanityListProvider> _mockProfanityListProvider;
 
         [SetUp]
         public void Setup()
@@ -38,14 +37,12 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             _orchestrator = new Mock<IApplicationReviewsOrchestrator>();
             _vacancyId = Guid.NewGuid();
             _applicationReviewId = Guid.NewGuid();
-            _applicationReviewIdTwo = Guid.NewGuid();
             _employerAccountId = "ADGFHAS";
             _mockProfanityListProvider = new Mock<IProfanityListProvider>();
             _mockProfanityListProvider.Setup(x => x.GetProfanityListAsync()).Returns(GetProfanityListAsync());
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(EmployerRecruitClaims.IdamsUserIdClaimTypeIdentifier, _applicationReviewId.ToString()),
-            }));
+            var user = new ClaimsPrincipal(new ClaimsIdentity([
+                new Claim(EmployerRecruitClaims.IdamsUserIdClaimTypeIdentifier, _applicationReviewId.ToString())
+            ]));
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
             _controller = new ApplicationReviewsController(_orchestrator.Object)
@@ -66,10 +63,12 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             var applicationReview1 = _fixture.Create<ApplicationReview>();
             var applicationReview2 = _fixture.Create<ApplicationReview>();
             var applicationReview3 = _fixture.Create<ApplicationReview>();
-            var applications = new List<ApplicationReview> { };
-            applications.Add(applicationReview1);
-            applications.Add(applicationReview2);
-            applications.Add(applicationReview3);
+            var applications = new List<ApplicationReview>
+            {
+                applicationReview1,
+                applicationReview2,
+                applicationReview3
+            };
 
             _orchestrator.Setup(o =>
                     o.GetApplicationReviewsToUnsuccessfulViewModelAsync(It.Is<VacancyRouteModel>(y => y == routeModel), It.Is<SortColumn>(x => x.Equals(SortColumn.DateApplied)), It.Is<SortOrder>(x => x.Equals(SortOrder.Descending))))
@@ -127,10 +126,12 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             var applicationReview1 = _fixture.Create<ApplicationReview>();
             var applicationReview2 = _fixture.Create<ApplicationReview>();
             var applicationReview3 = _fixture.Create<ApplicationReview>();
-            var applications = new List<ApplicationReview> { };
-            applications.Add(applicationReview1);
-            applications.Add(applicationReview2);
-            applications.Add(applicationReview3);
+            var applications = new List<ApplicationReview>
+            {
+                applicationReview1,
+                applicationReview2,
+                applicationReview3
+            };
 
             _orchestrator.Setup(o =>
             o.GetApplicationReviewsToUnsuccessfulViewModelAsync(It.Is<VacancyRouteModel>(y => y == routeModel), It.Is<SortColumn>(x => x.Equals(SortColumn.Default)), It.Is<SortOrder>(x => x.Equals(SortOrder.Default))))
@@ -158,8 +159,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         public async Task POST_ApplicationReviewsToUnsuccessfulAsync_RedirectsToAction()
         {
             // Arrange
-            var listOfApplicationReviews = new List<Guid>();
-            listOfApplicationReviews.Add(_applicationReviewId);
+            var listOfApplicationReviews = new List<Guid> {_applicationReviewId};
             var request = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulViewModel>()
                 .With(x => x.VacancyId, _vacancyId)
@@ -278,7 +278,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
                 .With(x => x.EmployerAccountId, _employerAccountId)
                 .With(x => x.Outcome, ApplicationReviewStatus.Unsuccessful)
                 .With(x=>x.CandidateFeedback, "")
-                .With(x=>x.ApplicationsToUnsuccessful, new List<VacancyApplication>{new VacancyApplication()})
+                .With(x=>x.ApplicationsToUnsuccessful, [new VacancyApplication()])
                 .With(x=>x.IsMultipleApplications, false)
                 .Create();
             var validator = new ApplicationReviewsFeedbackModelValidator(_mockProfanityListProvider.Object);
@@ -296,15 +296,13 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         public async Task GET_ApplicationReviewsToUnsuccessfulConfirmation_ReturnsViewModelWithMultipleApplicationsText()
         {
             // Arrange
-            var listOfApplicationReviews = new List<Guid>();
-            listOfApplicationReviews.Add(_applicationReviewId);
-            listOfApplicationReviews.Add(_applicationReviewIdTwo);
-
             var vacancyApplication1 = _fixture.Create<VacancyApplication>();
             var vacancyApplication2 = _fixture.Create<VacancyApplication>();
-            var vacancyApplications = new List<VacancyApplication> { };
-            vacancyApplications.Add(vacancyApplication1);
-            vacancyApplications.Add(vacancyApplication2);
+            var vacancyApplications = new List<VacancyApplication>
+            {
+                vacancyApplication1,
+                vacancyApplication2
+            };
 
             var routeModel = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulRouteModel>()
@@ -341,12 +339,11 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         public async Task GET_ApplicationReviewsToUnsuccessfulConfirmation_ReturnsViewModelWithSingleApplicationsText()
         {
             // Arrange
-            var listOfApplicationReviews = new List<Guid>();
-            listOfApplicationReviews.Add(_applicationReviewId);
-
             var vacancyApplication1 = _fixture.Create<VacancyApplication>();
-            var vacancyApplications = new List<VacancyApplication> { };
-            vacancyApplications.Add(vacancyApplication1);
+            var vacancyApplications = new List<VacancyApplication>
+            {
+                vacancyApplication1
+            };
 
             var routeModel = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulRouteModel>()
@@ -383,8 +380,10 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         {
             // Arrange
             var vacancyApplication1 = _fixture.Create<VacancyApplication>();
-            var vacancyApplications = new List<VacancyApplication> { };
-            vacancyApplications.Add(vacancyApplication1);
+            var vacancyApplications = new List<VacancyApplication>
+            {
+                vacancyApplication1
+            };
             var request = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulConfirmationViewModel>()
                 .With(x => x.VacancyId, _vacancyId)
@@ -409,8 +408,10 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
         {
             // Arrange
             var vacancyApplication1 = _fixture.Create<VacancyApplication>();
-            var vacancyApplications = new List<VacancyApplication> { };
-            vacancyApplications.Add(vacancyApplication1);
+            var vacancyApplications = new List<VacancyApplication>
+            {
+                vacancyApplication1
+            };
             var request = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulConfirmationViewModel>()
                 .With(x => x.VacancyId, _vacancyId)
@@ -441,9 +442,11 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             // Arrange
             var vacancyApplication1 = _fixture.Create<VacancyApplication>();
             var vacancyApplication2 = _fixture.Create<VacancyApplication>();
-            var vacancyApplications = new List<VacancyApplication> { };
-            vacancyApplications.Add(vacancyApplication1);
-            vacancyApplications.Add(vacancyApplication2);
+            var vacancyApplications = new List<VacancyApplication>
+            {
+                vacancyApplication1,
+                vacancyApplication2
+            };
             var request = _fixture
                 .Build<ApplicationReviewsToUnsuccessfulConfirmationViewModel>()
                 .With(x => x.VacancyId, _vacancyId)
@@ -468,9 +471,7 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.Controllers
             Assert.That(InfoMessages.ApplicationsToUnsuccessfulBannerHeader, Is.EqualTo(_controller.TempData[TempDataKeys.ApplicationReviewsUnsuccessfulInfoMessage]));
         }
 
-        public Task<IEnumerable<string>> GetProfanityListAsync()
-        {
-            return Task.FromResult<IEnumerable<string>>(new[] { "bother", "dang", "balderdash", "drat" });
-        }
+        private static Task<IEnumerable<string>> GetProfanityListAsync() => 
+            Task.FromResult<IEnumerable<string>>(["bother", "dang", "balderdash", "drat"]);
     }
 }

--- a/src/Employer/UnitTests/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewEditModelTests.cs
+++ b/src/Employer/UnitTests/Employer.Web/ViewModels/ApplicationReview/ApplicationReviewEditModelTests.cs
@@ -50,7 +50,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.ViewModels.ApplicationRev
             var m = new ApplicationReviewEditModel
             {
                 Outcome = ApplicationReviewStatus.EmployerUnsuccessful,
-                CandidateFeedback = candidateFeedback
+                CandidateFeedback = candidateFeedback,
+                IsApplicationSharedByProvider = true
             };
 
             var validator = new ApplicationReviewEditModelValidator(_mockProfanityListProvider.Object);
@@ -84,7 +85,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.ViewModels.ApplicationRev
         {
             var m = new ApplicationReviewEditModel {
                 Outcome = ApplicationReviewStatus.EmployerUnsuccessful,
-                CandidateFeedback = "?$@#()\"\'\\!,+-=_:;.&€£*%/[] \\A-Z \a-z \0-9 your comments will be sent to the candidate."
+                CandidateFeedback = "?$@#()\"\'\\!,+-=_:;.&€£*%/[] \\A-Z \a-z \0-9 your comments will be sent to the candidate.",
+                IsApplicationSharedByProvider = true
             };
 
             var validator = new ApplicationReviewEditModelValidator(_mockProfanityListProvider.Object);
@@ -103,7 +105,8 @@ namespace Esfa.Recruit.Employer.UnitTests.Employer.Web.ViewModels.ApplicationRev
             var m = new ApplicationReviewEditModel
             {
                 Outcome = outcome,
-                CandidateFeedback = feedback
+                CandidateFeedback = feedback,
+                IsApplicationSharedByProvider = true
             };
 
             var validator = new ApplicationReviewEditModelValidator(_mockProfanityListProvider.Object);

--- a/src/Provider/Provider.Web/ViewModels/ApplicationReview/ApplicationReviewStatusChangeModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/ApplicationReview/ApplicationReviewStatusChangeModel.cs
@@ -8,6 +8,6 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.ApplicationReview
     {
         public ApplicationReviewStatus? Outcome { get; set; }
         public string CandidateFeedback { get; set; }
-        public bool NavigateToFeedbackPage { get; set; }
+        public bool IsApplicationSharedByProvider { get; set; }
     }
 }

--- a/src/Provider/Provider.Web/ViewModels/ApplicationReview/ApplicationReviewViewModel.cs
+++ b/src/Provider/Provider.Web/ViewModels/ApplicationReview/ApplicationReviewViewModel.cs
@@ -70,7 +70,6 @@ namespace Esfa.Recruit.Provider.Web.ViewModels.ApplicationReview
         public bool CanShowRadioButtonReview => Status == ApplicationReviewStatus.New;
         public bool CanShowRadioButtonShared => (Status == ApplicationReviewStatus.New || Status == ApplicationReviewStatus.InReview);
         public bool CanShowRadioButtonInterviewing => (Status == ApplicationReviewStatus.New || Status == ApplicationReviewStatus.InReview || Status == ApplicationReviewStatus.Shared || Status == ApplicationReviewStatus.EmployerInterviewing);
-        public bool NavigateToFeedbackPage { get; set; }
         public string WhatIsYourInterest { get; set; }
         public List<WorkExperienceViewModel> Jobs { get; set; }
         public bool IsFaaV2Application { get; set; }

--- a/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationReview.cshtml
+++ b/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationReview.cshtml
@@ -301,7 +301,6 @@
                         <h3 class="govuk-fieldset__heading">What do you want to do with this application?</h3>
                     </legend>
                     <span esfa-validation-message-for="Outcome" class="govuk-error-message"></span>
-                    <input type="hidden" asp-for="NavigateToFeedbackPage" value="true"/>
                     <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         <div asp-show="@Model.CanShowRadioButtonReview" class="govuk-radios__item">
                             <input asp-for="Outcome" class="govuk-radios__input" id="outcome-reviewed" type="radio" value="@ApplicationReviewStatus.InReview.ToString()" checked="@(Model.Outcome == ApplicationReviewStatus.InReview ? "checked" : null)">

--- a/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationReviewV2.cshtml
+++ b/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationReviewV2.cshtml
@@ -364,7 +364,6 @@
                         <h3 class="govuk-heading-m govuk-!-margin-top-6">What do you want to do with this application?</h3>
                     </legend>
                     <span esfa-validation-message-for="Outcome" class="govuk-error-message"></span>
-                    <input type="hidden" asp-for="NavigateToFeedbackPage" value="true" />
                     <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         <div asp-show="@Model.CanShowRadioButtonReview" class="govuk-radios__item">
                             <input asp-for="Outcome" class="govuk-radios__input" id="outcome-reviewed" type="radio" value="@ApplicationReviewStatus.InReview.ToString()" checked="@(Model.Outcome == ApplicationReviewStatus.InReview ? "checked" : null)">

--- a/src/Shared/Recruit.Shared.Web/ViewModels/ApplicationReview/IApplicationReviewEditModel.cs
+++ b/src/Shared/Recruit.Shared.Web/ViewModels/ApplicationReview/IApplicationReviewEditModel.cs
@@ -6,6 +6,6 @@ namespace Esfa.Recruit.Shared.Web.ViewModels.ApplicationReview
     {
         ApplicationReviewStatus? Outcome { get; set; }
         string CandidateFeedback { get; set; }
-        bool NavigateToFeedbackPage { get; set; }
+        bool IsApplicationSharedByProvider { get; set; }
     }
 }

--- a/src/Shared/Recruit.Shared.Web/ViewModels/Validations/Fluent/ApplicationReviewEditModelValidator.cs
+++ b/src/Shared/Recruit.Shared.Web/ViewModels/Validations/Fluent/ApplicationReviewEditModelValidator.cs
@@ -14,7 +14,7 @@ namespace Esfa.Recruit.Shared.Web.ViewModels.Validations.Fluent
                 .NotNull()
                 .WithMessage(ApplicationReviewValidator.OutcomeRequired);
 
-            When(x => x.Outcome == ApplicationReviewStatus.EmployerUnsuccessful, () =>
+            When(x => x.Outcome == ApplicationReviewStatus.EmployerUnsuccessful && x.IsApplicationSharedByProvider, () =>
             {
                 RuleFor(x => x.CandidateFeedback)
                     .NotEmpty()


### PR DESCRIPTION
Replaced NavigateToFeedbackPage with IsApplicationSharedByProvider in IApplicationReviewEditModel and related ViewModels. Updated validation to require CandidateFeedback only when Outcome is EmployerUnsuccessful and IsApplicationSharedByProvider is true. Modified Razor views to reflect these changes and improved feedback UI. Refactored and modernised unit tests, removing unused variables and using collection initialisers.