### PR TITLE
FAI-3312 Add Breadcrumb RAA Dashboard

### DIFF
--- a/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Employer/Employer.Web/Views/Dashboard/Dashboard.cshtml
@@ -15,7 +15,16 @@
 }
 @section BackLink
 {
-    <a asp-hide="@Model.HasAnyVacancies" asp-route="@RouteNames.Dashboard_Account_Home" asp-route-employerAccountId="@Model.EmployerAccountId" class="govuk-back-link">Back</a>
+    <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+        <ol class="govuk-breadcrumbs__list govuk-!-margin-bottom-5">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="/">Home</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                Recruitment dashboard
+            </li>
+        </ol>
+    </nav>
 }
 <partial asp-hide="@Model.HasAnyVacancies" name="_NoVacanciesContent" model="@(new VacancyRouteModel { EmployerAccountId = Model.EmployerAccountId })" />
 <div asp-show="@Model.HasAnyVacancies">

--- a/src/Employer/Employer.Web/Views/Shared/_Layout.cshtml
+++ b/src/Employer/Employer.Web/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <partial name="_Header" model="@accountId"></partial>
     <div class="govuk-width-container">
-        @RenderSection(RazorSections.BackLink, required: false)
+        @await RenderSectionAsync(RazorSections.BackLink, required: false)
         <main class="govuk-main-wrapper" id="main-content" role="main">
             @RenderBody()
         </main>

--- a/src/Provider/Provider.Web/Views/Dashboard/Dashboard.cshtml
+++ b/src/Provider/Provider.Web/Views/Dashboard/Dashboard.cshtml
@@ -6,6 +6,19 @@
     ViewBag.Title = "Recruitment dashboard";
     var vacancyRouteModel = new VacancyRouteModel { Ukprn = Model.Ukprn };
 }
+@section BackLink
+{
+    <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+        <ol class="govuk-breadcrumbs__list govuk-!-margin-bottom-5">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="/">Home</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                Recruitment dashboard
+            </li>
+        </ol>
+    </nav>
+}
 <partial asp-hide="@Model.HasAnyVacancies" name="_ProviderNoVacanciesContent" model="@vacancyRouteModel" />
 <div asp-show="@Model.HasAnyVacancies">
     <partial name="@PartialNames.Alerts" for="Alerts" />

--- a/src/Provider/Provider.Web/Views/Shared/_ProviderLayout.cshtml
+++ b/src/Provider/Provider.Web/Views/Shared/_ProviderLayout.cshtml
@@ -13,7 +13,7 @@
 
 @section breadcrumb
 {
-    @RenderSection("BackLink", required: false)
+    @await RenderSectionAsync("BackLink", required: false)
 }
 
 @section Scripts


### PR DESCRIPTION
🎨 style: replace Back link with GOV.UK breadcrumb navigation

1. Replaced simple "Back" link with GOV.UK-style breadcrumb in Dashboard.cshtml and provider Dashboard.cshtml for improved accessibility and user experience
2. Updated _Layout.cshtml and _ProviderLayout.cshtml to use @await RenderSectionAsync for asynchronous breadcrumb rendering, replacing synchronous @RenderSection
3. Ensured consistent breadcrumb navigation across both employer and provider dashboards

Changes made by Balaji Jambulingam