### PR TITLE
FAI-3524 Non English postcodes being used on Vacancies

### DIFF
--- a/src/Employer/Employer.Web/Controllers/CloneVacancyController.cs
+++ b/src/Employer/Employer.Web/Controllers/CloneVacancyController.cs
@@ -13,20 +13,14 @@ using Esfa.Recruit.Shared.Web.ViewModels;
 namespace Esfa.Recruit.Employer.Web.Controllers
 {
     [Route(RoutePaths.AccountVacancyRoutePath)]
-    public class CloneVacancyController : Controller
+    public class CloneVacancyController(CloneVacancyOrchestrator orchestrator) : Controller
     {
-        private readonly CloneVacancyOrchestrator _orchestrator;
-        public CloneVacancyController(CloneVacancyOrchestrator orchestrator)
-        {
-            _orchestrator = orchestrator;
-        }
-
         [HttpGet("clone", Name = RouteNames.CloneVacancy_Get)]
         public async Task<IActionResult> Clone(VacancyRouteModel vrm)
         {
-            var vacancy = await _orchestrator.GetCloneableAuthorisedVacancyAsync(vrm);
+            var vacancy = await orchestrator.GetCloneableAuthorisedVacancyAsync(vrm);
 
-            return _orchestrator.IsNewDatesRequired(vacancy) 
+            return orchestrator.IsNewDatesRequired(vacancy) 
                 ? RedirectToRoute(RouteNames.CloneVacancyWithNewDates_Get, new {vrm.VacancyId, vrm.EmployerAccountId}) 
                 : RedirectToRoute(RouteNames.CloneVacancyDatesQuestion_Get, new {vrm.VacancyId, vrm.EmployerAccountId});
         }
@@ -34,7 +28,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpGet("clone-dates-question", Name = RouteNames.CloneVacancyDatesQuestion_Get)]
         public async Task<IActionResult> CloneVacancyDatesQuestion(VacancyRouteModel vrm)
         {
-            var vm = await _orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(vrm);
+            var vm = await orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(vrm);
             return View(vm);
         }
 
@@ -43,18 +37,18 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         {
             if (!ModelState.IsValid)
             {
-                var vm = await _orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(model);
+                var vm = await orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(model);
                 return View(vm);
             }
 
             if (model.HasConfirmedClone == true)
             {
-                var response = await _orchestrator.PostCloneVacancyWithSameDates(model, User.ToVacancyUser());
+                var response = await orchestrator.PostCloneVacancyWithSameDates(model, User.ToVacancyUser());
 
                 if (!response.Success)
                 {
                     response.AddErrorsToModelState(ModelState);
-                    var vm = await _orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(model);
+                    var vm = await orchestrator.GetCloneVacancyDatesQuestionViewModelAsync(model);
                     return View(vm);
                 }
 
@@ -69,14 +63,14 @@ namespace Esfa.Recruit.Employer.Web.Controllers
         [HttpGet("clone-with-dates", Name = RouteNames.CloneVacancyWithNewDates_Get)]
         public async Task<IActionResult> CloneVacancyWithNewDates(VacancyRouteModel vrm)
         {
-            var vm = await _orchestrator.GetCloneVacancyWithNewDatesViewModelAsync(vrm);
+            var vm = await orchestrator.GetCloneVacancyWithNewDatesViewModelAsync(vrm);
             return View(vm);
         }
 
         [HttpPost("clone-with-dates", Name = RouteNames.CloneVacancyWithNewDates_Post)]
         public async Task<IActionResult> CloneVacancyWithNewDates(CloneVacancyWithNewDatesEditModel model)
         {
-            var response = await _orchestrator.PostCloneVacancyWithNewDates(model, User.ToVacancyUser());
+            var response = await orchestrator.PostCloneVacancyWithNewDates(model, User.ToVacancyUser());
 
             if(!response.Success)
             {
@@ -85,7 +79,7 @@ namespace Esfa.Recruit.Employer.Web.Controllers
 
             if (!ModelState.IsValid)
             {
-                var vm = await _orchestrator.GetDirtyCloneVacancyWithNewDatesViewModelAsync(model);
+                var vm = await orchestrator.GetDirtyCloneVacancyWithNewDatesViewModelAsync(model);
                 return View(vm);
             }
 

--- a/src/Employer/Employer.Web/Controllers/Part1/EnterLocationManuallyController.cs
+++ b/src/Employer/Employer.Web/Controllers/Part1/EnterLocationManuallyController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Recruit.Employer.Web.Configuration;
 using Esfa.Recruit.Employer.Web.Configuration.Routing;
-using Esfa.Recruit.Employer.Web.Extensions;
 using Esfa.Recruit.Employer.Web.Models.AddLocation;
 using Esfa.Recruit.Employer.Web.Services;
 using Esfa.Recruit.Employer.Web.ViewModels.Part1.AddLocation;
@@ -11,7 +10,6 @@ using Esfa.Recruit.Shared.Web.Extensions;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Locations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.FeatureManagement.Mvc;
 
 namespace Esfa.Recruit.Employer.Web.Controllers.Part1;
 

--- a/src/Employer/Employer.Web/Orchestrators/CloneVacancyOrchestrator.cs
+++ b/src/Employer/Employer.Web/Orchestrators/CloneVacancyOrchestrator.cs
@@ -15,22 +15,16 @@ using ErrorMessages = Esfa.Recruit.Shared.Web.ViewModels.ErrorMessages;
 
 namespace Esfa.Recruit.Employer.Web.Orchestrators
 {
-    public class CloneVacancyOrchestrator : EntityValidatingOrchestrator<Vacancy, CloneVacancyWithNewDatesEditModel>
+    public class CloneVacancyOrchestrator(
+        IRecruitVacancyClient vacancyClient,
+        ITimeProvider timeProvider,
+        ILogger<CloneVacancyOrchestrator> logger,
+        IUtility utility)
+        : EntityValidatingOrchestrator<Vacancy, CloneVacancyWithNewDatesEditModel>(logger)
     {
         private const VacancyRuleSet ValidationRules = VacancyRuleSet.ClosingDate | VacancyRuleSet.StartDate | VacancyRuleSet.StartDateEndDate;
         public const string ChangeBothDatesTitle = "Change the closing date and start date";
         public const string ChangeEitherDatesTitle = "Change the closing date or start date";
-        private readonly IRecruitVacancyClient _vacancyClient;
-        private readonly ITimeProvider _timeProvider;
-        private readonly IUtility _utility;
-
-        public CloneVacancyOrchestrator(IRecruitVacancyClient vacancyClient,
-            ITimeProvider timeProvider, ILogger<CloneVacancyOrchestrator> logger, IUtility utility) : base(logger)
-        {
-            _vacancyClient = vacancyClient;
-            _timeProvider = timeProvider;
-            _utility = utility;
-        }
 
         public async Task<CloneVacancyDatesQuestionViewModel> GetCloneVacancyDatesQuestionViewModelAsync(VacancyRouteModel vrm)
         {
@@ -82,7 +76,7 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
                     StartDay = $"{vacancy.StartDate.Value.Day:00}",
                     StartMonth = $"{vacancy.StartDate.Value.Month:00}",
                     StartYear = $"{vacancy.StartDate.Value.Year}",
-                    CurrentYear = _timeProvider.Now.Year
+                    CurrentYear = timeProvider.Now.Year
                 };
             }
         }
@@ -101,19 +95,19 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
             model.StartDay = dirtyModel.StartDay;
             model.StartMonth = dirtyModel.StartMonth;
             model.StartYear = dirtyModel.StartYear;
-            model.CurrentYear = _timeProvider.Now.Year;
+            model.CurrentYear = timeProvider.Now.Year;
 
             return model;
         }
 
         public bool IsNewDatesRequired(Vacancy vacancy)
-            => vacancy.ClosingDate < _timeProvider.Now.Date.AddDays(7);
+            => vacancy.ClosingDate < timeProvider.Now.Date.AddDays(7);
 
         public async Task<OrchestratorResponse<Guid>> PostCloneVacancyWithSameDates(CloneVacancyDatesQuestionEditModel model, VacancyUser user)
         {
             var vacancy = await GetCloneableAuthorisedVacancyAsync(model);
 
-            var newVacancyId = await _vacancyClient.CloneVacancyAsync(
+            var newVacancyId = await vacancyClient.CloneVacancyAsync(
                 model.VacancyId,
                 user,
                 SourceOrigin.EmployerWeb,
@@ -135,9 +129,9 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
             return await ValidateAndExecute(
                 vacancy,
-                v => _vacancyClient.Validate(v, ValidationRules),
+                v => vacancyClient.Validate(v, ValidationRules),
                 v =>
-                    _vacancyClient.CloneVacancyAsync(
+                    vacancyClient.CloneVacancyAsync(
                         model.VacancyId,
                         user,
                         SourceOrigin.EmployerWeb,
@@ -148,9 +142,9 @@ namespace Esfa.Recruit.Employer.Web.Orchestrators
 
         public async Task<Vacancy> GetCloneableAuthorisedVacancyAsync(VacancyRouteModel vrm)
         {
-            var vacancy = await _vacancyClient.GetVacancyAsync(vrm.VacancyId);
+            var vacancy = await vacancyClient.GetVacancyAsync(vrm.VacancyId);
 
-            _utility.CheckAuthorisedAccess(vacancy, vrm.EmployerAccountId);
+            utility.CheckAuthorisedAccess(vacancy, vrm.EmployerAccountId);
 
             if (!vacancy.CanClone)
                 throw new InvalidStateException(string.Format(ErrorMessages.VacancyNotAvailableForCloning, vacancy.Title));

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/ErrorCodes.cs
@@ -12,5 +12,6 @@
         public const string TrainingProviderMustHaveEmployerPermission = "104";
         public const string TrainingProviderMustBeMainOrEmployerProfile = "105";
         public const string TrainingProviderMustDeliverTrainingCourse = "106";
+        public const string EmployerLocationMustBeInEngland = "107";
     }
 }

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/CustomValidators/VacancyValidators/VacancyFluentValidationExtensions.cs
@@ -2,7 +2,7 @@ using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Domain.Extensions;
 using Esfa.Recruit.Vacancies.Client.Domain.Models;
-using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Locations;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 using FluentValidation;
 using FluentValidation.Results;
@@ -184,15 +184,47 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomVali
             });
         }
 
+        internal static IRuleBuilderInitial<Vacancy, Vacancy> EmployerLocationMustBeInEngland(this IRuleBuilder<Vacancy, Vacancy> ruleBuilder, ILocationsService locationsService) =>
+            (IRuleBuilderInitial<Vacancy, Vacancy>)ruleBuilder.CustomAsync(async (vacancy, context, _) =>
+            {
+                if (vacancy?.EmployerLocations == null || vacancy.EmployerLocations.Count == 0)
+                    return;
+
+                var (message, errorCode) = vacancy.EmployerLocationOption switch
+                {
+                    AvailableWhere.OneLocation => (
+                        "Location must be in England. Your apprenticeship must be in England to advertise it on this service",
+                        VacancyValidationErrorCodes.AddressCountryNotInEngland),
+
+                    AvailableWhere.MultipleLocations => (
+                        "All locations must be in England. Your apprenticeship must be in England to advertise it on this service",
+                        $"Multiple-{VacancyValidationErrorCodes.AddressCountryNotInEngland}"),
+
+                    _ => ("Location must be in England. Your apprenticeship must be in England to advertise it on this service",
+                        VacancyValidationErrorCodes.AddressCountryNotInEngland)
+                };
+
+                foreach (var address in vacancy.EmployerLocations)
+                {
+                    if (await locationsService.IsPostcodeInEnglandAsync(address.Postcode) != true)
+                    {
+                        context.AddFailure(new ValidationFailure(nameof(Vacancy.EmployerLocations), message)
+                        {
+                            ErrorCode = errorCode,
+                            CustomState = VacancyRuleSet.EmployerLocationOutOfArea
+                        });
+                    }
+                }
+            });
 
         internal static IRuleBuilderOptions<Vacancy, T> RunCondition<T>(this IRuleBuilderOptions<Vacancy, T> context, VacancyRuleSet condition)
         {
-            return context.Configure(c=>c.ApplyCondition(x => x.CanRunValidator(condition)));
+            return context.Configure(c => c.ApplyCondition(x => x.CanRunValidator(condition)));
         }
-        
+
         internal static IRuleBuilderInitial<Vacancy, T> RunCondition<T>(this IRuleBuilderInitial<Vacancy, T> context, VacancyRuleSet condition)
         {
-            return context.Configure(c=>c.ApplyCondition(x => x.CanRunValidator(condition)));
+            return context.Configure(c => c.ApplyCondition(x => x.CanRunValidator(condition)));
         }
 
         private static bool CanRunValidator<T>(this ValidationContext<T> context, VacancyRuleSet validationToCheck)

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentExtensions.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentExtensions.cs
@@ -1,8 +1,8 @@
-using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators;
-using FluentValidation;
 using System;
 using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
+using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators;
+using FluentValidation;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
 {

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/Fluent/FluentVacancyValidator.cs
@@ -4,10 +4,9 @@ using Esfa.Recruit.Vacancies.Client.Application.Providers;
 using Esfa.Recruit.Vacancies.Client.Application.Services;
 using Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent.CustomValidators.VacancyValidators;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Esfa.Recruit.Vacancies.Client.Domain.Repositories;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Locations;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
-using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using FluentValidation;
 
 namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
@@ -22,6 +21,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
         private readonly ITrainingProviderSummaryProvider _trainingProviderSummaryProvider;
         private readonly IProfanityListProvider _profanityListProvider;
         private readonly IProviderRelationshipsService _providerRelationshipService;
+        private readonly ILocationsService _locationsService;
 
         public FluentVacancyValidator(
             ITimeProvider timeProvider,
@@ -30,9 +30,9 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
             IReferenceDataClient referenceDataClient,
             IHtmlSanitizerService htmlSanitizerService,
             ITrainingProviderSummaryProvider trainingProviderSummaryProvider,
-            ITrainingProviderService trainingProviderService,
             IProfanityListProvider profanityListProvider,
-            IProviderRelationshipsService providerRelationshipService)
+            IProviderRelationshipsService providerRelationshipService,
+            ILocationsService locationsService)
         {
             _timeProvider = timeProvider;
             _minimumWageService = minimumWageService;
@@ -42,6 +42,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
             _trainingProviderSummaryProvider = trainingProviderSummaryProvider;
             _profanityListProvider = profanityListProvider;
             _providerRelationshipService = providerRelationshipService;
+            _locationsService = locationsService;
 
             SingleFieldValidations();
             CrossFieldValidations();
@@ -203,7 +204,6 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                     .WithErrorCode("604")
                     .WithState(_ => VacancyRuleSet.EmployerNameOption)
                     .RunCondition(VacancyRuleSet.EmployerNameOption)
-
             );
 
             RuleFor(x => x.EmployerNameOption)
@@ -235,6 +235,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                 RuleForEach(x => x.EmployerLocations)
                     .SetValidator(new AddressValidator((long)VacancyRuleSet.EmployerAddress))
                     .RunCondition(VacancyRuleSet.EmployerAddress);
+
+                RuleFor(x => x)
+                    .EmployerLocationMustBeInEngland(_locationsService)
+                    .RunCondition(VacancyRuleSet.EmployerAddress);
             });
             
             When(v => v.EmployerLocationOption == AvailableWhere.MultipleLocations, () =>
@@ -249,6 +253,10 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                 RuleForEach(x => x.EmployerLocations)
                     .SetValidator(new AddressValidator((long)VacancyRuleSet.EmployerAddress))
                     .RunCondition(VacancyRuleSet.EmployerAddress);
+
+                RuleFor(x => x)
+                    .EmployerLocationMustBeInEngland(_locationsService)
+                    .RunCondition(VacancyRuleSet.EmployerAddress);
             });
 
             When(v => v.EmployerLocationOption == AvailableWhere.AcrossEngland, () =>
@@ -261,7 +269,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation.Fluent
                     .WithMessage("Information about where the apprentice will work must be 500 characters or less")
                     .WithState(_ => VacancyRuleSet.EmployerAddress)
                     .ProfanityCheck(_profanityListProvider)
-                    .WithMessage($"Additional information must not contain a banned word or phrase")
+                    .WithMessage("Additional information must not contain a banned word or phrase")
                     .WithState(_ => VacancyRuleSet.EmployerAddress)
                     .RunCondition(VacancyRuleSet.EmployerAddress);
             });

--- a/src/Shared/Recruit.Vacancies.Client/Application/Validation/VacancyRuleSet.cs
+++ b/src/Shared/Recruit.Vacancies.Client/Application/Validation/VacancyRuleSet.cs
@@ -43,6 +43,7 @@ namespace Esfa.Recruit.Vacancies.Client.Application.Validation
         CompetitiveWage = 1L << 34,
         AdditionalTrainingDescription = 1L << 35,
         TrainingProviderDeliverCourse = 1L << 36,
+        EmployerLocationOutOfArea = 1L << 37,
         All = ~None,
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
@@ -1,0 +1,51 @@
+﻿using Esfa.Recruit.Vacancies.Client.Application.Validation;
+using Esfa.Recruit.Vacancies.Client.Domain.Entities;
+using Xunit;
+
+namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField;
+
+public class EmployerLocationValidationTests : VacancyValidationTestsBase
+{
+    [Fact]
+    public void NoErrorsWhenLocationIsValid()
+    {
+        var vacancy = new Vacancy
+        {
+            EmployerLocation = new Address
+            {
+                AddressLine1 = "address line 1",
+                AddressLine2 = "address line 2",
+                AddressLine3 = "address line 3",
+                Postcode = "SW1 1AB",
+                Country = "England"
+            }
+        };
+
+        MockLocationsService.Setup(p => p.IsPostcodeInEnglandAsync("SW1 1AB")).ReturnsAsync(true);
+
+        var result = Validator.Validate(vacancy, VacancyRuleSet.EmployerAddress);
+
+        result.HasErrors.Should().BeFalse();
+        result.Errors.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void ErrorWhenLocationIsOutOfArea()
+    {
+        var vacancy = new Vacancy
+        {
+            EmployerLocation = new Address
+            {
+                Postcode = "AB1 2CD"
+            },
+            EmployerLocationOption = AvailableWhere.OneLocation
+        };
+
+        MockLocationsService.Setup(p => p.IsPostcodeInEnglandAsync("AB1 2CD")).ReturnsAsync(false);
+
+        var result = Validator.Validate(vacancy, VacancyRuleSet.EmployerAddress);
+
+        result.HasErrors.Should().BeTrue();
+        result.Errors.Should().HaveCount(1);
+    }
+}

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
@@ -1,12 +1,13 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Application.Validation;
 using Esfa.Recruit.Vacancies.Client.Domain.Entities;
-using Xunit;
+using NUnit.Framework;
 
 namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.VacancyValidation.SingleField;
 
+[TestFixture]
 public class EmployerLocationValidationTests : VacancyValidationTestsBase
 {
-    [Fact]
+    [Test]
     public void NoErrorsWhenLocationIsValid()
     {
         var vacancy = new Vacancy
@@ -30,7 +31,7 @@ public class EmployerLocationValidationTests : VacancyValidationTestsBase
         result.Errors.Should().HaveCount(0);
     }
 
-    [Fact]
+    [Test]
     public void ErrorWhenLocationIsOutOfArea()
     {
         var vacancy = new Vacancy

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/SingleField/EmployerLocationValidationTests.cs
@@ -11,14 +11,15 @@ public class EmployerLocationValidationTests : VacancyValidationTestsBase
     {
         var vacancy = new Vacancy
         {
-            EmployerLocation = new Address
+            EmployerLocations = [new Address
             {
                 AddressLine1 = "address line 1",
                 AddressLine2 = "address line 2",
                 AddressLine3 = "address line 3",
                 Postcode = "SW1 1AB",
                 Country = "England"
-            }
+            }],
+            EmployerLocationOption = AvailableWhere.OneLocation
         };
 
         MockLocationsService.Setup(p => p.IsPostcodeInEnglandAsync("SW1 1AB")).ReturnsAsync(true);
@@ -34,18 +35,22 @@ public class EmployerLocationValidationTests : VacancyValidationTestsBase
     {
         var vacancy = new Vacancy
         {
-            EmployerLocation = new Address
+            EmployerLocations = [new Address
             {
-                Postcode = "AB1 2CD"
-            },
+                AddressLine1 = "address line 1",
+                AddressLine2 = "address line 2",
+                AddressLine3 = "address line 3",
+                Postcode = "CF10 3RB",
+                Country = "Wales"
+            }],
             EmployerLocationOption = AvailableWhere.OneLocation
         };
 
-        MockLocationsService.Setup(p => p.IsPostcodeInEnglandAsync("AB1 2CD")).ReturnsAsync(false);
+        MockLocationsService.Setup(p => p.IsPostcodeInEnglandAsync("CF10 3RB")).ReturnsAsync(false);
 
         var result = Validator.Validate(vacancy, VacancyRuleSet.EmployerAddress);
 
         result.HasErrors.Should().BeTrue();
-        result.Errors.Should().HaveCount(1);
+        result.Errors.Should().HaveCount(2);
     }
 }

--- a/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
+++ b/src/Shared/UnitTests/Vacancies.Client/Application/VacancyValidation/VacancyValidationTestsBase.cs
@@ -8,6 +8,7 @@ using Esfa.Recruit.Vacancies.Client.Domain.Entities;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Client;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.ReferenceData.ApprenticeshipProgrammes;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services;
+using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.Locations;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.ProviderRelationship;
 using Esfa.Recruit.Vacancies.Client.Infrastructure.Services.TrainingProvider;
 using Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.Rules.VacancyRules;
@@ -25,9 +26,10 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.V
         protected readonly TestProfanityListProvider MockProfanityListProvider;
         protected readonly Mock<IProviderRelationshipsService> MockProviderRelationshipsService;
         protected readonly Mock<ITrainingProviderService> MockTrainingProviderService;
+        protected readonly Mock<ILocationsService> MockLocationsService;
         protected ITimeProvider TimeProvider;
         protected readonly Mock<IFeature> Feature;
-        
+
 
         protected VacancyValidationTestsBase()
         {
@@ -71,6 +73,7 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.V
             MockProfanityListProvider = new TestProfanityListProvider();
             MockProviderRelationshipsService = new Mock<IProviderRelationshipsService>();
             MockTrainingProviderService = new Mock<ITrainingProviderService>();
+            MockLocationsService = new Mock<ILocationsService>();
             MockTrainingProviderService.Setup(x => x.GetCourseProviders(123)).ReturnsAsync(new List<TrainingProviderSummary>
             {
                 new()
@@ -88,8 +91,8 @@ namespace Esfa.Recruit.Vacancies.Client.UnitTests.Vacancies.Client.Application.V
             {
                 var fluentValidator = new FluentVacancyValidator(TimeProvider, MockMinimumWageService.Object, 
                     MockApprenticeshipProgrammeProvider.Object, MockReferenceDataClient.Object, SanitizerService, 
-                    MockTrainingProviderSummaryProvider.Object, MockTrainingProviderService.Object, 
-                    MockProfanityListProvider, MockProviderRelationshipsService.Object);
+                    MockTrainingProviderSummaryProvider.Object,
+                    MockProfanityListProvider, MockProviderRelationshipsService.Object, MockLocationsService.Object);
                 return new EntityValidator<Vacancy, VacancyRuleSet>(fluentValidator);
             }
         }


### PR DESCRIPTION
Add England-only employer location validation & refactor DI

Refactor controllers and orchestrators to use primary constructors for dependency injection. Add EmployerLocationMustBeInEngland validation, new error code, and rule set flag to enforce all employer locations are in England. Update FluentVacancyValidator and tests to support and verify this validation. Clean up unused usings and improve message formatting.