### PR TITLE
FAI-3529  RAA - Multiple h1 headings are available on provider rejecting a shared application page

### DIFF
--- a/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationStatusConfirmation.cshtml
+++ b/src/Provider/Provider.Web/Views/ApplicationReview/ApplicationStatusConfirmation.cshtml
@@ -32,16 +32,16 @@
             </div>
         </div>
         <div asp-show="@Model.ShowStatusEmployerUnsuccessful">
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+            <h2 class="govuk-heading-xl govuk-!-margin-bottom-6">
                 Make this application unsuccessful
-            </h1>
-            <p>
+            </h2>
+            <p class="govuk-body">
                 You will make this application unsuccessful:
             </p>
             <div class="govuk-details__text govuk-!-margin-bottom-6">
                 <p class="govuk-body">@Model.Name : @Model.FriendlyId</p>
             </div>
-            <p>
+            <p class="govuk-body">
                 This applicant will be notified with this message:
             </p>
             <div class="govuk-details__text govuk-!-margin-bottom-6">


### PR DESCRIPTION
Update heading level and paragraph styling for employer unsuccessful section

Changed "Make this application unsuccessful" heading from h1 to h2 for better semantic structure. Applied "govuk-body" class to paragraphs for consistent GOV.UK styling.